### PR TITLE
Add IMAP ID command

### DIFF
--- a/Implemented.md
+++ b/Implemented.md
@@ -58,7 +58,7 @@
 #### Other Commands
 
 - [ ] ENABLE - Allows the client to enable server-side extensions.
-- [ ] ID - Allows the client to identify itself to the server.
+ - [x] ID - Allows the client to identify itself to the server.
 - [ ] CONDSTORE - Provides support for conditional STORE operations.
 - [ ] QRESYNC - Provides support for quick resynchronization of the mailbox.
 - [ ] METADATA - Allows the client to retrieve and store metadata associated with mailboxes.

--- a/Package.swift
+++ b/Package.swift
@@ -27,8 +27,9 @@ let package = Package(
         .package(url: "https://github.com/thebarndog/swift-dotenv", from: "2.1.0"),
 		.package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.0.0"),
-		.package(url: "https://github.com/apple/swift-nio-imap", branch: "main"),
+        .package(url: "https://github.com/apple/swift-nio-imap", branch: "main"),
         .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.0.0"),
+        .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-testing", branch: "main"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
     ],
@@ -40,6 +41,7 @@ let package = Package(
                 .product(name: "NIOSSL", package: "swift-nio-ssl"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "NIOIMAP", package: "swift-nio-imap"),
+                .product(name: "OrderedCollections", package: "swift-collections"),
             ]
         ),
         .executableTarget(

--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ implements support for each capability.
 | **IDLE** | Push new message alerts (RFC 2177) | ✅ | ✅ | ✅ |
 | **NAMESPACE** | Query folder structure roots (RFC 2342) | ✅ | ✅ | ❌ |
 | **QUOTA** | Storage quota reporting (RFC 2087) | ✅ | ✅ | ❌ |
-| **ID** | Identify client/server (RFC 2971) | ✅ | ✅ | ❌ |
+| **ID** | Identify client/server (RFC 2971) | ✅ | ✅ | ✅ |
 | **XLIST** | Gmail folder role mapping (legacy) | ✅ | ❌ | ❌ |
 | **CHILDREN** | Show folder substructure (RFC 3348) | ✅ | ❌ | ❌ |
 | **X-GM-EXT-1** | Gmail labels, threads, msg IDs | ✅ | ❌ | ❌ |

--- a/Sources/SwiftMail/IMAP/IMAP/Commands/IDCommand.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/IDCommand.swift
@@ -1,0 +1,20 @@
+import Foundation
+import NIOIMAP
+import OrderedCollections
+
+/// Command for IMAP ID.
+struct IDCommand: IMAPCommand {
+    typealias ResultType = IDResponse
+    typealias HandlerType = IDHandler
+
+    /// Client identification parameters.
+    let parameters: OrderedDictionary<String, String?>
+
+    init(parameters: OrderedDictionary<String, String?> = [:]) {
+        self.parameters = parameters
+    }
+
+    func toTaggedCommand(tag: String) -> TaggedCommand {
+        TaggedCommand(tag: tag, command: .id(parameters))
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/IDHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/IDHandler.swift
@@ -1,0 +1,28 @@
+import Foundation
+import NIOIMAP
+import NIOIMAPCore
+import NIO
+import NIOConcurrencyHelpers
+import OrderedCollections
+
+/// Handler for the IMAP ID command.
+final class IDHandler: BaseIMAPCommandHandler<IDResponse>, IMAPCommandHandler, @unchecked Sendable {
+    private var responseParams: OrderedDictionary<String, String?> = [:]
+
+    override func handleUntaggedResponse(_ response: Response) -> Bool {
+        if case .untagged(let payload) = response, case .id(let params) = payload {
+            lock.withLock { self.responseParams = params }
+            return false
+        }
+        return super.handleUntaggedResponse(response)
+    }
+
+    override func handleTaggedOKResponse(_ response: TaggedResponse) {
+        let params = lock.withLock { responseParams }
+        succeedWithResult(IDResponse(parameters: params))
+    }
+
+    override func handleTaggedErrorResponse(_ response: TaggedResponse) {
+        failWithError(IMAPError.commandFailed(String(describing: response.state)))
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -5,6 +5,7 @@ import NIOIMAPCore
 import NIO
 import NIOSSL
 import NIOConcurrencyHelpers
+import OrderedCollections
 
 /** 
  An actor that represents a connection to an IMAP server.
@@ -194,9 +195,9 @@ public actor IMAPServer {
 	   - `IMAPError.connectionFailed` if not connected
 	 - Note: Logs login attempts at info level (without credentials)
 	 */
-	public func login(username: String, password: String) async throws {
-		let command = LoginCommand(username: username, password: password)
-		let loginCapabilities = try await executeCommand(command)
+        public func login(username: String, password: String) async throws {
+                let command = LoginCommand(username: username, password: password)
+                let loginCapabilities = try await executeCommand(command)
 		
 		// If we got capabilities from the login response, use them
 		if !loginCapabilities.isEmpty {
@@ -204,8 +205,25 @@ public actor IMAPServer {
 		} else {
 			// Otherwise, fetch capabilities explicitly
 			try await fetchCapabilities()
-		}
-	}
+                }
+        }
+
+        /// Identify the client to the server using the `ID` command.
+        /// - Parameter parameters: Key/value pairs describing the client. Pass an empty dictionary to send no information.
+        /// - Returns: Information returned by the server.
+        /// - Throws: ``IMAPError.commandNotSupported`` if the server does not support the command or ``IMAPError.commandFailed`` on failure.
+        public func id(parameters: [String: String?] = [:]) async throws -> IDResponse {
+                guard capabilities.contains(.id) else {
+                        throw IMAPError.commandNotSupported("ID command not supported by server")
+                }
+
+                var ordered = OrderedDictionary<String, String?>()
+                for (key, value) in parameters {
+                        ordered[key] = value
+                }
+                let command = IDCommand(parameters: ordered)
+                return try await executeCommand(command)
+        }
 	
 	/** 
 	 Disconnect from the server without sending a command

--- a/Sources/SwiftMail/IMAP/Models/IDResponse.swift
+++ b/Sources/SwiftMail/IMAP/Models/IDResponse.swift
@@ -1,0 +1,27 @@
+import Foundation
+import OrderedCollections
+
+/// Information returned by the IMAP `ID` command.
+///
+/// The server may return any key/value pairs describing its
+/// implementation. Values may be `nil` if the server omits them.
+public struct IDResponse: Sendable {
+    /// Raw key/value pairs returned by the server.
+    public var parameters: OrderedDictionary<String, String?>
+
+    /// Create a new response with the provided parameters.
+    public init(parameters: OrderedDictionary<String, String?> = [:]) {
+        self.parameters = parameters
+    }
+
+    /// Access a value by key.
+    public subscript(key: String) -> String? {
+        parameters[key] ?? nil
+    }
+
+    /// Commonly used name field of the server.
+    public var name: String? { self["name"] }
+
+    /// Server version string if provided.
+    public var version: String? { self["version"] }
+}


### PR DESCRIPTION
## Summary
- implement IMAP `ID` command
- expose `IDResponse` model
- add Swift collections dependency
- document new capability in README and Implemented list

## Testing
- `swift test -l`

------
https://chatgpt.com/codex/tasks/task_b_687f920b61c88326ad2ef8da2a2e4315