### PR TITLE
Allow BYE during LOGOUT

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Handler/LogoutHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/LogoutHandler.swift
@@ -10,6 +10,22 @@ import NIOConcurrencyHelpers
 /// Handler for IMAP LOGOUT command
 final class LogoutHandler: BaseIMAPCommandHandler<Void>, IMAPCommandHandler, @unchecked Sendable {
 
+    /// Handle untagged responses specific to LOGOUT.
+    ///
+    /// Servers typically send a `BYE` response during the logout sequence.
+    /// The default implementation treats this as a connection failure, so we
+    /// override it to simply ignore the `BYE` and wait for the tagged `OK`.
+    override func handleUntaggedResponse(_ response: Response) -> Bool {
+        if case .untagged(let payload) = response,
+           case .conditionalState(let status) = payload,
+           case .bye = status {
+            // Ignore BYE during logout and continue processing
+            return false
+        }
+
+        return super.handleUntaggedResponse(response)
+    }
+
     /// Process an incoming response
     /// - Parameter response: The response to process
     /// - Returns: Whether the response was handled by this handler


### PR DESCRIPTION
## Summary
- handle BYE in `LogoutHandler` without treating it as a failure

## Testing
- `swift test -c release` *(fails: build process didn't complete)*

------
https://chatgpt.com/codex/tasks/task_b_687b9861f3c083268baefc1b29feab05