### PR TITLE
Implement basic search functionality in IMAP

### DIFF
--- a/Sources/SwiftIMAP/IMAP/Commands/SearchCommand.swift
+++ b/Sources/SwiftIMAP/IMAP/Commands/SearchCommand.swift
@@ -1,15 +1,17 @@
 import Foundation
 import NIO
 import NIOIMAP
+import NIOIMAPCore
 
 public struct SearchCommand<T: MessageIdentifier>: IMAPCommand {
-    public typealias ResultType = [T]
-    public typealias HandlerType = SearchHandler
+    // Update the result type to return a MessageIdentifierSet
+    public typealias ResultType = MessageIdentifierSet<T>
+    public typealias HandlerType = SearchHandler<T>
     
     public let identifierSet: MessageIdentifierSet<T>?
     public let criteria: [SearchCriteria]
     
-    public var handlerType: HandlerType.Type { SearchHandler.self }
+    public var handlerType: HandlerType.Type { SearchHandler<T>.self }
     
     public var timeoutSeconds: Int { return 10 }
     
@@ -28,9 +30,11 @@ public struct SearchCommand<T: MessageIdentifier>: IMAPCommand {
         let nioCriteria = criteria.map { $0.toNIO() }
         
         if T.self == UID.self {
-            return TaggedCommand(tag: tag, command: .uidSearch(identifierSet?.toNIOSet() ?? .all, nioCriteria))
+            // For UID search, we need to use the key parameter
+            return TaggedCommand(tag: tag, command: .uidSearch(key: .and(nioCriteria)))
         } else {
-            return TaggedCommand(tag: tag, command: .search(identifierSet?.toNIOSet() ?? .all, nioCriteria))
+            // For regular search, we need to use the key parameter
+            return TaggedCommand(tag: tag, command: .search(key: .and(nioCriteria)))
         }
     }
 }

--- a/Sources/SwiftIMAP/IMAP/Commands/SearchCommand.swift
+++ b/Sources/SwiftIMAP/IMAP/Commands/SearchCommand.swift
@@ -1,0 +1,36 @@
+import Foundation
+import NIO
+import NIOIMAP
+
+public struct SearchCommand<T: MessageIdentifier>: IMAPCommand {
+    public typealias ResultType = [T]
+    public typealias HandlerType = SearchHandler
+    
+    public let identifierSet: MessageIdentifierSet<T>?
+    public let criteria: [SearchCriteria]
+    
+    public var handlerType: HandlerType.Type { SearchHandler.self }
+    
+    public var timeoutSeconds: Int { return 10 }
+    
+    public init(identifierSet: MessageIdentifierSet<T>? = nil, criteria: [SearchCriteria]) {
+        self.identifierSet = identifierSet
+        self.criteria = criteria
+    }
+    
+    public func validate() throws {
+        guard !criteria.isEmpty else {
+            throw IMAPError.invalidArgument("Search criteria cannot be empty")
+        }
+    }
+    
+    public func toTaggedCommand(tag: String) -> TaggedCommand {
+        let nioCriteria = criteria.map { $0.toNIO() }
+        
+        if T.self == UID.self {
+            return TaggedCommand(tag: tag, command: .uidSearch(identifierSet?.toNIOSet() ?? .all, nioCriteria))
+        } else {
+            return TaggedCommand(tag: tag, command: .search(identifierSet?.toNIOSet() ?? .all, nioCriteria))
+        }
+    }
+}

