### PR TITLE
Refactor Message struct

### DIFF
--- a/Sources/SwiftMail/IMAP/Models/Message.swift
+++ b/Sources/SwiftMail/IMAP/Models/Message.swift
@@ -1,10 +1,10 @@
 // Message.swift
-// Structure to represent a complete email with all parts
+// Defines the `Message` type used to represent a complete email.
 
 import Foundation
 
-/// Structure to represent a complete email with all parts
-public struct Message: Sendable {
+/// Represents a complete email message including headers and parts.
+public struct Message: Codable, Sendable {
     /// The email header information
     public let header: MessageInfo
     
@@ -74,79 +74,7 @@ public struct Message: Sendable {
         self.header = header
         self.parts = parts
     }
-    
-    /// Find the plain text body of the email
-    /// - Returns: The plain text body, or nil if not found
-    private func findTextBody() -> String? {
-        // First look for a part with content type "text/plain" that is not an attachment
-        for part in parts where part.contentType.lowercased() == "text/plain" && 
-                               part.disposition?.lowercased() != "attachment" {
-            guard let partData = part.data,
-                  let text = String(data: partData, encoding: .utf8) else {
-                continue
-            }
-            
-            let decodedText = part.encoding?.lowercased() == "quoted-printable" ? 
-                text.decodeQuotedPrintable() : 
-                text
-            
-            if let decodedText = decodedText {
-                return decodedText
-            }
-        }
-        
-        // If not found, look for any text part
-        for part in parts where part.contentType.lowercased().hasPrefix("text/") {
-            guard let partData = part.data,
-                  let text = String(data: partData, encoding: .utf8) else {
-                continue
-            }
-            
-            let decodedText = part.encoding?.lowercased() == "quoted-printable" ? 
-                text.decodeQuotedPrintable() : 
-                text
-            
-            if let decodedText = decodedText {
-                return decodedText
-            }
-        }
-        
-        return nil
-    }
-    
-    /// Find the HTML body of the email
-    /// - Returns: The HTML body, or nil if not found
-    private func findHtmlBody() -> String? {
-        // Look for a part with content type "text/html" that is not an attachment
-        for part in parts where part.contentType.lowercased() == "text/html" && 
-                               part.disposition?.lowercased() != "attachment" {
-            guard let partData = part.data,
-                  let text = String(data: partData, encoding: .utf8) else {
-                continue
-            }
-            
-            let decodedHtml = part.encoding?.lowercased() == "quoted-printable" ? 
-                text.decodeQuotedPrintable() : 
-                text
-            
-            if let decodedHtml = decodedHtml {
-                return decodedHtml
-            }
-        }
-        
-        return nil
-    }
-    
-    /// Find all attachments in the email
-    /// - Returns: An array of message parts that are attachments
-    private func findAttachments() -> [MessagePart] {
-        // Look for parts with disposition "attachment" or filename
-        return parts.filter { part in
-            (part.disposition?.lowercased() == "attachment") || 
-            (part.filename != nil && !part.filename!.isEmpty)
-        }
-    }
-    
+
     /// Get a formatted preview of the email content
     /// - Parameter maxLength: The maximum length of the preview
     /// - Returns: A string preview of the email content
@@ -171,6 +99,81 @@ public struct Message: Sendable {
         }
         
         return "No preview available"
+    }
+}
+
+// MARK: - Helper Methods
+private extension Message {
+    /// Find the plain text body of the email
+    /// - Returns: The plain text body, or `nil` if not found
+    func findTextBody() -> String? {
+        // First look for a part with content type "text/plain" that is not an attachment
+        for part in parts where part.contentType.lowercased() == "text/plain" &&
+            part.disposition?.lowercased() != "attachment" {
+                guard let partData = part.data,
+                      let text = String(data: partData, encoding: .utf8) else {
+                    continue
+                }
+
+                let decodedText = part.encoding?.lowercased() == "quoted-printable" ?
+                    text.decodeQuotedPrintable() :
+                    text
+
+                if let decodedText = decodedText {
+                    return decodedText
+                }
+        }
+
+        // If not found, look for any text part
+        for part in parts where part.contentType.lowercased().hasPrefix("text/") {
+            guard let partData = part.data,
+                  let text = String(data: partData, encoding: .utf8) else {
+                continue
+            }
+
+            let decodedText = part.encoding?.lowercased() == "quoted-printable" ?
+                text.decodeQuotedPrintable() :
+                text
+
+            if let decodedText = decodedText {
+                return decodedText
+            }
+        }
+
+        return nil
+    }
+
+    /// Find the HTML body of the email
+    /// - Returns: The HTML body, or `nil` if not found
+    func findHtmlBody() -> String? {
+        // Look for a part with content type "text/html" that is not an attachment
+        for part in parts where part.contentType.lowercased() == "text/html" &&
+            part.disposition?.lowercased() != "attachment" {
+                guard let partData = part.data,
+                      let text = String(data: partData, encoding: .utf8) else {
+                    continue
+                }
+
+                let decodedHtml = part.encoding?.lowercased() == "quoted-printable" ?
+                    text.decodeQuotedPrintable() :
+                    text
+
+                if let decodedHtml = decodedHtml {
+                    return decodedHtml
+                }
+        }
+
+        return nil
+    }
+
+    /// Find all attachments in the email
+    /// - Returns: An array of message parts that are attachments
+    func findAttachments() -> [MessagePart] {
+        // Look for parts with disposition "attachment" or filename
+        return parts.filter { part in
+            (part.disposition?.lowercased() == "attachment") ||
+            (part.filename != nil && !part.filename!.isEmpty)
+        }
     }
 }
 


### PR DESCRIPTION
## Summary
- make `Message` codable
- document `Message` with DocC comments
- move helper methods into a private extension

## Testing
- `swift test -c debug` *(fails: 'File extension for MIME type resolution' expectations)*

------
https://chatgpt.com/codex/tasks/task_b_684d4260e6148326822303a0f451692b