### PR TITLE
Improve robustness of quoted-printable decoding

### DIFF
--- a/Sources/SwiftMail/IMAP/Models/Data+Decoding.swift
+++ b/Sources/SwiftMail/IMAP/Models/Data+Decoding.swift
@@ -30,8 +30,10 @@ extension Data {
             if let decodedContent = textContent.decodeQuotedPrintable(encoding: encoding) {
                 return decodedContent.data(using: .utf8) ?? self
             }
-            
-            return self
+
+            // Fall back to a lossy decoding approach to handle malformed input
+            let lossyContent = textContent.decodeQuotedPrintableLossy(encoding: encoding)
+            return lossyContent.data(using: .utf8) ?? self
             
         case "base64":
             // First try decoding the raw data

--- a/Tests/SwiftIMAPTests/QuotedPrintableTests.swift
+++ b/Tests/SwiftIMAPTests/QuotedPrintableTests.swift
@@ -187,6 +187,24 @@ struct QuotedPrintableTests {
         let invalidResult = invalidHex.decodeQuotedPrintable()
         #expect(invalidResult == nil, "Should return nil for invalid hex")
     }
+
+    @Test("Lossy decoding handles invalid sequences", .tags(.decoding))
+    func lossyDecodingHandlesInvalidSequences() {
+        // This input contains both valid and invalid quoted-printable sequences
+        let mixed = "Line1=0D=0ALine2=ZZ"
+
+        // Strict decoding should fail due to the invalid sequence at the end
+        #expect(mixed.decodeQuotedPrintable() == nil)
+
+        // Lossy decoding should still decode the valid sequences
+        let lossy = mixed.decodeQuotedPrintableLossy()
+        #expect(lossy == "Line1\r\nLine2=ZZ")
+
+        // Another example with a trailing '=' which is incomplete
+        let trailingEquals = "Hello=0D=0A="
+        #expect(trailingEquals.decodeQuotedPrintable() == nil)
+        #expect(trailingEquals.decodeQuotedPrintableLossy() == "Hello\r\n=")
+    }
     
     @Test("Performance with large content", .tags(.performance, .decoding))
     func performanceWithLargeContent() {


### PR DESCRIPTION
## Summary
- handle malformed quoted-printable sequences with new lossy decoder
- fall back to lossy decoding for message parts
- test lossy decoding of mixed valid/invalid sequences

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68b98bc93dd883268c39e58efa140653