### PR TITLE
Fix Q-encoded MIME header decoding

### DIFF
--- a/Sources/SwiftMail/Extensions/String+QuotedPrintable.swift
+++ b/Sources/SwiftMail/Extensions/String+QuotedPrintable.swift
@@ -22,60 +22,73 @@ extension String {
         return encoded
     }
 
-    /// Decodes a quoted-printable encoded string by removing "soft line
-    /// breaks" and replacing all quoted-printable escape sequences with the
-    /// matching characters.
-    /// - returns: The decoded string, or `nil` for invalid input.
+    /// Decodes a quoted-printable encoded string by removing "soft line" breaks and replacing all
+    /// quoted-printable escape sequences with the matching characters.
+    /// - Returns: The decoded string, or `nil` for invalid input.
     public func decodeQuotedPrintable() -> String? {
-        // Remove soft line breaks (=<CR><LF>)
-        let withoutSoftBreaks = self.replacingOccurrences(of: "=\r\n", with: "")
-            .replacingOccurrences(of: "=\n", with: "")
-        
-        var result = ""
-        var index = withoutSoftBreaks.startIndex
-        
-        while index < withoutSoftBreaks.endIndex {
-            let char = withoutSoftBreaks[index]
-            
-            if char == "=" {
-                // Check if we have enough characters for a hex sequence
-                let nextIndex = withoutSoftBreaks.index(after: index)
-                guard nextIndex < withoutSoftBreaks.endIndex,
-                      let nextNextIndex = withoutSoftBreaks.index(nextIndex, offsetBy: 1, limitedBy: withoutSoftBreaks.endIndex) else {
-                    return nil // Invalid encoding
-                }
-                
-                // Get the two hex characters
-                let hex = String(withoutSoftBreaks[nextIndex...nextNextIndex])
-                
-                // Convert hex to byte
-                guard let byte = UInt8(hex, radix: 16) else {
-                    return nil // Invalid hex sequence
-                }
-                
-                // Convert byte to character (quoted-printable is just byte substitution)
-                result.append(Character(UnicodeScalar(byte)))
-                index = withoutSoftBreaks.index(after: nextNextIndex)
-            } else {
-                result.append(char)
-                index = withoutSoftBreaks.index(after: index)
-            }
+        if let decoded = decodeQuotedPrintable(encoding: .utf8) {
+            return decoded
         }
-        
-        return result
+        return decodeQuotedPrintable(encoding: .isoLatin1)
     }
 
-    /// Decodes a quoted-printable encoded string but tolerates invalid
-    /// sequences by leaving them as-is in the output. This is useful for
-    /// handling real-world messages that might contain malformed
+    /// Decodes a quoted-printable encoded string but tolerates invalid sequences by leaving them as-is
+    /// in the output. This is useful for handling real-world messages that might contain malformed
     /// quoted-printable data.
     /// - Returns: The decoded string with invalid sequences preserved.
     public func decodeQuotedPrintableLossy() -> String {
-        // Remove soft line breaks (=<CR><LF>)
+        return decodeQuotedPrintableLossy(encoding: .utf8)
+    }
+
+    /// Decodes a quoted-printable encoded string with a specific encoding
+    /// - Parameter enc: The target string encoding. The default is UTF-8.
+    /// - Returns: The decoded string, or `nil` for invalid input.
+    public func decodeQuotedPrintable(encoding enc: String.Encoding) -> String? {
+        // Remove soft line breaks (=<CR><LF> or =<LF>)
         let withoutSoftBreaks = self.replacingOccurrences(of: "=\r\n", with: "")
             .replacingOccurrences(of: "=\n", with: "")
 
-        var result = ""
+        var bytes = Data()
+        var index = withoutSoftBreaks.startIndex
+
+        while index < withoutSoftBreaks.endIndex {
+            let char = withoutSoftBreaks[index]
+
+            if char == "=" {
+                let nextIndex = withoutSoftBreaks.index(after: index)
+                guard nextIndex < withoutSoftBreaks.endIndex,
+                      let nextNextIndex = withoutSoftBreaks.index(nextIndex, offsetBy: 1, limitedBy: withoutSoftBreaks.endIndex) else {
+                    return nil
+                }
+                let hex = String(withoutSoftBreaks[nextIndex...nextNextIndex])
+                guard let byte = UInt8(hex, radix: 16) else {
+                    return nil
+                }
+                bytes.append(byte)
+                index = withoutSoftBreaks.index(after: nextNextIndex)
+            } else {
+                if let ascii = char.asciiValue {
+                    bytes.append(ascii)
+                } else if let data = String(char).data(using: enc) {
+                    bytes.append(contentsOf: data)
+                }
+                index = withoutSoftBreaks.index(after: index)
+            }
+        }
+
+        return String(data: bytes, encoding: enc)
+    }
+
+    /// Decodes a quoted-printable encoded string with a specific encoding, tolerating invalid sequences
+    /// by preserving them in the output.
+    /// - Parameter enc: The target string encoding. The default is UTF-8.
+    /// - Returns: The decoded string with invalid sequences preserved.
+    public func decodeQuotedPrintableLossy(encoding enc: String.Encoding) -> String {
+        // Remove soft line breaks
+        let withoutSoftBreaks = self.replacingOccurrences(of: "=\r\n", with: "")
+            .replacingOccurrences(of: "=\n", with: "")
+
+        var bytes = Data()
         var index = withoutSoftBreaks.startIndex
 
         while index < withoutSoftBreaks.endIndex {
@@ -88,115 +101,88 @@ extension String {
                     if nextNextIndex < withoutSoftBreaks.endIndex {
                         let hex = String(withoutSoftBreaks[nextIndex...nextNextIndex])
                         if let byte = UInt8(hex, radix: 16) {
-                            result.append(Character(UnicodeScalar(byte)))
+                            bytes.append(byte)
                             index = withoutSoftBreaks.index(after: nextNextIndex)
                             continue
                         }
                     }
                 }
-                // If we reach here, the sequence is invalid or incomplete.
-                // Treat the '=' as a literal character and continue.
-                result.append("=")
+                // Invalid or incomplete sequence: treat '=' literally
+                bytes.append(UInt8(ascii: "="))
                 index = withoutSoftBreaks.index(after: index)
             } else {
-                result.append(char)
+                if let ascii = char.asciiValue {
+                    bytes.append(ascii)
+                } else if let data = String(char).data(using: enc) {
+                    bytes.append(contentsOf: data)
+                }
                 index = withoutSoftBreaks.index(after: index)
             }
         }
 
-        return result
-    }
-    
-    /// Decodes a quoted-printable encoded string with a specific encoding
-    /// - parameter enc: A string encoding. The default is UTF-8.
-    /// - returns: The decoded string, or `nil` for invalid input.
-    public func decodeQuotedPrintable(encoding enc: String.Encoding) -> String? {
-        // First decode the quoted-printable sequences
-        guard let decoded = self.decodeQuotedPrintable() else {
-            return nil
-        }
-        
-        // Then convert to the target encoding if needed
-        // For most cases, the decoded string should already be in the correct encoding
-        return decoded
-    }
-
-    /// Decodes a quoted-printable encoded string with a specific encoding,
-    /// tolerating invalid sequences by preserving them in the output.
-    /// - Parameter enc: A string encoding. The default is UTF-8.
-    /// - Returns: The decoded string with invalid sequences preserved.
-    public func decodeQuotedPrintableLossy(encoding enc: String.Encoding) -> String {
-        // First decode using the lossy variant
-        let decoded = self.decodeQuotedPrintableLossy()
-
-        // Then convert to the target encoding if needed
-        // For most cases, the decoded string should already be in the correct encoding
-        return decoded
+        return String(data: bytes, encoding: enc) ?? String(decoding: bytes, as: UTF8.self)
     }
 
     /// Decode a MIME-encoded header string
     /// - Returns: The decoded string
     public func decodeMIMEHeader() -> String {
-        // Regular expression to match MIME encoded-word syntax: =?charset?encoding?encoded-text?=
         let pattern = "=\\?([^?]+)\\?([bBqQ])\\?([^?]*)\\?="
-        
         guard let regex = try? NSRegularExpression(pattern: pattern, options: []) else {
             return self
         }
-        
-        var result = self
-        
-        // Find all matches and process them in reverse order to avoid index issues
+
         let matches = regex.matches(in: self, options: [], range: NSRange(self.startIndex..., in: self))
-        
-        for match in matches.reversed() {
-            guard let charsetRange = Range(match.range(at: 1), in: self),
+
+        var result = ""
+        var lastIndex = self.startIndex
+        var lastWasEncodedWord = false
+
+        for match in matches {
+            guard let range = Range(match.range, in: self),
+                  let charsetRange = Range(match.range(at: 1), in: self),
                   let encodingRange = Range(match.range(at: 2), in: self),
-                  let textRange = Range(match.range(at: 3), in: self),
-                  let fullRange = Range(match.range, in: self) else {
+                  let textRange = Range(match.range(at: 3), in: self) else {
                 continue
             }
-            
+
+            let between = self[lastIndex..<range.lowerBound]
+            if !(lastWasEncodedWord && between.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty) {
+                result += String(between)
+            }
+
             let charset = String(self[charsetRange])
             let encoding = String(self[encodingRange]).uppercased()
-            let encodedText = String(self[textRange])
-            
+            var encodedText = String(self[textRange])
             var decodedText = ""
-            
-            // Convert charset to String.Encoding
+
             let stringEncoding = String.encodingFromCharset(charset)
-            
-            // Decode based on encoding type
+
             if encoding == "B" {
-                // Base64 encoding
                 if let data = Data(base64Encoded: encodedText, options: .ignoreUnknownCharacters),
                    let decoded = String(data: data, encoding: stringEncoding) {
                     decodedText = decoded
-                } else {
-                    // Try with UTF-8 if the specified charset fails
-                    if let data = Data(base64Encoded: encodedText, options: .ignoreUnknownCharacters),
-                       let decoded = String(data: data, encoding: .utf8) {
-                        decodedText = decoded
-                    }
+                } else if let data = Data(base64Encoded: encodedText, options: .ignoreUnknownCharacters),
+                          let decoded = String(data: data, encoding: .utf8) {
+                    decodedText = decoded
                 }
             } else if encoding == "Q" {
-                // Quoted-printable encoding
+                // In MIME headers, underscores represent spaces
+                encodedText = encodedText.replacingOccurrences(of: "_", with: " ")
                 if let decoded = encodedText.decodeQuotedPrintable(encoding: stringEncoding) {
                     decodedText = decoded
                 } else if let decoded = encodedText.decodeQuotedPrintable() {
-                    // Fallback to UTF-8 if the specified charset fails
                     decodedText = decoded
                 }
             }
-            
-            if !decodedText.isEmpty {
-                result = result.replacingCharacters(in: fullRange, with: decodedText)
-            }
+
+            result += decodedText
+            lastIndex = range.upperBound
+            lastWasEncodedWord = true
         }
-        
-        // Handle consecutive encoded words (they should be concatenated without spaces)
-        result = result.replacingOccurrences(of: "?= =?", with: "")
-        
+
+        let remainder = self[lastIndex...]
+        result += String(remainder)
+
         return result
     }
 
@@ -210,7 +196,7 @@ extension String {
             let charsetString = self[charsetRange].replacingOccurrences(of: "charset=", with: "")
             return String.encodingFromCharset(charsetString)
         }
-        
+
         // Look for meta tag with charset
         let metaPattern = "<meta[^>]*charset=([^\\s;\"'/>]+)"
         if let range = self.range(of: metaPattern, options: .regularExpression, range: nil, locale: nil),
@@ -218,11 +204,11 @@ extension String {
             let charsetString = self[charsetRange].replacingOccurrences(of: "charset=", with: "")
             return String.encodingFromCharset(charsetString)
         }
-        
+
         // Default to UTF-8
         return .utf8
     }
-    
+
     /// Decode quoted-printable content in message bodies
     /// - Returns: The decoded content
     public func decodeQuotedPrintableContent() -> String {
@@ -232,7 +218,7 @@ extension String {
         var bodyContent = ""
         var headerContent = ""
         var contentEncoding: String.Encoding = .utf8
-        
+
         // Process each line
         for line in lines {
             if !inBody {
@@ -242,10 +228,10 @@ extension String {
                     headerContent += line + "\n"
                     continue
                 }
-                
+
                 // Add header line
                 headerContent += line + "\n"
-                
+
                 // Check for Content-Type header with charset
                 if line.lowercased().contains("content-type:") && line.lowercased().contains("charset=") {
                     if let range = line.range(of: "charset=([^\\s;\"']+)", options: .regularExpression) {
@@ -256,9 +242,9 @@ extension String {
                         contentEncoding = String.encodingFromCharset(charsetString)
                     }
                 }
-                
+
                 // Check if this is a Content-Transfer-Encoding header
-                if line.lowercased().contains("content-transfer-encoding:") && 
+                if line.lowercased().contains("content-transfer-encoding:") &&
                    line.lowercased().contains("quoted-printable") {
                     // Found quoted-printable encoding
                     inBody = false
@@ -268,7 +254,7 @@ extension String {
                 bodyContent += line + "\n"
             }
         }
-        
+
         // If we found quoted-printable encoding, decode the body
         if !bodyContent.isEmpty {
             // Decode the body content with the detected encoding
@@ -279,16 +265,14 @@ extension String {
                 return headerContent + decodedBody
             }
         }
-        
+
         // If we didn't find quoted-printable encoding or no body content,
         // try to decode the entire content with the detected charset
         if let decodedContent = self.decodeQuotedPrintable(encoding: contentEncoding) {
             return decodedContent
         }
-        
+
         // Last resort: try with UTF-8
         return self.decodeQuotedPrintable() ?? self
     }
 }
-
- 

--- a/Tests/SwiftIMAPTests/QuotedPrintableTests.swift
+++ b/Tests/SwiftIMAPTests/QuotedPrintableTests.swift
@@ -102,6 +102,13 @@ struct QuotedPrintableTests {
         let isoEncoded = "=?ISO-8859-1?Q?J=F6rg=20M=FCller?="
         #expect(isoEncoded.decodeMIMEHeader() == "Jörg Müller")
     }
+
+    @Test("Real-world subject decoding", .tags(.decoding, .mime))
+    func realWorldSubjectDecoding() {
+        let raw = "=?UTF-8?Q?=5B_Last_Chance_-_10=25_OFF_=5D_=F0=9F=8E=93_Hot_Deal=3A_Top_On?= =?UTF-8?Q?line_Courses_Starting_at_just_=249_=E2=80=93_Don=E2=80=99t_Miss?= =?UTF-8?Q?_Out?="
+        let expected = "[ Last Chance - 10% OFF ] 🎓 Hot Deal: Top Online Courses Starting at just $9 – Don’t Miss Out"
+        #expect(raw.decodeMIMEHeader() == expected)
+    }
     
     // MARK: - HTML File Tests
     


### PR DESCRIPTION
## Summary
- decode Q-encoded MIME headers with proper UTF-8 handling
- handle whitespace between encoded words and underscores-as-space
- add regression test for subject decoding

## Testing
- `swift test`

------
https://chatgpt.com/codex/tasks/task_b_68b99f198180832696794ee020399d6e