### PR TITLE
Handle multiple IMAP "To" and "Cc" recipients

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Handler/FetchMessageInfoHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/FetchMessageInfoHandler.swift
@@ -121,15 +121,11 @@ final class FetchMessageInfoHandler: BaseIMAPCommandHandler<[MessageInfo]>, IMAP
                 header.from = formatAddress(envelope.from[0])
             }
             
-            // Handle to addresses - check if array is not empty
-            if !envelope.to.isEmpty {
-                header.to = formatAddress(envelope.to[0])
-            }
-            
-            // Handle cc addresses - check if array is not empty
-            if !envelope.cc.isEmpty {
-                header.cc = formatAddress(envelope.cc[0])
-            }
+            // Handle to addresses - capture all recipients
+            header.to = envelope.to.map { formatAddress($0) }
+
+            // Handle cc addresses - capture all recipients
+            header.cc = envelope.cc.map { formatAddress($0) }
             
             if let date = envelope.date {
                 let dateString = String(date)

--- a/Sources/SwiftMail/IMAP/Models/Message+CustomDebugStringConvertible.swift
+++ b/Sources/SwiftMail/IMAP/Models/Message+CustomDebugStringConvertible.swift
@@ -11,7 +11,7 @@ extension Message: CustomDebugStringConvertible {
         
         // Safely unwrap other optional values
         let fromString = from ?? "No sender"
-        let toString = to ?? "No recipients"
+        let toString = to.isEmpty ? "No recipients" : to.joined(separator: ", ")
         let subjectString = subject ?? "No subject"
         
         // Compact header information

--- a/Sources/SwiftMail/IMAP/Models/Message.swift
+++ b/Sources/SwiftMail/IMAP/Models/Message.swift
@@ -29,12 +29,12 @@ public struct Message: Codable, Sendable {
     }
     
     /// The recipients of the message
-    public var to: String? {
+    public var to: [String] {
         return header.to
     }
-    
+
     /// The CC recipients of the message
-    public var cc: String? {
+    public var cc: [String] {
         return header.cc
     }
     

--- a/Sources/SwiftMail/IMAP/Models/MessageInfo.swift
+++ b/Sources/SwiftMail/IMAP/Models/MessageInfo.swift
@@ -18,10 +18,10 @@ public struct MessageInfo: Codable, Sendable {
     public var from: String?
     
     /// The recipients of the message
-    public var to: String?
-    
+    public var to: [String] = []
+
     /// The CC recipients of the message
-    public var cc: String?
+    public var cc: [String] = []
     
     /// The date of the message
     public var date: Date?
@@ -56,8 +56,8 @@ public struct MessageInfo: Codable, Sendable {
         uid: SwiftMail.UID? = nil,
         subject: String? = nil,
         from: String? = nil,
-        to: String? = nil,
-        cc: String? = nil,
+        to: [String] = [],
+        cc: [String] = [],
         date: Date? = nil,
         messageId: String? = nil,
         flags: [Flag] = [],


### PR DESCRIPTION
## Summary
- allow `MessageInfo.to` and `MessageInfo.cc` to store multiple recipients
- expose recipient arrays on `Message`
- fetch handler now maps all `To`/`Cc` addresses instead of just the first
- `to` and `cc` now default to empty arrays instead of optionals

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_6898b35f78cc832687f8fd66f1486b21