### PR TITLE
Support crosscompile

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -66,7 +66,7 @@
     {
       "identity" : "swift-nio-imap",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-imap",
+      "location" : "https://github.com/OlofT/swift-nio-imap",
       "state" : {
         "branch" : "main",
         "revision" : "ad065b2f307d11c34717406decc893d9ed1c9d7c"

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,11 @@ let package = Package(
         .package(url: "https://github.com/thebarndog/swift-dotenv", from: "2.1.0"),
 		.package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.0.0"),
-        .package(url: "https://github.com/apple/swift-nio-imap", branch: "main"),
+        //.package(url: "https://github.com/apple/swift-nio-imap", branch: "main"),
+		
+		// a nio-imap fork that supplies crosscompile
+		.package(url: "https://github.com/OlofT/swift-nio-imap", branch: "main"),
+		
         .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-testing", branch: "main"),

--- a/Sources/SwiftMail/Extensions/String+Hostname.swift
+++ b/Sources/SwiftMail/Extensions/String+Hostname.swift
@@ -5,8 +5,10 @@ import Foundation
 
 #if canImport(Darwin)
 import Darwin
-#else
+#elseif canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 extension String {

--- a/Sources/SwiftMail/SMTP/SMTPServer.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer.swift
@@ -9,8 +9,10 @@ import Logging
 
 import NIOConcurrencyHelpers
 
-#if os(Linux)
+#if canImport(Glibc)
 import Glibc
+#elseif canImport(Musl)
+import Musl
 #endif
 
 /**


### PR DESCRIPTION
Change GLibc imports to:
```
#if canImport(Darwin)
import Darwin
#elseif canImport(Glibc)
import Glibc
#elseif canImport(Musl)
import Musl
```
As per instructions in: https://www.swift.org/documentation/articles/static-linux-getting-started.html

This allows SwiftMail to be cross compiled, which is very nice.

Sadly NIO-imap has the same problem, and a similar PR is awaiting merge. In the meantime `https://github.com/OlofT/swift-nio-imap` can be used instead (just a plain fork).
