### PR TITLE
Fix reentrant lock crashes in IMAP handler paths

### DIFF
--- a/Sources/SwiftMail/Core/Logging/MailLogger.swift
+++ b/Sources/SwiftMail/Core/Logging/MailLogger.swift
@@ -4,7 +4,6 @@
 import Foundation
 import Logging
 import NIO
-import NIOConcurrencyHelpers
 import NIOIMAP
 
 /// Base class for mail protocol loggers
@@ -20,7 +19,7 @@ class MailLogger: ChannelDuplexHandler, @unchecked Sendable {
     // Common properties - using protected-like access
 	let outboundLogger: Logging.Logger
 	let inboundLogger: Logging.Logger
-	let lock = NIOLock()
+	let lock = NSRecursiveLock()
     
     // Make inboundBuffer accessible for modification by subclasses
 	var inboundBuffer: [String] = []
@@ -95,4 +94,12 @@ class MailLogger: ChannelDuplexHandler, @unchecked Sendable {
 	func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         fatalError("channelRead(context:data:) must be implemented by subclasses")
     }
-} 
+}
+
+private extension NSRecursiveLock {
+    func withLock<T>(_ body: () throws -> T) rethrows -> T {
+        lock()
+        defer { unlock() }
+        return try body()
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/FetchMessageInfoHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/FetchMessageInfoHandler.swift
@@ -19,7 +19,8 @@ final class FetchMessageInfoHandler: BaseIMAPCommandHandler<[MessageInfo]>, IMAP
         super.handleTaggedOKResponse(response)
         
         // Succeed with the collected headers
-        succeedWithResult(lock.withLock { self.messageInfos })
+        let collectedInfos = lock.withLock { self.messageInfos }
+        succeedWithResult(collectedInfos)
     }
     
     /// Handle a tagged error response

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/FetchPartHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/FetchPartHandler.swift
@@ -30,7 +30,8 @@ final class FetchPartHandler: BaseIMAPCommandHandler<Data>, IMAPCommandHandler, 
 		super.handleTaggedOKResponse(response)
 		
 		// Succeed with the collected data
-		succeedWithResult(lock.withLock { self.partData })
+		let collectedPartData = lock.withLock { self.partData }
+		succeedWithResult(collectedPartData)
 	}
     
     /// Handle a tagged error response


### PR DESCRIPTION
## Summary\n- avoid re-entrant lock usage in fetch handlers\n- harden command/logging lock paths against callback re-entry\n\n## Validation\n- swift build\n- swift test -q\n\n## Context\nAddresses NIOLock precondition crashes observed under real IMAP callback interleavings.