### PR TITLE
Added fetching of internal date for email time

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Commands/FetchCommands.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/FetchCommands.swift
@@ -36,6 +36,7 @@ struct FetchMessageInfoCommand<T: MessageIdentifier>: IMAPTaggedCommand {
         let attributes: [FetchAttribute] = [
             .uid,
             .envelope,
+            .internalDate,
             .bodyStructure(extensions: true),
             .bodySection(peek: true, .header, nil),
             .flags
@@ -65,7 +66,7 @@ struct FetchMessageInfoCommand<T: MessageIdentifier>: IMAPTaggedCommand {
 	let section: Section
     
     /// Custom timeout for this operation
-	var timeoutSeconds: Int { return 10 }
+	var timeoutSeconds: Int { return 60 }
     
     /// Initialize a new fetch message part command
     /// - Parameters:

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/FetchMessageInfoHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/FetchMessageInfoHandler.swift
@@ -172,7 +172,21 @@ final class FetchMessageInfoHandler: BaseIMAPCommandHandler<[MessageInfo]>, IMAP
             
         case .uid(let uid):
 				header.uid = UID(nio: uid)
-            
+
+        case .internalDate(let serverDate):
+            let c = serverDate.components
+            var dc = DateComponents()
+            dc.year = c.year
+            dc.month = c.month
+            dc.day = c.day
+            dc.hour = c.hour
+            dc.minute = c.minute
+            dc.second = c.second
+            dc.timeZone = Foundation.TimeZone(secondsFromGMT: c.zoneMinutes * 60)
+            if let date = Calendar(identifier: .gregorian).date(from: dc) {
+                header.internalDate = date
+            }
+
         case .flags(let flags):
             header.flags = flags.map(self.convertFlag)
             

--- a/Sources/SwiftMail/IMAP/Models/MessageInfo.swift
+++ b/Sources/SwiftMail/IMAP/Models/MessageInfo.swift
@@ -26,9 +26,12 @@ public struct MessageInfo: Codable, Sendable {
     /// The BCC recipients of the message
     public var bcc: [String] = []
     
-    /// The date of the message
+    /// The date of the message (from the ENVELOPE Date: header — set by the sender)
     public var date: Date?
-    
+
+    /// The server-side delivery date (IMAP INTERNALDATE — when the server received the message)
+    public var internalDate: Date?
+
     /// The message ID
     public var messageId: String?
     
@@ -50,6 +53,7 @@ public struct MessageInfo: Codable, Sendable {
         case cc
         case bcc
         case date
+        case internalDate
         case messageId
         case flags
         case parts
@@ -64,7 +68,8 @@ public struct MessageInfo: Codable, Sendable {
     ///   - from: The sender of the message
     ///   - to: The recipients of the message
     ///   - cc: The CC recipients of the message
-    ///   - date: The date of the message
+    ///   - date: The date of the message (envelope Date: header)
+    ///   - internalDate: The server-side delivery date (IMAP INTERNALDATE)
     ///   - messageId: The message ID
     ///   - flags: The flags of the message
     ///   - parts: The message parts
@@ -78,6 +83,7 @@ public struct MessageInfo: Codable, Sendable {
         cc: [String] = [],
         bcc: [String] = [],
         date: Date? = nil,
+        internalDate: Date? = nil,
         messageId: String? = nil,
         flags: [Flag] = [],
         parts: [MessagePart] = [],
@@ -91,6 +97,7 @@ public struct MessageInfo: Codable, Sendable {
         self.cc = cc
         self.bcc = bcc
         self.date = date
+        self.internalDate = internalDate
         self.messageId = messageId
         self.flags = flags
         self.parts = parts
@@ -110,6 +117,7 @@ public extension MessageInfo {
         let cc = try container.decodeIfPresent([String].self, forKey: .cc) ?? []
         let bcc = try container.decodeIfPresent([String].self, forKey: .bcc) ?? []
         let date = try container.decodeIfPresent(Date.self, forKey: .date)
+        let internalDate = try container.decodeIfPresent(Date.self, forKey: .internalDate)
         let messageId = try container.decodeIfPresent(String.self, forKey: .messageId)
         let flags = try container.decodeIfPresent([Flag].self, forKey: .flags) ?? []
         let parts = try container.decodeIfPresent([MessagePart].self, forKey: .parts) ?? []
@@ -124,6 +132,7 @@ public extension MessageInfo {
             cc: cc,
             bcc: bcc,
             date: date,
+            internalDate: internalDate,
             messageId: messageId,
             flags: flags,
             parts: parts,


### PR DESCRIPTION
Hi,

I noticed that the email time fetched right now is the sender claimed time. This patch would allow also getting the server received time, which is useful for email clients.

Thanks,
Kwang