### PR TITLE
Fail closed when STARTTLS upgrade fails on port 587

### DIFF
--- a/Tests/SwiftSMTPTests/SMTPTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPTests.swift
@@ -1,6 +1,5 @@
 import Testing
 @testable import SwiftMail
-@testable import SwiftMail
 
 struct SMTPTests {
     @Test
@@ -55,4 +54,40 @@ struct SMTPTests {
         #expect(email.recipients.count == 1, "Should have 1 recipient")
         #expect(email.recipients[0].address == "recipient@example.com", "Recipient address should match")
     }
-} 
+
+    @Test
+    func testRequiresSTARTTLSUpgradePolicy() {
+        #expect(
+            SMTPServer.requiresSTARTTLSUpgrade(
+                port: 587,
+                useSSL: false,
+                capabilities: ["SIZE", "STARTTLS", "AUTH PLAIN"]
+            )
+        )
+
+        #expect(
+            !SMTPServer.requiresSTARTTLSUpgrade(
+                port: 587,
+                useSSL: false,
+                capabilities: ["SIZE", "AUTH PLAIN"]
+            )
+        )
+
+        #expect(
+            !SMTPServer.requiresSTARTTLSUpgrade(
+                port: 465,
+                useSSL: true,
+                capabilities: ["STARTTLS"]
+            )
+        )
+    }
+
+    @Test
+    func testSTARTTLSFailureIsFatalForPort587RegardlessOfHost() {
+        #expect(SMTPServer.shouldFailClosedOnSTARTTLSFailure(port: 587, host: "smtp.gmail.com"))
+        #expect(SMTPServer.shouldFailClosedOnSTARTTLSFailure(port: 587, host: "smtp.example.com"))
+
+        #expect(!SMTPServer.shouldFailClosedOnSTARTTLSFailure(port: 465, host: "smtp.gmail.com"))
+        #expect(!SMTPServer.shouldFailClosedOnSTARTTLSFailure(port: 25, host: "smtp.example.com"))
+    }
+}


### PR DESCRIPTION
## Summary
- require STARTTLS upgrade on SMTP submission connections when server advertises STARTTLS (port 587, non-implicit TLS)
- fail closed if the STARTTLS handshake fails instead of continuing in cleartext
- add SMTP tests that verify policy and failure behavior

## Why
On port 587, continuing after an advertised STARTTLS failure can silently downgrade transport security. This change enforces a safer default for submission traffic.

## Validation
- swift test --filter SMTPTests