### PR TITLE
Add CREATE command support for folder creation

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Commands/CreateMailboxCommand.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/CreateMailboxCommand.swift
@@ -1,0 +1,22 @@
+import Foundation
+import NIOIMAPCore
+import NIO
+
+/** Command to create a new mailbox */
+struct CreateMailboxCommand: IMAPCommand {
+    typealias ResultType = Void
+    typealias HandlerType = CreateMailboxHandler
+
+    let mailboxName: String
+
+    /// Initialize a new CREATE command
+    /// - Parameter mailboxName: The name of the mailbox to create
+    init(mailboxName: String) {
+        self.mailboxName = mailboxName
+    }
+
+    func toTaggedCommand(tag: String) -> TaggedCommand {
+        let mailbox = MailboxName(ByteBuffer(string: mailboxName))
+        return TaggedCommand(tag: tag, command: .create(mailbox, []))
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/CreateMailboxHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/CreateMailboxHandler.swift
@@ -1,0 +1,32 @@
+import Foundation
+import NIOIMAPCore
+import NIO
+import Logging
+
+/** Handler for the CREATE command */
+final class CreateMailboxHandler: BaseIMAPCommandHandler<Void>, IMAPCommandHandler, @unchecked Sendable {
+    typealias ResultType = Void
+    typealias InboundIn = Response
+    typealias InboundOut = Never
+
+    override func processResponse(_ response: Response) -> Bool {
+        // Call the base class implementation to buffer the response
+        let handled = super.processResponse(response)
+
+        // Process the response
+        if case .tagged(let tagged) = response, tagged.tag == commandTag {
+            // This is our tagged response, handle it
+            switch tagged.state {
+            case .ok:
+                succeedWithResult(())
+            case .no(let text):
+                failWithError(IMAPError.commandFailed("NO response: \(text)"))
+            case .bad(let text):
+                failWithError(IMAPError.commandFailed("BAD response: \(text)"))
+            }
+            return true
+        }
+
+        return handled
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -356,13 +356,30 @@ public actor IMAPServer {
     }
     
     // MARK: - Mailbox Commands
-    
+
+    /**
+     Create a new mailbox on the server
+
+     This method creates a new mailbox (folder) with the specified name.
+     Use forward slashes to create hierarchical mailboxes (e.g., "Work/Projects").
+
+     - Parameter mailboxName: The name of the mailbox to create
+     - Throws:
+     - `IMAPError.commandFailed` if the mailbox cannot be created
+     - `IMAPError.connectionFailed` if not connected
+     - Note: Logs mailbox creation at debug level
+     */
+    public func createMailbox(_ mailboxName: String) async throws {
+        let command = CreateMailboxCommand(mailboxName: mailboxName)
+        try await executeCommand(command)
+    }
+
     /**
      Select a mailbox
-     
+
      This method selects a mailbox and makes it the current mailbox for subsequent
      operations. Only one mailbox can be selected at a time.
-     
+
      - Parameter mailboxName: The name of the mailbox to select
      - Returns: Status information about the selected mailbox
      - Throws:


### PR DESCRIPTION
- Added CreateMailboxCommand to send IMAP CREATE commands
- Added CreateMailboxHandler to process CREATE responses
- Added public createMailbox() method to IMAPServer
- Supports creating nested folders with "/" delimiter (e.g., "Work/Projects")

This enables  clients to programmatically create new folders on IMAP servers without requiring manual folder creation.