### PR TITLE
Add Equatable conformance for Flag

### DIFF
--- a/Sources/SwiftMail/IMAP/Models/Flag+Equatable.swift
+++ b/Sources/SwiftMail/IMAP/Models/Flag+Equatable.swift
@@ -1,0 +1,19 @@
+import Foundation
+
+// MARK: - Equatable Implementation
+extension Flag: Equatable {
+    public static func == (lhs: Flag, rhs: Flag) -> Bool {
+        switch (lhs, rhs) {
+        case (.seen, .seen),
+             (.answered, .answered),
+             (.flagged, .flagged),
+             (.deleted, .deleted),
+             (.draft, .draft):
+            return true
+        case (.custom(let lhsValue), .custom(let rhsValue)):
+            return lhsValue.caseInsensitiveCompare(rhsValue) == .orderedSame
+        default:
+            return false
+        }
+    }
+}

--- a/Sources/SwiftMail/IMAP/Models/Flag.swift
+++ b/Sources/SwiftMail/IMAP/Models/Flag.swift
@@ -91,4 +91,4 @@ extension Flag: Codable {
         default: self = .custom(value)
         }
     }
-} 
+}


### PR DESCRIPTION
## Summary
- Provide Equatable conformance for `Flag` in a dedicated `Flag+Equatable` extension file with case-insensitive handling for custom flags.

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68b06e83d25083268bdd7715cd02534d