### PR TITLE
IMAP XOAUTH2 interoperability hardening for Microsoft 365

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Handler/CommandHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/CommandHandler.swift
@@ -71,12 +71,28 @@ class BaseIMAPCommandHandler<ResultType: Sendable>: CommandHandler, RemovableCha
     /// Succeed the promise with a result
     /// - Parameter result: The result to succeed with
     func succeedWithResult(_ result: ResultType) {
+        let shouldSucceed = lock.withLock { () -> Bool in
+            if isCompleted {
+                return false
+            }
+            isCompleted = true
+            return true
+        }
+        guard shouldSucceed else { return }
         promise.succeed(result)
     }
     
     /// Fail the promise with an error
     /// - Parameter error: The error to fail with
     func failWithError(_ error: Error) {
+        let shouldFail = lock.withLock { () -> Bool in
+            if isCompleted {
+                return false
+            }
+            isCompleted = true
+            return true
+        }
+        guard shouldFail else { return }
         promise.fail(error)
     }
     
@@ -182,7 +198,17 @@ class BaseIMAPCommandHandler<ResultType: Sendable>: CommandHandler, RemovableCha
         // Always forward the response to the next handler
         context.fireChannelRead(data)
     }
-    
+    /// Channel inactive method from ChannelInboundHandler
+    func channelInactive(context: ChannelHandlerContext) {
+        let shouldFail = lock.withLock { !isCompleted }
+        if shouldFail {
+            failWithError(IMAPError.connectionFailed("Connection closed before command completed"))
+            handleCompletion(context: context)
+        }
+
+        context.fireChannelInactive()
+    }
+
     /// Error caught method from ChannelInboundHandler
     func errorCaught(context: ChannelHandlerContext, error: Error) {
         // Handle the error

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -668,7 +668,7 @@ final class IMAPConnection {
         let timeoutSeconds = command.timeoutSeconds
 
         let logger = self.logger
-        let scheduledTask = group.next().scheduleTask(in: .seconds(Int64(timeoutSeconds))) {
+        let scheduledTask = channel.eventLoop.scheduleTask(in: .seconds(Int64(timeoutSeconds))) {
             logger.warning("Command timed out after \(timeoutSeconds) seconds")
             resultPromise.fail(IMAPError.timeout)
         }
@@ -722,7 +722,7 @@ final class IMAPConnection {
         let handler = HandlerType.init(commandTag: "", promise: resultPromise)
 
         let logger = self.logger
-        let scheduledTask = group.next().scheduleTask(in: .seconds(Int64(timeoutSeconds))) {
+        let scheduledTask = channel.eventLoop.scheduleTask(in: .seconds(Int64(timeoutSeconds))) {
             logger.warning("Handler execution timed out after \(timeoutSeconds) seconds")
             resultPromise.fail(IMAPError.timeout)
         }

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -457,7 +457,6 @@ final class IMAPConnection {
             await handleConnectionTerminationInResponses(handler.untaggedResponses)
             duplexLogger.flushInboundBuffer()
 
-<<<<<<< HEAD
             isSessionAuthenticated = true
             if !refreshedCapabilities.isEmpty {
                 self.capabilities = Set(refreshedCapabilities)

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -425,7 +425,8 @@ final class IMAPConnection {
 
         let authenticationTimeoutSeconds = 10
         let logger = self.logger
-        let scheduledTask = group.next().scheduleTask(in: .seconds(Int64(authenticationTimeoutSeconds))) {
+        // Schedule on the channel event loop to avoid cross-loop promise completion.
+        let scheduledTask = channel.eventLoop.scheduleTask(in: .seconds(Int64(authenticationTimeoutSeconds))) {
             logger.warning("XOAUTH2 authentication timed out after \(authenticationTimeoutSeconds) seconds")
             handlerPromise.fail(IMAPError.timeout)
         }

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -430,9 +430,9 @@ final class IMAPConnection {
         if shouldUseInlineInitialResponse {
             initialResponse = InitialResponse(credentialBuffer)
         } else if supportsSASLIR {
-            // Some servers behave better when SASL-IR is explicitly present but empty ("="),
-            // then credentials are sent on the continuation challenge.
-            initialResponse = .empty
+            // Use true continuation mode for oversized payloads.
+            // Sending an explicit empty SASL-IR ("=") can be interpreted as an empty credential attempt.
+            initialResponse = nil
         } else {
             initialResponse = nil
         }

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -457,8 +457,16 @@ final class IMAPConnection {
             await handleConnectionTerminationInResponses(handler.untaggedResponses)
             duplexLogger.flushInboundBuffer()
 
+<<<<<<< HEAD
             isSessionAuthenticated = true
-            try await refreshCapabilities(using: refreshedCapabilities)
+            if !refreshedCapabilities.isEmpty {
+                self.capabilities = Set(refreshedCapabilities)
+            } else {
+                // AUTHENTICATE often returns an OK without CAPABILITY data.
+                // Avoid issuing a follow-up CAPABILITY command here because we're already
+                // inside commandQueue.run, and a nested executeCommand would deadlock.
+                logger.debug("XOAUTH2 completed without capability data; retaining existing capability snapshot")
+            }
         } catch {
             scheduledTask.cancel()
             responseBuffer.hasActiveHandler = false


### PR DESCRIPTION
## Summary\n- harden XOAUTH2 continuation fallback and command timeout behavior\n- bound inline SASL-IR payload sizing and fall back to continuation mode\n- avoid re-entrant capability refresh after XOAUTH2 completes inside command queue\n- fail command promises on channel close to prevent hangs\n\n## Validation\n- swift build\n- swift test -q\n\n## Notes\nExtracted from production fixes in LightMail against Microsoft 365 IMAP XOAUTH2 flows.