### PR TITLE
Expose BCC recipients when fetching IMAP messages

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Handler/FetchMessageInfoHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/FetchMessageInfoHandler.swift
@@ -129,6 +129,9 @@ final class FetchMessageInfoHandler: BaseIMAPCommandHandler<[MessageInfo]>, IMAP
 
             // Handle cc addresses - capture all recipients
             header.cc = envelope.cc.map { formatAddress($0) }
+
+            // Handle bcc addresses - capture all recipients
+            header.bcc = envelope.bcc.map { formatAddress($0) }
             
             if let date = envelope.date {
                 let dateString = String(date)

--- a/Sources/SwiftMail/IMAP/Models/Message.swift
+++ b/Sources/SwiftMail/IMAP/Models/Message.swift
@@ -37,7 +37,12 @@ public struct Message: Codable, Sendable {
     public var cc: [String] {
         return header.cc
     }
-    
+
+    /// The BCC recipients of the message
+    public var bcc: [String] {
+        return header.bcc
+    }
+
     /// The date of the message
     public var date: Date? {
         return header.date

--- a/Sources/SwiftMail/IMAP/Models/MessageInfo.swift
+++ b/Sources/SwiftMail/IMAP/Models/MessageInfo.swift
@@ -22,6 +22,9 @@ public struct MessageInfo: Codable, Sendable {
 
     /// The CC recipients of the message
     public var cc: [String] = []
+
+    /// The BCC recipients of the message
+    public var bcc: [String] = []
     
     /// The date of the message
     public var date: Date?
@@ -37,6 +40,21 @@ public struct MessageInfo: Codable, Sendable {
     
     /// Additional header fields
     public var additionalFields: [String: String]?
+
+    private enum CodingKeys: String, CodingKey {
+        case sequenceNumber
+        case uid
+        case subject
+        case from
+        case to
+        case cc
+        case bcc
+        case date
+        case messageId
+        case flags
+        case parts
+        case additionalFields
+    }
     
     /// Initialize a new email header
     /// - Parameters:
@@ -58,6 +76,7 @@ public struct MessageInfo: Codable, Sendable {
         from: String? = nil,
         to: [String] = [],
         cc: [String] = [],
+        bcc: [String] = [],
         date: Date? = nil,
         messageId: String? = nil,
         flags: [Flag] = [],
@@ -70,10 +89,45 @@ public struct MessageInfo: Codable, Sendable {
         self.from = from
         self.to = to
         self.cc = cc
+        self.bcc = bcc
         self.date = date
         self.messageId = messageId
         self.flags = flags
         self.parts = parts
         self.additionalFields = additionalFields
+    }
+}
+
+public extension MessageInfo {
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+
+        let sequenceNumber = try container.decode(SequenceNumber.self, forKey: .sequenceNumber)
+        let uid = try container.decodeIfPresent(UID.self, forKey: .uid)
+        let subject = try container.decodeIfPresent(String.self, forKey: .subject)
+        let from = try container.decodeIfPresent(String.self, forKey: .from)
+        let to = try container.decodeIfPresent([String].self, forKey: .to) ?? []
+        let cc = try container.decodeIfPresent([String].self, forKey: .cc) ?? []
+        let bcc = try container.decodeIfPresent([String].self, forKey: .bcc) ?? []
+        let date = try container.decodeIfPresent(Date.self, forKey: .date)
+        let messageId = try container.decodeIfPresent(String.self, forKey: .messageId)
+        let flags = try container.decodeIfPresent([Flag].self, forKey: .flags) ?? []
+        let parts = try container.decodeIfPresent([MessagePart].self, forKey: .parts) ?? []
+        let additionalFields = try container.decodeIfPresent([String: String].self, forKey: .additionalFields)
+
+        self.init(
+            sequenceNumber: sequenceNumber,
+            uid: uid,
+            subject: subject,
+            from: from,
+            to: to,
+            cc: cc,
+            bcc: bcc,
+            date: date,
+            messageId: messageId,
+            flags: flags,
+            parts: parts,
+            additionalFields: additionalFields
+        )
     }
 }

--- a/Tests/SwiftIMAPTests/MessageBodyTests.swift
+++ b/Tests/SwiftIMAPTests/MessageBodyTests.swift
@@ -15,10 +15,11 @@ func testFindHtmlBodyWithCharset() throws {
             from: "test@example.com",
             to: ["recipient@example.com"],
             cc: [],
+            bcc: ["hidden@example.com"],
             date: Date(),
             flags: []
         )
-        
+
         let htmlPart = MessagePart(
             section: Section([1]),
             contentType: "text/html; charset=utf-8",
@@ -61,6 +62,9 @@ func testFindHtmlBodyWithCharset() throws {
         let textBody = message.textBody
         #expect(textBody != nil)
         #expect(textBody?.contains("Test plain text content") == true)
+
+        // Verify BCC recipients are exposed
+        #expect(message.bcc == ["hidden@example.com"])
 }
 
 @Test


### PR DESCRIPTION
## Summary
- add BCC storage to MessageInfo and Message so blind recipients are available to clients
- populate BCC recipients from IMAP envelopes while maintaining backward-compatible decoding
- cover the new surface with a regression test that exercises message.bcc

## Testing
- swift test

------
https://chatgpt.com/codex/tasks/task_b_68dc0a9603788326b80f3b5e5d8d5186

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Adds BCC recipients to MessageInfo/Message, populates from IMAP envelopes, ensures backward-compatible decoding, and tests access via message.bcc.
> 
> - **Models**:
>   - Add `bcc: [String]` to `MessageInfo` with `CodingKeys` and custom `init(from:)` for backward-compatible decoding.
>   - Expose `bcc` via `Message.bcc`.
> - **IMAP Handler**:
>   - Populate `header.bcc` from IMAP `envelope.bcc` in `FetchMessageInfoHandler`.
> - **Tests**:
>   - Extend `MessageBodyTests.testFindHtmlBodyWithCharset` to include and assert `message.bcc`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit dea7882423bba691b371385db4d485d32f1e39f2. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->