### PR TITLE
Added Email parsing

### DIFF
--- a/Sources/SwiftMail/Extensions/EmailAddress+StringConversion.swift
+++ b/Sources/SwiftMail/Extensions/EmailAddress+StringConversion.swift
@@ -19,7 +19,7 @@ extension EmailAddress: LosslessStringConvertible {
         
         // Email address with a name
         // Format: "Name <email@example.com>" or "\"Name with, special chars\" <email@example.com>"
-        let namePattern = "(?:\"([^\"]+)\"|([^<]+))\\s*<([^>]+)>"
+        let namePattern = "(?:\"([^\"]+)\"|([^<]*))\\s*<([^>]+)>"
         let nameRegex = try? NSRegularExpression(pattern: namePattern, options: [])
         
         if let match = nameRegex?.firstMatch(in: description, options: [], range: NSRange(location: 0, length: description.count)) {

--- a/Tests/SwiftMailCoreTests/EmailAddressTests.swift
+++ b/Tests/SwiftMailCoreTests/EmailAddressTests.swift
@@ -20,4 +20,11 @@ struct EmailAddressTests {
         let email = EmailAddress(name: "John Doe, Jr.", address: "john@example.com")
         #expect(email.description == "\"John Doe, Jr.\" <john@example.com>")
     }
-} 
+    
+    @Test("Email address parsing without name")
+    func testParsingWithoutName() throws {
+        let email = EmailAddress("<test@example.com>")
+        let validEmail = try #require(email)
+        #expect(validEmail.description == "test@example.com")
+    }
+}


### PR DESCRIPTION
Added email address conversion from addresses in the form "<test@xample.com>". Currently mail addresses without name but enclosed in angle brackets fail conversion, although they are valid email addresses.