--- a/Sources/SwiftIMAP/IMAP/Handler/SearchHandler.swift
+++ b/Sources/SwiftIMAP/IMAP/Handler/SearchHandler.swift
@@ -1,0 +1,29 @@
+import Foundation
+import NIO
+import NIOIMAP
+
+public final class SearchHandler: BaseIMAPCommandHandler<[MessageIdentifier]>, IMAPCommandHandler {
+    public typealias ResultType = [MessageIdentifier]
+    public typealias InboundIn = Response
+    public typealias InboundOut = Never
+    
+    private var searchResults: [MessageIdentifier] = []
+    
+    override public func processResponse(_ response: Response) -> Bool {
+        let handled = super.processResponse(response)
+        
+        if case .search(let identifiers) = response {
+            searchResults.append(contentsOf: identifiers.map { MessageIdentifier($0.rawValue) })
+        }
+        
+        return handled
+    }
+    
+    override public func handleTaggedOKResponse(_ response: TaggedResponse) {
+        succeedWithResult(searchResults)
+    }
+    
+    override public func handleTaggedErrorResponse(_ response: TaggedResponse) {
+        failWithError(IMAPError.searchFailed(String(describing: response.state)))
+    }
+}

--- a/Sources/SwiftIMAP/IMAP/Handler/SearchHandler.swift
+++ b/Sources/SwiftIMAP/IMAP/Handler/SearchHandler.swift
@@ -1,29 +1,80 @@
 import Foundation
 import NIO
 import NIOIMAP
+import NIOIMAPCore
 
