### PR TITLE
Fix quoted-printable decoding crash on truncated input

### DIFF
--- a/Sources/SwiftMail/Extensions/String+QuotedPrintable.swift
+++ b/Sources/SwiftMail/Extensions/String+QuotedPrintable.swift
@@ -56,8 +56,11 @@ extension String {
 
             if char == "=" {
                 let nextIndex = withoutSoftBreaks.index(after: index)
-                guard nextIndex < withoutSoftBreaks.endIndex,
-                      let nextNextIndex = withoutSoftBreaks.index(nextIndex, offsetBy: 1, limitedBy: withoutSoftBreaks.endIndex) else {
+                guard nextIndex < withoutSoftBreaks.endIndex else {
+                    return nil
+                }
+                let nextNextIndex = withoutSoftBreaks.index(after: nextIndex)
+                guard nextNextIndex < withoutSoftBreaks.endIndex else {
                     return nil
                 }
                 let hex = String(withoutSoftBreaks[nextIndex...nextNextIndex])

--- a/Sources/SwiftMail/IMAP/Models/MessagePart.swift
+++ b/Sources/SwiftMail/IMAP/Models/MessagePart.swift
@@ -96,7 +96,7 @@ public struct MessagePart: Sendable {
 			
 			// If the part encoding is quoted-printable, decode the base64 result
 			if encoding?.lowercased() == "quoted-printable" {
-				return base64Text.decodeQuotedPrintable()
+				return base64Text.decodeQuotedPrintable() ?? base64Text.decodeQuotedPrintableLossy()
 			} else {
 				return base64Text
 			}
@@ -104,11 +104,10 @@ public struct MessagePart: Sendable {
 		
 		// Try direct UTF-8 decoding
 		if let text = String(data: partData, encoding: .utf8) {
-			let decodedText = encoding?.lowercased() == "quoted-printable" ?
-				text.decodeQuotedPrintable() :
-				text
-
-			return decodedText
+			if encoding?.lowercased() == "quoted-printable" {
+				return text.decodeQuotedPrintable() ?? text.decodeQuotedPrintableLossy()
+			}
+			return text
 		}
 		
 		return nil

--- a/Tests/SwiftIMAPTests/QuotedPrintableTests.swift
+++ b/Tests/SwiftIMAPTests/QuotedPrintableTests.swift
@@ -180,19 +180,34 @@ struct QuotedPrintableTests {
     func edgeCasesAndMalformedInput() {
         // Test empty string
         #expect("".decodeQuotedPrintable() == "")
-        
+
         // Test string without encoding
         #expect("Plain text".decodeQuotedPrintable() == "Plain text")
-        
+
         // Test malformed encoding (incomplete hex) - should return nil for invalid input
         let malformed = "Hello=2World"  // Missing second hex digit
         let result = malformed.decodeQuotedPrintable()
         #expect(result == nil, "Should return nil for malformed input")
-        
+
         // Test with invalid hex characters - should return nil for invalid input
         let invalidHex = "Hello=ZZ"
         let invalidResult = invalidHex.decodeQuotedPrintable()
         #expect(invalidResult == nil, "Should return nil for invalid hex")
+
+        // Test = followed by only one character (previously crashed with String index out of bounds)
+        let equalsOneChar = "Hello=X"
+        #expect(equalsOneChar.decodeQuotedPrintable() == nil, "Should return nil for = with only one trailing char")
+        #expect(equalsOneChar.decodeQuotedPrintableLossy() == "Hello=X", "Lossy should preserve = with one trailing char")
+
+        // Test = as the very last character
+        let trailingEquals = "Hello="
+        #expect(trailingEquals.decodeQuotedPrintable() == nil, "Should return nil for trailing =")
+        #expect(trailingEquals.decodeQuotedPrintableLossy() == "Hello=", "Lossy should preserve trailing =")
+
+        // Test = at second-to-last position with valid first hex digit
+        let equalsOneHex = "Hello=A"
+        #expect(equalsOneHex.decodeQuotedPrintable() == nil, "Should return nil for = with only one hex digit")
+        #expect(equalsOneHex.decodeQuotedPrintableLossy() == "Hello=A", "Lossy should preserve incomplete hex")
     }
 
     @Test("Lossy decoding handles invalid sequences", .tags(.decoding))


### PR DESCRIPTION
## Summary

- **Fix crash** in `decodeQuotedPrintable(encoding:)` when `=` appears near the end of the input string (e.g. `"Hello=X"`, `"Hello="`, `"Hello=A"`)
- **Add lossy fallbacks** in `MessagePart.textContent` so malformed quoted-printable bodies degrade gracefully instead of returning `nil`

## Root Cause

`index(_:offsetBy:limitedBy:)` returns `endIndex` (not `nil`) when the offset lands exactly on the limit. Using that result in a closed range subscript (`nextIndex...endIndex`) reads past the buffer, causing a `String index out of range` crash.

## Fix

Replace `index(_:offsetBy:limitedBy:)` with simple `index(after:)` + `< endIndex` guards that are correct by construction. This matches the pattern already used in `decodeQuotedPrintableLossy`.

## Test plan

- [x] Added 3 edge case tests covering the crash scenarios (`"Hello=X"`, `"Hello="`, `"Hello=A"`)
- [x] Tests verify both strict (returns `nil`) and lossy (preserves text) behavior
- [x] All existing tests continue to pass