### PR TITLE
Avoid mixing data from unsolicited IMAP fetch responses

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -1005,6 +1005,15 @@ public actor IMAPServer {
         
         // Create the handler for this command
         let handler = CommandType.HandlerType.init(commandTag: tag, promise: resultPromise)
+
+        // Configure handler with expected identifiers when possible
+        if let partHandler = handler as? FetchPartHandler {
+            if let fetchCommand = command as? FetchMessagePartCommand<UID> {
+                partHandler.expectedUID = fetchCommand.identifier
+            } else if let fetchCommand = command as? FetchMessagePartCommand<SequenceNumber> {
+                partHandler.expectedSequence = fetchCommand.identifier
+            }
+        }
         
         // Get timeout value for this command
         let timeoutSeconds = command.timeoutSeconds


### PR DESCRIPTION
## Summary
- filter part fetch responses by expected UID or sequence
- configure FetchPartHandler with the expected identifier

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68bea4a995bc8326a5564fe3419aeb78