### PR TITLE
Add visionOS support to platform conditionals

### DIFF
--- a/Sources/SwiftMail/Extensions/String+Charset.swift
+++ b/Sources/SwiftMail/Extensions/String+Charset.swift
@@ -1,5 +1,5 @@
 import Foundation
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
 import CoreFoundation
 #endif
 
@@ -125,7 +125,7 @@ public func stringEncoding(for rawCharset: String) -> String.Encoding? {
 
     // 5) Try CoreFoundation's IANA name -> CFStringEncoding -> NSStringEncoding
     // This covers the majority of charsets, including windows-125x, iso-2022-jp, euc-kr, gbk, gb18030, big5, koi8-r, etc.
-    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+    #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
     let cfEnc = CFStringConvertIANACharSetNameToEncoding(label as CFString)
     if cfEnc != kCFStringEncodingInvalidId {
         let nsEnc = CFStringConvertEncodingToNSStringEncoding(cfEnc)

--- a/Sources/SwiftMail/Extensions/String+QuotedPrintable.swift
+++ b/Sources/SwiftMail/Extensions/String+QuotedPrintable.swift
@@ -1,5 +1,5 @@
 import Foundation
-#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+#if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
 import CoreFoundation
 #endif
 

--- a/Sources/SwiftMail/IMAP/Extensions/Int+Utilities.swift
+++ b/Sources/SwiftMail/IMAP/Extensions/Int+Utilities.swift
@@ -9,7 +9,7 @@ extension Int {
     /// - Parameter locale: The locale to use for formatting (defaults to current)
     /// - Returns: A human-readable string representation of the file size
 	public func formattedFileSize(locale: Locale = .current) -> String {
-        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS)
+        #if os(macOS) || os(iOS) || os(tvOS) || os(watchOS) || os(visionOS)
         // Use MeasurementFormatter on Apple platforms
         let byteCount = Measurement(value: Double(self), unit: UnitInformationStorage.bytes)
         let formatter = MeasurementFormatter()


### PR DESCRIPTION
- Add visionOS to platform checks in Int+Utilities.swift
- Add visionOS to platform checks in String+QuotedPrintable.swift
- Add visionOS to platform checks in String+Charset.swift

This enables SwiftMail to compile and run on visionOS by including it in the existing Apple platform conditional compilation blocks.