### PR TITLE
Decode MIME-encoded attachment filenames

### DIFF
--- a/Sources/SwiftMail/IMAP/Models/MessagePart+BodyStructure.swift
+++ b/Sources/SwiftMail/IMAP/Models/MessagePart+BodyStructure.swift
@@ -81,9 +81,17 @@ extension Array where Element == MessagePart {
                     }
                 }
             }
-            
+
+            // Decode any MIME-encoded filename
+            if let name = filename {
+                let decoded = name.decodeMIMEHeader()
+                if !decoded.isEmpty {
+                    filename = decoded
+                }
+            }
+
             // Set content ID if available
-            let contentId: String? = part.fields.id.map { 
+            let contentId: String? = part.fields.id.map {
                 let str = String($0)
                 return str.isEmpty ? nil : str
             } ?? nil


### PR DESCRIPTION
## Summary
- Decode RFC 2047 encoded filenames when building IMAP message parts so attachments keep their intended names
- Test decoding of MIME-encoded attachment filenames

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68b9417b57908326a094526a00276502