### PR TITLE
Add NAMESPACE command support

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Commands/NamespaceCommand.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/NamespaceCommand.swift
@@ -1,0 +1,13 @@
+import Foundation
+import NIOIMAP
+import NIO
+
+/// Command to fetch namespace information
+struct NamespaceCommand: IMAPCommand {
+    typealias ResultType = Namespace.Response
+    typealias HandlerType = NamespaceHandler
+
+    func toTaggedCommand(tag: String) -> TaggedCommand {
+        return TaggedCommand(tag: tag, command: .namespace)
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/NamespaceHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/NamespaceHandler.swift
@@ -1,0 +1,31 @@
+import Foundation
+@preconcurrency import NIOIMAP
+import NIOIMAPCore
+import NIO
+import NIOConcurrencyHelpers
+
+/// Handler for IMAP NAMESPACE command
+final class NamespaceHandler: BaseIMAPCommandHandler<Namespace.Response>, IMAPCommandHandler, @unchecked Sendable {
+    private var namespace: Namespace.Response?
+
+    override func handleTaggedOKResponse(_ response: TaggedResponse) {
+        if let ns = lock.withLock({ self.namespace }) {
+            succeedWithResult(ns)
+        } else {
+            failWithError(IMAPError.commandFailed("NAMESPACE response missing"))
+        }
+    }
+
+    override func handleTaggedErrorResponse(_ response: TaggedResponse) {
+        failWithError(IMAPError.commandFailed(String(describing: response.state)))
+    }
+
+    override func handleUntaggedResponse(_ response: Response) -> Bool {
+        if case .untagged(let payload) = response {
+            if case .mailboxData(.namespace(let ns)) = payload {
+                lock.withLock { self.namespace = Namespace.Response(from: ns) }
+            }
+        }
+        return false
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -52,6 +52,9 @@ public actor IMAPServer {
         /** Special folders - mailboxes with SPECIAL-USE attributes */
         public private(set) var specialMailboxes: [Mailbox.Info] = []
 
+        /// Namespaces discovered from the server
+        public private(set) var namespaces: Namespace.Response?
+
         /// Active handler managing an IDLE session, if any
         private var idleHandler: IdleHandler?
 	
@@ -963,8 +966,18 @@ public actor IMAPServer {
 
 // MARK: - Common Mail Operations
 extension IMAPServer {
-	/** 
-	 Lists mailboxes with special-use attributes.
+        /// Retrieve namespace information from the server.
+        /// - Returns: The namespace response describing personal, other user and shared namespaces.
+        /// - Throws: `IMAPError.commandFailed` if the command fails.
+        public func fetchNamespaces() async throws -> Namespace.Response {
+                let command = NamespaceCommand()
+                let response = try await executeCommand(command)
+                self.namespaces = response
+                return response
+        }
+
+        /**
+         Lists mailboxes with special-use attributes.
 	 
 	 Special-use mailboxes are those designated for specific purposes like
 	 Sent, Drafts, Trash, etc., as defined in RFC 6154.

--- a/Sources/SwiftMail/IMAP/Models/Namespace.swift
+++ b/Sources/SwiftMail/IMAP/Models/Namespace.swift
@@ -1,0 +1,49 @@
+import Foundation
+import NIOIMAPCore
+
+/// Representation of an IMAP namespace response
+public enum Namespace {
+    /// Description of a single namespace
+    public struct Description: Sendable {
+        /// The prefix string of the namespace
+        public let prefix: String
+        /// The hierarchy delimiter if provided
+        public let delimiter: Character?
+
+        /// Initialize from raw values
+        public init(prefix: String, delimiter: Character?) {
+            self.prefix = prefix
+            self.delimiter = delimiter
+        }
+
+        /// Initialize from ``NIOIMAPCore.NamespaceDescription``
+        init(from nio: NIOIMAPCore.NamespaceDescription) {
+            self.prefix = nio.string.stringValue
+            self.delimiter = nio.delimiter
+        }
+    }
+
+    /// The namespaces returned by the server
+    public struct Response: Sendable {
+        /// Personal namespaces
+        public let personal: [Description]
+        /// Other user namespaces
+        public let otherUsers: [Description]
+        /// Shared namespaces
+        public let shared: [Description]
+
+        /// Initialize from raw values
+        public init(personal: [Description], otherUsers: [Description], shared: [Description]) {
+            self.personal = personal
+            self.otherUsers = otherUsers
+            self.shared = shared
+        }
+
+        /// Initialize from ``NIOIMAPCore.NamespaceResponse``
+        init(from nio: NIOIMAPCore.NamespaceResponse) {
+            self.personal = nio.userNamespace.map { Description(from: $0) }
+            self.otherUsers = nio.otherUserNamespace.map { Description(from: $0) }
+            self.shared = nio.sharedNamespace.map { Description(from: $0) }
+        }
+    }
+}


### PR DESCRIPTION
## Summary
- add `Namespace` model for representing IMAP namespaces
- implement `NamespaceCommand` and `NamespaceHandler`
- expose `fetchNamespaces()` in `IMAPServer` and store discovered namespaces

## Testing
- `swift build`
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_687f91c323208326b2c410b575b65039