### PR TITLE
Preserve spaces in sanitized filenames

### DIFF
--- a/Sources/SwiftMail/Extensions/String+FileSystem.swift
+++ b/Sources/SwiftMail/Extensions/String+FileSystem.swift
@@ -4,13 +4,16 @@
 import Foundation
 
 extension String {
-    /// Sanitize a filename to ensure it's valid
-    /// - Returns: A sanitized filename
+    /// Sanitize a filename to ensure it's valid for most file systems.
+    ///
+    /// This removes disallowed characters while leaving all whitespace
+    /// untouched so that a filename such as "my document.pdf" remains user
+    /// friendly.
+    /// - Returns: A sanitized filename that is safe to write to disk
     public func sanitizedFileName() -> String {
         let invalidCharacters = CharacterSet(charactersIn: ":/\\?%*|\"<>")
         return self
             .components(separatedBy: invalidCharacters)
-            .joined(separator: "_")
-            .replacingOccurrences(of: " ", with: "_")
+            .joined()
     }
-} 
+}

--- a/Tests/SwiftMailCoreTests/String+UtilitiesTests.swift
+++ b/Tests/SwiftMailCoreTests/String+UtilitiesTests.swift
@@ -13,13 +13,13 @@ struct StringUtilitiesTests {
         #expect("document.txt".sanitizedFileName() == "document.txt")
         #expect("image.jpg".sanitizedFileName() == "image.jpg")
         
-        // Test invalid characters are replaced
-        #expect("file:with/invalid\\chars?.txt".sanitizedFileName() == "file_with_invalid_chars_.txt")
-        #expect("doc*with|special<chars>.pdf".sanitizedFileName() == "doc_with_special_chars_.pdf")
-        
-        // Test spaces are replaced with underscores
-        #expect("my document.pdf".sanitizedFileName() == "my_document.pdf")
-        #expect("file with spaces.txt".sanitizedFileName() == "file_with_spaces.txt")
+        // Test invalid characters are removed
+        #expect("file:with/invalid\\chars?.txt".sanitizedFileName() == "filewithinvalidchars.txt")
+        #expect("doc*with|special<chars>.pdf".sanitizedFileName() == "docwithspecialchars.pdf")
+
+        // Test spaces are preserved exactly
+        #expect("my document.pdf".sanitizedFileName() == "my document.pdf")
+        #expect("file   with  spaces.txt".sanitizedFileName() == "file   with  spaces.txt")
         
         // Test empty string
         #expect("".sanitizedFileName() == "")


### PR DESCRIPTION
## Summary
- Remove invalid characters from file names while leaving spaces untouched
- Drop whitespace collapsing from `sanitizedFileName`
- Update utilities tests for the new filename behavior

## Testing
- `swift test`


------
https://chatgpt.com/codex/tasks/task_b_68c2960050188326bd658988b2889b78