### PR TITLE
Fix IMAP APPEND reliability issues

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Commands/AppendCommand.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/AppendCommand.swift
@@ -33,12 +33,15 @@ struct AppendCommand: IMAPCommand {
         let appendOptions = AppendOptions(flagList: nioFlags, internalDate: internalDate)
         let metadata = AppendMessage(options: appendOptions, data: AppendData(byteCount: messageBuffer.readableBytes))
 
-        try await channel.write(IMAPClientHandler.OutboundIn.part(.append(.start(tag: tag, appendingTo: mailbox)))).get()
-        // Flush APPEND metadata before waiting on message-bytes write completion.
-        // Otherwise the server never receives the literal header and cannot send continuation.
-        try await channel.writeAndFlush(IMAPClientHandler.OutboundIn.part(.append(.beginMessage(message: metadata)))).get()
-        try await channel.write(IMAPClientHandler.OutboundIn.part(.append(.messageBytes(messageBuffer)))).get()
-        try await channel.write(IMAPClientHandler.OutboundIn.part(.append(.endMessage))).get()
-        try await channel.writeAndFlush(IMAPClientHandler.OutboundIn.part(.append(.finish))).get()
+        channel.write(IMAPClientHandler.OutboundIn.part(.append(.start(tag: tag, appendingTo: mailbox))), promise: nil)
+        channel.write(IMAPClientHandler.OutboundIn.part(.append(.beginMessage(message: metadata))), promise: nil)
+        // Flush APPEND metadata first so servers can respond with literal continuation.
+        channel.flush()
+
+        // Do not await write promises here. These writes may be continuation-gated by the IMAP state machine,
+        // and awaiting them can deadlock this command send path until timeout.
+        channel.write(IMAPClientHandler.OutboundIn.part(.append(.messageBytes(messageBuffer))), promise: nil)
+        channel.write(IMAPClientHandler.OutboundIn.part(.append(.endMessage)), promise: nil)
+        channel.writeAndFlush(IMAPClientHandler.OutboundIn.part(.append(.finish)), promise: nil)
     }
 }

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -1437,7 +1437,7 @@ extension IMAPServer {
             throw IMAPError.invalidArgument("Mailbox name must not be empty")
         }
 
-        var content = email.constructContent(use8BitMIME: true)
+        var content = canonicalizeCRLF(email.constructContent(use8BitMIME: true))
         if !content.hasSuffix("\r\n") {
             content.append("\r\n")
         }
@@ -1470,5 +1470,14 @@ extension IMAPServer {
         }
 
         return try await append(email: email, to: targetMailbox, flags: flags, internalDate: date)
+    }
+}
+
+private extension IMAPServer {
+    func canonicalizeCRLF(_ value: String) -> String {
+        let normalized = value
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+        return normalized.replacingOccurrences(of: "\n", with: "\r\n")
     }
 }


### PR DESCRIPTION
## Summary

Three fixes for IMAP APPEND reliability:

- **Fix literal flush ordering** — Ensure the literal payload is flushed to the channel before waiting for the server response, preventing hangs when the write and response race.
- **Avoid deadlock on continuation-gated writes** — Restructure the APPEND send path so that continuation-based literal writes don't deadlock when the server requires a continuation response before accepting the payload.
- **Canonicalize CRLF for payloads** — Normalize line endings to `\r\n` before sending APPEND payloads, as required by RFC 3501. Messages composed with `\n`-only line endings would otherwise cause byte count mismatches or server rejection.

Found while implementing draft save functionality in a mail client built on SwiftMail.

## Test plan

- [ ] Verify APPEND works for saving drafts to an IMAP Drafts folder
- [ ] Verify APPEND works with messages containing mixed line endings (`\n`, `\r\n`, `\r`)
- [ ] Verify no hangs or deadlocks during concurrent APPEND operations