-public final class SearchHandler: BaseIMAPCommandHandler<[MessageIdentifier]>, IMAPCommandHandler {
-    public typealias ResultType = [MessageIdentifier]
+/**
+ * Handler for IMAP SEARCH commands.
+ * 
+ * This handler processes search responses from the IMAP server and collects
+ * the message identifiers that match the search criteria.
+ *
+ * The generic parameter T specifies the exact MessageIdentifier type to be collected.
+ */
+public final class SearchHandler<T: MessageIdentifier>: BaseIMAPCommandHandler<MessageIdentifierSet<T>>, IMAPCommandHandler {
+    public typealias ResultType = MessageIdentifierSet<T>
     public typealias InboundIn = Response
     public typealias InboundOut = Never
     
-    private var searchResults: [MessageIdentifier] = []
+    private var searchResults: [T] = []
     
     override public func processResponse(_ response: Response) -> Bool {
         let handled = super.processResponse(response)
         
-        if case .search(let identifiers) = response {
-            searchResults.append(contentsOf: identifiers.map { MessageIdentifier($0.rawValue) })
+        // Check for untagged status responses that indicate errors
+        if case let .untagged(untagged) = response,
+           case let .conditionalState(status) = untagged {
+            switch status {
+            case .bad(let responseText):
+                // Handle BAD response (protocol error)
+                failWithError(IMAPError.commandFailed("Search failed: BAD \(responseText.text)"))
+                return true
+            case .no(let responseText):
+                // Handle NO response (operational error)
+                failWithError(IMAPError.commandFailed("Search failed: NO \(responseText.text)"))
+                return true
+            default:
+                // Other status responses are handled by the base class
+                break
+            }
         }
+        
+		// Check for search response data using proper pattern matching
+		if case let .untagged(untagged) = response,
+		   case let .mailboxData(mailboxData) = untagged,
+		   case let .search(ids, _) = mailboxData {
+			// Convert the IDs to the appropriate MessageIdentifier type
+			let results = ids.map { T.init(UInt32($0)) }
+			searchResults.append(contentsOf: results)
+			print("Extracted \(results.count) message identifiers from search response")
+		}
         
         return handled
     }
     
     override public func handleTaggedOKResponse(_ response: TaggedResponse) {
-        succeedWithResult(searchResults)
+        // When we receive an OK response, the search is complete
+        // Return the collected search results as a MessageIdentifierSet
+        print("Search complete, returning \(searchResults.count) results")
+        
+        // Create a MessageIdentifierSet from the array of results
+        var resultSet = MessageIdentifierSet<T>()
+        for identifier in searchResults {
+            resultSet.insert(identifier)
+        }
+        
+        succeedWithResult(resultSet)
     }
     
     override public func handleTaggedErrorResponse(_ response: TaggedResponse) {
-        failWithError(IMAPError.searchFailed(String(describing: response.state)))
+        // If the search command fails, report the error with more specific information
+        switch response.state {
+        case .bad(let responseText):
+            failWithError(IMAPError.commandFailed("Search failed: BAD \(responseText.text)"))
+        case .no(let responseText):
+            failWithError(IMAPError.commandFailed("Search failed: NO \(responseText.text)"))
+        default:
+            failWithError(IMAPError.commandFailed("Search failed: \(String(describing: response.state))"))
+        }
     }
 }

--- a/Sources/SwiftIMAP/IMAPError.swift
+++ b/Sources/SwiftIMAP/IMAPError.swift
@@ -58,4 +58,67 @@ extension IMAPError: CustomStringConvertible {
             return "Command not supported: \(reason)"
         }
     }
+}
+
+// Add LocalizedError conformance for better error messages in system contexts
+extension IMAPError: LocalizedError {
+    public var errorDescription: String? {
+        return description
+    }
+    
+    public var failureReason: String? {
+        switch self {
+        case .connectionFailed(let reason):
+            return "Could not establish connection to the IMAP server: \(reason)"
+        case .loginFailed(let reason):
+            return "Authentication with the IMAP server failed: \(reason)"
+        case .selectFailed(let reason):
+            return "Could not select the requested mailbox: \(reason)"
+        case .fetchFailed(let reason):
+            return "Failed to fetch messages: \(reason)"
+        case .logoutFailed(let reason):
+            return "Failed to properly logout: \(reason)"
+        case .timeout:
+            return "The operation took too long and timed out"
+        case .greetingFailed(let reason):
+            return "Server did not provide a proper greeting: \(reason)"
+        case .invalidArgument(let reason):
+            return "An invalid argument was provided: \(reason)"
+        case .emptyIdentifierSet:
+            return "An empty set of message identifiers was provided"
+        case .commandFailed(let reason):
+            return "The IMAP command failed to execute: \(reason)"
+        case .copyFailed(let reason):
+            return "Failed to copy messages: \(reason)"
+        case .storeFailed(let reason):
+            return "Failed to store flags: \(reason)"
+        case .expungeFailed(let reason):
+            return "Failed to expunge deleted messages: \(reason)"
+        case .moveFailed(let reason):
+            return "Failed to move messages: \(reason)"
+        case .commandNotSupported(let reason):
+            return "The requested command is not supported by the server: \(reason)"
+        }
+    }
+    
+    public var recoverySuggestion: String? {
+        switch self {
+        case .connectionFailed:
+            return "Check your network connection and server settings."
+        case .loginFailed:
+            return "Verify your username and password."
+        case .selectFailed:
+            return "Make sure the mailbox exists and you have permission to access it."
+        case .fetchFailed:
+            return "Ensure you have selected a mailbox and have valid message identifiers."
+        case .timeout:
+            return "Try again later when the server might be less busy."
+        case .commandFailed(let reason) where reason.contains("not allowed now"):
+            return "Make sure to select a mailbox before performing this operation."
+        case .commandNotSupported:
+            return "This operation may not be supported by your email provider."
+        default:
+            return "Check the error details and try again."
+        }
+    }
 } 

--- a/Sources/SwiftIMAP/IMAPServer.swift
+++ b/Sources/SwiftIMAP/IMAPServer.swift
@@ -673,14 +673,15 @@ public actor IMAPServer {
 	}
 	
 	/**
-	 Perform a search on the IMAP server
+	 Searches for messages matching the given criteria
+	 
 	 - Parameters:
-	 - identifierSet: An optional set of message identifiers to limit the search scope
-	 - criteria: An array of search criteria
-	 - Returns: A collection of message identifiers matching the search criteria
+	   - identifierSet: Optional set of message identifiers to search within
+	   - criteria: The search criteria to apply
+	 - Returns: A set of message identifiers matching the search criteria
 	 - Throws: An error if the search operation fails
 	 */
