### PR TITLE
Add IMAP commands list

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+  "tasks": {
+    "build": "swift build"
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,5 +1,17 @@
 {
   "tasks": {
-    "build": "swift build"
-  }
+    "build": "swift build",
+    "test": "swift test"
+  },
+  "image": "swift:latest",
+  "runArgs": ["--platform", "linux/amd64"],
+  "settings": {
+    "terminal.integrated.shell.linux": "/bin/bash"
+  },
+  "extensions": [
+    "ms-vscode.cpptools",
+    "ms-vscode.cmake-tools",
+    "ms-vscode.cmake"
+  ],
+  "postCreateCommand": "swift package resolve"
 }

--- a/IMAPCapabilities.md
+++ b/IMAPCapabilities.md
@@ -1,0 +1,37 @@
+# IMAP Capabilities
+
+## Capabilities in Use
+- [x] IMAP4rev1
+  - Description: The base IMAP4 revision 1 protocol.
+- [x] IDLE
+  - Description: Allows the server to send real-time updates to the client.
+- [x] UIDPLUS
+  - Description: Provides additional commands for unique identifiers.
+- [x] LITERAL+
+  - Description: Allows the use of literals without size limitations.
+- [x] SASL-IR
+  - Description: Allows initial client response in the first authentication command.
+- [x] AUTH=PLAIN
+  - Description: Allows plain text authentication.
+
+## Capabilities Not in Use
+- [ ] COMPRESS=DEFLATE
+  - Description: Allows compression of data streams.
+- [ ] ENABLE
+  - Description: Allows the client to enable server-side features.
+- [ ] CONDSTORE
+  - Description: Allows conditional STORE operations.
+- [ ] QRESYNC
+  - Description: Allows quick resynchronization of the client with the server.
+- [ ] ESEARCH
+  - Description: Provides extended search capabilities.
+- [ ] SEARCHRES
+  - Description: Allows the server to return search results.
+- [ ] SORT
+  - Description: Provides server-side sorting of messages.
+- [ ] THREAD
+  - Description: Provides server-side threading of messages.
+- [ ] XLIST
+  - Description: Provides extended list capabilities.
+- [ ] X-GM-EXT-1
+  - Description: Provides Google-specific IMAP extensions.

--- a/IMAPCommands.md
+++ b/IMAPCommands.md
@@ -1,0 +1,74 @@
+# IMAP Commands
+
+## Supported Commands
+- [x] LoginCommand
+  - IMAP Command: LOGIN
+  - Description: Used to authenticate a user with a username and password.
+- [x] LogoutCommand
+  - IMAP Command: LOGOUT
+  - Description: Used to log out the user from the IMAP server.
+- [x] CloseCommand
+  - IMAP Command: CLOSE
+  - Description: Used to close the currently selected mailbox.
+- [x] FetchHeadersCommand
+  - IMAP Command: FETCH
+  - Description: Used to fetch message headers from the server.
+- [x] FetchMessagePartCommand
+  - IMAP Command: FETCH
+  - Description: Used to fetch a specific part of a message.
+- [x] FetchStructureCommand
+  - IMAP Command: FETCH
+  - Description: Used to fetch the structure of a message.
+- [x] ListCommand
+  - IMAP Command: LIST
+  - Description: Used to list all available mailboxes. Special-folders version implemented.
+- [x] MoveCommand
+  - IMAP Command: MOVE
+  - Description: Used to move messages from one mailbox to another.
+- [x] SelectMailboxCommand
+  - IMAP Command: SELECT
+  - Description: Used to select a mailbox.
+- [x] CapabilityCommand
+  - IMAP Command: CAPABILITY
+  - Description: Used to retrieve server capabilities.
+- [x] CopyCommand
+  - IMAP Command: COPY
+  - Description: Used to copy messages from one mailbox to another.
+- [x] StoreCommand
+  - IMAP Command: STORE
+  - Description: Used to store flags on messages.
+- [x] ExpungeCommand
+  - IMAP Command: EXPUNGE
+  - Description: Used to expunge deleted messages.
+
+## Commands to be Implemented
+- [ ] AppendCommand
+  - IMAP Command: APPEND
+  - Description: Used to append a message to a mailbox.
+- [ ] CheckCommand
+  - IMAP Command: CHECK
+  - Description: Used to request a checkpoint of the currently selected mailbox.
+- [ ] CreateCommand
+  - IMAP Command: CREATE
+  - Description: Used to create a new mailbox.
+- [ ] DeleteCommand
+  - IMAP Command: DELETE
+  - Description: Used to delete a mailbox.
+- [ ] ExamineCommand
+  - IMAP Command: EXAMINE
+  - Description: Used to open a mailbox in read-only mode.
+- [ ] RenameCommand
+  - IMAP Command: RENAME
+  - Description: Used to rename a mailbox.
+- [ ] SearchCommand
+  - IMAP Command: SEARCH
+  - Description: Used to search messages in the currently selected mailbox.
+- [ ] StatusCommand
+  - IMAP Command: STATUS
+  - Description: Used to request the status of a mailbox.
+- [ ] SubscribeCommand
+  - IMAP Command: SUBSCRIBE
+  - Description: Used to subscribe to a mailbox.
+- [ ] UnsubscribeCommand
+  - IMAP Command: UNSUBSCRIBE
+  - Description: Used to unsubscribe from a mailbox.


### PR DESCRIPTION
Add a file that lists which IMAP commands are already implemented and which are not

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Cocoanetics/SwiftMail/pull/1?shareId=a3d3030b-321c-437b-a291-fc0266f70f03).