### PR TITLE
Add streaming message fetch

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Commands/FetchCommands.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/FetchCommands.swift
@@ -7,25 +7,19 @@ import NIOIMAP
 
 /// Command for fetching message headers
 struct FetchMessageInfoCommand<T: MessageIdentifier>: IMAPCommand {
-	typealias ResultType = [MessageInfo]
-	typealias HandlerType = FetchMessageInfoHandler
-    
+        typealias ResultType = [MessageInfo]
+        typealias HandlerType = FetchMessageInfoHandler
+
     /// The set of message identifiers to fetch
-	let identifierSet: MessageIdentifierSet<T>
-    
-    /// Optional limit on the number of headers to return
-	let limit: Int?
+        let identifierSet: MessageIdentifierSet<T>
     
     /// Custom timeout for this operation
 	let timeoutSeconds = 10
     
     /// Initialize a new fetch headers command
-    /// - Parameters:
-    ///   - identifierSet: The set of message identifiers to fetch
-    ///   - limit: Optional limit on the number of headers to return
-	init(identifierSet: MessageIdentifierSet<T>, limit: Int? = nil) {
+    /// - Parameter identifierSet: The set of message identifiers to fetch
+    init(identifierSet: MessageIdentifierSet<T>) {
         self.identifierSet = identifierSet
-        self.limit = limit
     }
     
     /// Validate the command before execution

--- a/Sources/SwiftMail/SwiftMail.docc/Articles/GettingStartedWithIMAP.md
+++ b/Sources/SwiftMail/SwiftMail.docc/Articles/GettingStartedWithIMAP.md
@@ -56,15 +56,19 @@ let mailboxes = try await imapServer.listMailboxes(wildcard: "%")
 
 ## Fetching Messages
 
-Fetch messages from the selected mailbox:
+Fetch messages from the selected mailbox. By default these methods fetch only the first message to keep payloads small. For large mailboxes you can
+stream messages one by one and cancel early if needed:
 
 ```swift
 // Get the latest 10 messages
 if let latestMessagesSet = mailboxInfo.latest(10) {
-    let emails = try await imapServer.fetchMessages(using: latestMessagesSet)
-    print("Fetched \(emails.count) messages")
+    for try await email in imapServer.fetchMessagesStream(using: latestMessagesSet) {
+        print("Fetched message #\(email.sequenceNumber)")
+    }
 }
 ```
+If you prefer to receive all messages at once, you can still use
+``fetchMessages(using:)`` which collects the stream into an array.
 
 ## Searching Messages
 

--- a/Sources/SwiftMail/SwiftMail.docc/Resources/imap-5.swift
+++ b/Sources/SwiftMail/SwiftMail.docc/Resources/imap-5.swift
@@ -25,7 +25,8 @@ print("Mailbox contains \(mailboxInfo.messageCount) messages")
 
 // Get the latest 10 messages
 if let latestMessagesSet = mailboxInfo.latest(10) {
-	// Fetch the messages
-	let emails = try await imapServer.fetchMessages(using: latestMessagesSet)
-	print("\nFetched \(emails.count) messages")
+        // Stream the messages one by one
+        for try await email in imapServer.fetchMessagesStream(using: latestMessagesSet) {
+                print("\nFetched message #\(email.sequenceNumber)")
+        }
 }

--- a/Sources/SwiftMail/SwiftMail.docc/Resources/imap-6.swift
+++ b/Sources/SwiftMail/SwiftMail.docc/Resources/imap-6.swift
@@ -25,9 +25,10 @@ print("Mailbox contains \(mailboxInfo.messageCount) messages")
 
 // Get the latest 10 messages
 if let latestMessagesSet = mailboxInfo.latest(10) {
-	// Fetch the messages
-	let emails = try await imapServer.fetchMessages(using: latestMessagesSet)
-	print("\nFetched \(emails.count) messages")
+        // Stream the messages one by one
+        for try await email in imapServer.fetchMessagesStream(using: latestMessagesSet) {
+                print("\nFetched message #\(email.sequenceNumber)")
+        }
 }
 
 // Will store results using sequence numbers

--- a/Sources/SwiftMail/SwiftMail.docc/Resources/imap-7.swift
+++ b/Sources/SwiftMail/SwiftMail.docc/Resources/imap-7.swift
@@ -25,9 +25,10 @@ print("Mailbox contains \(mailboxInfo.messageCount) messages")
 
 // Get the latest 10 messages
 if let latestMessagesSet = mailboxInfo.latest(10) {
-	// Fetch the messages
-	let emails = try await imapServer.fetchMessages(using: latestMessagesSet)
-	print("\nFetched \(emails.count) messages")
+        // Stream the messages one by one
+        for try await email in imapServer.fetchMessagesStream(using: latestMessagesSet) {
+                print("\nFetched message #\(email.sequenceNumber)")
+        }
 }
 
 // Will store results using sequence numbers

--- a/Sources/SwiftMail/SwiftMail.docc/Resources/imap-8.swift
+++ b/Sources/SwiftMail/SwiftMail.docc/Resources/imap-8.swift
@@ -25,9 +25,10 @@ print("Mailbox contains \(mailboxInfo.messageCount) messages")
 
 // Get the latest 10 messages
 if let latestMessagesSet = mailboxInfo.latest(10) {
-	// Fetch the messages
-	let emails = try await imapServer.fetchMessages(using: latestMessagesSet)
-	print("\nFetched \(emails.count) messages")
+        // Stream the messages one by one
+        for try await email in imapServer.fetchMessagesStream(using: latestMessagesSet) {
+                print("\nFetched message #\(email.sequenceNumber)")
+        }
 }
 
 // Will store results using sequence numbers

--- a/Sources/SwiftMail/SwiftMail.docc/Resources/imap-9.swift
+++ b/Sources/SwiftMail/SwiftMail.docc/Resources/imap-9.swift
@@ -25,9 +25,10 @@ print("Mailbox contains \(mailboxInfo.messageCount) messages")
 
 // Get the latest 10 messages
 if let latestMessagesSet = mailboxInfo.latest(10) {
-	// Fetch the messages
-	let emails = try await imapServer.fetchMessages(using: latestMessagesSet)
-	print("\nFetched \(emails.count) messages")
+        // Stream the messages one by one
+        for try await email in imapServer.fetchMessagesStream(using: latestMessagesSet) {
+                print("\nFetched message #\(email.sequenceNumber)")
+        }
 }
 
 // Will store results using sequence numbers


### PR DESCRIPTION
## Summary
- remove limit parameter from message and header fetch APIs
- stream headers and messages one at a time internally to avoid large payloads
- update IMAP docs and examples for simpler streaming usage

## Testing
- `swift test 2>&1 | tail -n 20`


------
https://chatgpt.com/codex/tasks/task_b_68b5a42eb9ac8326a30ebdb6c370decb