-	public func search<T: MessageIdentifier>(identifierSet: MessageIdentifierSet<T>? = nil, criteria: [SearchCriteria]) async throws -> [T] {
+	public func search<T: MessageIdentifier>(identifierSet: MessageIdentifierSet<T>? = nil, criteria: [SearchCriteria]) async throws -> MessageIdentifierSet<T> {
 		let command = SearchCommand(identifierSet: identifierSet, criteria: criteria)
 		return try await executeCommand(command)
 	}

--- a/Sources/SwiftIMAP/IMAPServer.swift
+++ b/Sources/SwiftIMAP/IMAPServer.swift
@@ -1,6 +1,3 @@
-// IMAPServer.swift
-// A Swift IMAP client that encapsulates connection logic
-
 import Foundation
 import Logging
 @preconcurrency import NIOIMAP
@@ -673,6 +670,19 @@ public actor IMAPServer {
 		commandTagCounter += 1
 		
 		return "\(tagPrefix)\(String(format: "%03d", commandTagCounter))"
+	}
+	
+	/**
+	 Perform a search on the IMAP server
+	 - Parameters:
+	 - identifierSet: An optional set of message identifiers to limit the search scope
+	 - criteria: An array of search criteria
+	 - Returns: A collection of message identifiers matching the search criteria
+	 - Throws: An error if the search operation fails
+	 */
+	public func search<T: MessageIdentifier>(identifierSet: MessageIdentifierSet<T>? = nil, criteria: [SearchCriteria]) async throws -> [T] {
+		let command = SearchCommand(identifierSet: identifierSet, criteria: criteria)
+		return try await executeCommand(command)
 	}
 }
 

