### PR TITLE
Add XOAUTH2 SMTP authentication

### DIFF
--- a/Sources/SwiftMail/SMTP/Commands/AuthCommand.swift
+++ b/Sources/SwiftMail/SMTP/Commands/AuthCommand.swift
@@ -50,6 +50,17 @@ struct AuthCommand: SMTPCommand {
         case .login:
             // For LOGIN auth, the initial command doesn't include credentials
             return "AUTH LOGIN"
+        case .xoauth2:
+            // XOAUTH2 format: user=<email>\x01auth=Bearer <token>\x01\x01
+            var data = Data()
+            data.append(contentsOf: "user=".utf8)
+            data.append(contentsOf: username.utf8)
+            data.append(0x01)
+            data.append(contentsOf: "auth=Bearer ".utf8)
+            data.append(contentsOf: password.utf8)
+            data.append(0x01)
+            data.append(0x01)
+            return "AUTH XOAUTH2 \(data.base64EncodedString())"
         }
     }
     

--- a/Sources/SwiftMail/SMTP/Commands/XOAuth2AuthCommand.swift
+++ b/Sources/SwiftMail/SMTP/Commands/XOAuth2AuthCommand.swift
@@ -1,0 +1,35 @@
+import Foundation
+import NIO
+
+/// Command to authenticate with SMTP server using XOAUTH2 method (used by Gmail and other OAuth2 providers)
+struct XOAuth2AuthCommand: SMTPCommand {
+    typealias ResultType = AuthResult
+    typealias HandlerType = PlainAuthHandler
+
+    let email: String
+    let accessToken: String
+    let timeoutSeconds: Int = 30
+
+    func toCommandString() -> String {
+        // XOAUTH2 format: "user=" + email + "\x01" + "auth=Bearer " + token + "\x01\x01"
+        var data = Data()
+        data.append(contentsOf: "user=".utf8)
+        data.append(contentsOf: email.utf8)
+        data.append(0x01)
+        data.append(contentsOf: "auth=Bearer ".utf8)
+        data.append(contentsOf: accessToken.utf8)
+        data.append(0x01)
+        data.append(0x01)
+        let encoded = data.base64EncodedString()
+        return "AUTH XOAUTH2 \(encoded)"
+    }
+
+    func validate() throws {
+        guard !email.isEmpty else {
+            throw SMTPError.authenticationFailed("Email cannot be empty")
+        }
+        guard !accessToken.isEmpty else {
+            throw SMTPError.authenticationFailed("Access token cannot be empty")
+        }
+    }
+}

--- a/Sources/SwiftMail/SMTP/Handlers/AuthHandler.swift
+++ b/Sources/SwiftMail/SMTP/Handlers/AuthHandler.swift
@@ -51,8 +51,8 @@ final class AuthHandler: BaseSMTPHandler<AuthResult>, @unchecked Sendable {
     override func processResponse(_ response: SMTPResponse) -> Bool {
         // Handle authentication based on the method and current state
         switch method {
-        case .plain:
-            // For PLAIN auth, we should get a success response immediately
+        case .plain, .xoauth2:
+            // For PLAIN and XOAUTH2 auth, we should get a success response immediately
             if response.code >= 200 && response.code < 300 {
                 promise.succeed(AuthResult(method: method, success: true))
                 return true
@@ -60,7 +60,7 @@ final class AuthHandler: BaseSMTPHandler<AuthResult>, @unchecked Sendable {
                 promise.succeed(AuthResult(method: method, success: false, errorMessage: response.message))
                 return true
             }
-            
+
         case .login:
             // For LOGIN auth, we need to handle multiple steps
             switch state {
@@ -128,6 +128,7 @@ final class AuthHandler: BaseSMTPHandler<AuthResult>, @unchecked Sendable {
 enum AuthMethod: String {
     case plain = "PLAIN"
     case login = "LOGIN"
+    case xoauth2 = "XOAUTH2"
 }
 
 /// Result of authentication attempt

--- a/Sources/SwiftMail/SMTP/Handlers/AuthHandlerStateMachine.swift
+++ b/Sources/SwiftMail/SMTP/Handlers/AuthHandlerStateMachine.swift
@@ -42,14 +42,14 @@ final class AuthHandlerStateMachine {
 	func processResponse(_ response: SMTPResponse,
                                sendCredential: (String) -> Void) -> (isComplete: Bool, result: AuthResult?) {
         switch method {
-        case .plain:
-            // For PLAIN auth, we should get a success response immediately
+        case .plain, .xoauth2:
+            // For PLAIN and XOAUTH2 auth, we should get a success response immediately
             if response.code >= 200 && response.code < 300 {
                 return (true, AuthResult(method: method, success: true))
             } else if response.code >= 400 {
                 return (true, AuthResult(method: method, success: false, errorMessage: response.message))
             }
-            
+
         case .login:
             // For LOGIN auth, we need to handle multiple steps
             switch state {

--- a/Sources/SwiftMail/SMTP/SMTPServer.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer.swift
@@ -277,7 +277,34 @@ public actor SMTPServer {
         throw SMTPError.authenticationFailed("Authentication failed with all available methods")
     }
     
-    /** 
+    /**
+     Authenticate with the SMTP server using XOAUTH2
+
+     This method authenticates using the XOAUTH2 mechanism, which is required
+     by Gmail and other providers when using OAuth2 access tokens for SMTP.
+
+     - Parameters:
+       - email: The email address of the account
+       - accessToken: A valid OAuth2 access token
+     - Throws:
+       - `SMTPError.authenticationFailed` if the server does not support XOAUTH2
+         or if the token is rejected
+       - `SMTPError.connectionFailed` if not connected
+     */
+    public func authenticateXOAUTH2(email: String, accessToken: String) async throws {
+        guard capabilities.contains("AUTH XOAUTH2") else {
+            throw SMTPError.authenticationFailed("Server does not support XOAUTH2 authentication")
+        }
+
+        let command = XOAuth2AuthCommand(email: email, accessToken: accessToken)
+        let result = try await executeCommand(command)
+
+        guard result.success else {
+            throw SMTPError.authenticationFailed(result.errorMessage ?? "XOAUTH2 authentication failed")
+        }
+    }
+
+    /**
      Disconnect from the SMTP server
      
      This method performs a clean disconnect from the server by:


### PR DESCRIPTION
## Summary

Adds XOAUTH2 authentication support for SMTP, complementing the existing IMAP XOAUTH2 support (#69).

- Add `SMTPServer.authenticateXOAUTH2(email:accessToken:)` public method
- Add `XOAuth2AuthCommand` for SMTP XOAUTH2 token encoding (RFC format: `user=<email>\x01auth=Bearer <token>\x01\x01`, base64-encoded)
- Add `.xoauth2` case to `AuthMethod` enum
- Handle XOAUTH2 responses in `AuthHandler` and `AuthHandlerStateMachine` (same flow as PLAIN — single response, no multi-step challenge)

This is required for sending email through Gmail and other OAuth2 providers via SMTP. Without it, apps using OAuth2 for IMAP authentication have no way to send mail through the same provider.

## Test plan

- [ ] Verify XOAUTH2 SMTP auth works with Gmail (port 587, STARTTLS)
- [ ] Verify existing PLAIN and LOGIN auth methods are unaffected
- [ ] Verify error handling for invalid/expired tokens