### PR TITLE
Add wildcard option for listMailboxes

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Commands/ListCommand.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/ListCommand.swift
@@ -9,19 +9,25 @@ struct ListCommand: IMAPCommand {
     
     let timeoutSeconds: Int = 30
     
+    // Wildcard to use when listing mailboxes ("*" by default)
+    private let wildcard: String
+
     // Return options for the LIST command
     private let returnOptions: [ReturnOption]
     
     /// Initialize a new LIST command
-    /// - Parameter returnOptions: Optional list of return options for the LIST command (e.g. SPECIAL-USE)
-    init(returnOptions: [ReturnOption] = []) {
+    /// - Parameters:
+    ///   - wildcard: The wildcard pattern used when listing mailboxes. Defaults to "*".
+    ///   - returnOptions: Optional list of return options for the LIST command (e.g. SPECIAL-USE)
+    init(wildcard: String = "*", returnOptions: [ReturnOption] = []) {
+        self.wildcard = wildcard
         self.returnOptions = returnOptions
     }
     
     func toTaggedCommand(tag: String) -> TaggedCommand {
         // Standard LIST parameters
         let reference = MailboxName(ByteBuffer(string: ""))
-        let mailbox = MailboxPatterns.mailbox(ByteBuffer(string: "*"))
+        let mailbox = MailboxPatterns.mailbox(ByteBuffer(string: wildcard))
         
         // Use return options if provided
         if !returnOptions.isEmpty {

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -1100,20 +1100,21 @@ extension IMAPServer {
 
 // MARK: - Mailbox Listing and Special Folders
 extension IMAPServer {
-	/** 
-	 Lists all available mailboxes on the server.
-	 
-	 This method retrieves a list of all mailboxes (folders) available on the server,
-	 including their attributes and hierarchy information.
-	 
-	 - Returns: An array of mailbox information
-	 - Throws: `IMAPError.commandFailed` if the list operation fails
-	 - Note: Logs mailbox listing at info level with count
-	 */
-	public func listMailboxes() async throws -> [Mailbox.Info] {
-		let command = ListCommand()
-		return try await executeCommand(command)
-	}
+        /**
+         Lists all available mailboxes on the server.
+
+         This method retrieves a list of all mailboxes (folders) available on the server,
+         including their attributes and hierarchy information.
+
+         - Parameter wildcard: The wildcard pattern used when listing mailboxes. Defaults to "*".
+         - Returns: An array of mailbox information
+         - Throws: `IMAPError.commandFailed` if the list operation fails
+         - Note: Logs mailbox listing at info level with count
+         */
+        public func listMailboxes(wildcard: String = "*") async throws -> [Mailbox.Info] {
+                let command = ListCommand(wildcard: wildcard)
+                return try await executeCommand(command)
+        }
 	
 	/** 
 	 Get the inbox folder or throw if not found

--- a/Sources/SwiftMail/SwiftMail.docc/Articles/GettingStartedWithIMAP.md
+++ b/Sources/SwiftMail/SwiftMail.docc/Articles/GettingStartedWithIMAP.md
@@ -43,6 +43,14 @@ let mailboxInfo = try await imapServer.selectMailbox("INBOX")
 print("Mailbox contains \(mailboxInfo.messageCount) messages")
 ```
 
+By default `listMailboxes()` uses the `"*"` wildcard, but you can specify a
+different pattern if needed:
+
+```swift
+// Only list top-level mailboxes
+let mailboxes = try await imapServer.listMailboxes(wildcard: "%")
+```
+
 ## Fetching Messages
 
 Fetch messages from the selected mailbox:


### PR DESCRIPTION
## Summary
- allow IMAP mailbox listing to use custom wildcard patterns
- update IMAPServer API to forward a `wildcard` parameter
- document how to list top-level mailboxes using `%`

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_687e49bf53788326a15dbc4f94f571f7