--- a/Sources/SwiftIMAP/Models/Header+CustomStringConvertible.swift
+++ b/Sources/SwiftIMAP/Models/Header+CustomStringConvertible.swift
@@ -4,6 +4,7 @@ extension Header: CustomStringConvertible {
     public var description: String {
         """
         From: \(from)
+        Subject: \(subject)
         Date: \(date.formattedForDisplay())
         """
     }

--- a/Sources/SwiftIMAP/Models/MessageIdentifierSet.swift
+++ b/Sources/SwiftIMAP/Models/MessageIdentifierSet.swift
@@ -122,6 +122,14 @@ public struct MessageIdentifierSet<Identifier: MessageIdentifier> {
         self.indexSet = Foundation.IndexSet(integer: Int(identifier.value))
     }
     
+    /// Creates a set from an array of identifiers
+    public init(_ identifiers: [Identifier]) {
+        self.indexSet = Foundation.IndexSet()
+        for identifier in identifiers {
+            self.indexSet.insert(Int(identifier.value))
+        }
+    }
+    
     /// Creates a set containing identifiers in the given range
     public init(_ range: ClosedRange<Identifier>) {
         self.indexSet = Foundation.IndexSet(integersIn: Int(range.lowerBound.value)...Int(range.upperBound.value))
@@ -193,6 +201,11 @@ public struct MessageIdentifierSet<Identifier: MessageIdentifier> {
     /// Returns a view of the ranges in the set
     public var ranges: [ClosedRange<Int>] {
         return indexSet.rangeView.map { $0.lowerBound...$0.upperBound - 1 }
+    }
+    
+    /// Converts the set to an array of identifiers
+    public func toArray() -> [Identifier] {
+        return indexSet.map { Identifier(UInt32($0)) }
     }
 }
 

--- a/Sources/SwiftIMAP/Models/SearchCriteria.swift
+++ b/Sources/SwiftIMAP/Models/SearchCriteria.swift
@@ -1,0 +1,115 @@
+import Foundation
+import NIOIMAP
+
+public enum SearchCriteria {
+    case all
+    case answered
+    case bcc(String)
+    case before(Date)
+    case body(String)
+    case cc(String)
+    case deleted
+    case draft
+    case flagged
+    case from(String)
+    case header(String, String)
+    case keyword(String)
+    case larger(Int)
+    case new
+    case not(SearchCriteria)
+    case old
+    case on(Date)
+    case or(SearchCriteria, SearchCriteria)
+    case recent
+    case seen
+    case sentBefore(Date)
+    case sentOn(Date)
+    case sentSince(Date)
+    case since(Date)
+    case smaller(Int)
+    case subject(String)
+    case text(String)
+    case to(String)
+    case uid(Int)
+    case unanswered
+    case undeleted
+    case undraft
+    case unflagged
+    case unkeyword(String)
+    case unseen
+
+    func toNIO() -> NIOIMAP.SearchKey {
+        switch self {
+        case .all:
+            return .all
+        case .answered:
+            return .answered
+        case .bcc(let value):
+            return .bcc(value)
+        case .before(let date):
+            return .before(date)
+        case .body(let value):
+            return .body(value)
+        case .cc(let value):
+            return .cc(value)
+        case .deleted:
+            return .deleted
+        case .draft:
+            return .draft
+        case .flagged:
+            return .flagged
+        case .from(let value):
+            return .from(value)
+        case .header(let field, let value):
+            return .header(field, value)
+        case .keyword(let value):
+            return .keyword(value)
+        case .larger(let size):
+            return .larger(size)
+        case .new:
+            return .new
+        case .not(let criteria):
+            return .not(criteria.toNIO())
+        case .old:
+            return .old
+        case .on(let date):
+            return .on(date)
+        case .or(let criteria1, let criteria2):
+            return .or(criteria1.toNIO(), criteria2.toNIO())
+        case .recent:
+            return .recent
+        case .seen:
+            return .seen
+        case .sentBefore(let date):
+            return .sentBefore(date)
+        case .sentOn(let date):
+            return .sentOn(date)
+        case .sentSince(let date):
+            return .sentSince(date)
+        case .since(let date):
+            return .since(date)
+        case .smaller(let size):
+            return .smaller(size)
+        case .subject(let value):
+            return .subject(value)
+        case .text(let value):
+            return .text(value)
+        case .to(let value):
+            return .to(value)
+        case .uid(let number):
+            return .uid(number)
+        case .unanswered:
+            return .unanswered
+        case .undeleted:
+            return .undeleted
+        case .undraft:
+            return .undraft
+        case .unflagged:
+            return .unflagged
+        case .unkeyword(let value):
+            return .unkeyword(value)
+        case .unseen:
+            return .unseen
+        }
+    }
+}


### PR DESCRIPTION
Related to #9

Implement basic IMAP search functionality.

* Add `SearchCommand` struct in `Sources/SwiftIMAP/IMAP/Commands/SearchCommand.swift` conforming to `IMAPCommand` protocol.
  * Add properties `identifierSet` and `criteria`.
  * Implement `toTaggedCommand` method to convert to IMAP tagged command.
  * Add initializer to accept `identifierSet` and `criteria` parameters.
* Add `SearchHandler` class in `Sources/SwiftIMAP/IMAP/Handler/SearchHandler.swift` conforming to `IMAPCommandHandler` protocol.
  * Add properties to store search results.
  * Implement `processResponse` method to handle tagged and untagged responses.
  * Implement `handleTaggedOKResponse` and `handleTaggedErrorResponse` methods.
* Add `SearchCriteria` enum in `Sources/SwiftIMAP/Models/SearchCriteria.swift` to model Swift NIO IMAP criteria.
  * Include cases like `.uid(number)`, `.unseen`, `.smaller(number)`, etc.
* Modify `Sources/SwiftIMAP/IMAPServer.swift` to implement `search` function with a generic type `<T: MessageIdentifier>`.
  * Accept parameters: `identifierSet` (optional) and `criteria` (array of enums).
  * Return a collection of message identifiers `[T]`.
  * Switch between `.search` and `.uidSearch` based on the type of `T`.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/Cocoanetics/SwiftMail/pull/10?shareId=8e73e046-66d8-4e35-8677-facc2c29d863).