### PR TITLE
Add optional calendar parameter to search date conversions

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Commands/SearchCommand.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/SearchCommand.swift
@@ -20,7 +20,9 @@ struct SearchCommand<T: MessageIdentifier>: IMAPTaggedCommand, Sendable {
     let identifierSet: MessageIdentifierSet<T>?
     /// Criteria that all messages must satisfy.
     let criteria: [SearchCriteria]
-    
+    /// Calendar used for date-to-day conversions in search criteria.
+    let calendar: Calendar
+
     /// Timeout in seconds for the search operation.
     var timeoutSeconds: Int { return 60 }
 
@@ -29,10 +31,12 @@ struct SearchCommand<T: MessageIdentifier>: IMAPTaggedCommand, Sendable {
      - Parameters:
        - identifierSet: Optional set limiting the messages to search.
        - criteria: The search criteria to apply.
+       - calendar: The calendar used for date-to-day conversions. Defaults to the Gregorian calendar.
      */
-    init(identifierSet: MessageIdentifierSet<T>? = nil, criteria: [SearchCriteria]) {
+    init(identifierSet: MessageIdentifierSet<T>? = nil, criteria: [SearchCriteria], calendar: Calendar = Calendar(identifier: .gregorian)) {
         self.identifierSet = identifierSet
         self.criteria = criteria
+        self.calendar = calendar
     }
 
     /// Validate that the command has at least one criterion.
@@ -48,7 +52,7 @@ struct SearchCommand<T: MessageIdentifier>: IMAPTaggedCommand, Sendable {
      - Returns: A ``TaggedCommand`` ready for sending.
      */
     func toTaggedCommand(tag: String) -> TaggedCommand {
-        let nioCriteria = criteria.map { $0.toNIO() }
+        let nioCriteria = criteria.map { $0.toNIO(calendar: calendar) }
 
         if T.self == UID.self {
             // For UID search, we need to use the key parameter

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -868,8 +868,8 @@ public actor IMAPServer {
      - `IMAPError.connectionFailed` if not connected
      - Note: Logs search operations at debug level with criteria count and results count
      */
-    public func search<T: MessageIdentifier>(identifierSet: MessageIdentifierSet<T>? = nil, criteria: [SearchCriteria]) async throws -> MessageIdentifierSet<T> {
-        let command = SearchCommand(identifierSet: identifierSet, criteria: criteria)
+    public func search<T: MessageIdentifier>(identifierSet: MessageIdentifierSet<T>? = nil, criteria: [SearchCriteria], calendar: Calendar = Calendar(identifier: .gregorian)) async throws -> MessageIdentifierSet<T> {
+        let command = SearchCommand(identifierSet: identifierSet, criteria: criteria, calendar: calendar)
         return try await executeCommand(command)
     }
     


### PR DESCRIPTION
## Summary

- Adds an optional `calendar` parameter to `SearchCriteria.toNIO()`, `SearchCommand`, and `IMAPServer.search()`, defaulting to `Calendar(identifier: .gregorian)` (current device timezone — fully backwards-compatible)
- Allows callers to pass a UTC-configured calendar for deterministic IMAP date-only conversions, preventing off-by-one day issues caused by timezone differences

## Motivation

IMAP RFC 3501 `SINCE`/`BEFORE` commands use date-only values (no time component). When converting a Swift `Date` to `IMAPCalendarDay`, the calendar's timezone determines which calendar day is extracted. For example, `2025-01-15T01:00:00Z` resolves to January 14 in UTC-8 but January 15 in UTC — producing different IMAP search boundaries for the same instant.

This change lets callers opt into UTC-based date extraction when they need consistent behavior across timezones, without changing the default for existing users.

## Changes

- `SearchCriteria.toNIO(calendar:)` — accepts and propagates calendar through all date cases and recursive criteria (`.and`, `.not`, `.or`)
- `SearchCommand` — stores and forwards the calendar to `toNIO()`
- `IMAPServer.search(criteria:calendar:)` — threads the calendar through to `SearchCommand`

All parameters default to `Calendar(identifier: .gregorian)`, so **no existing call sites need to change**.

## Test plan

- [x] Verified `swift build` succeeds with no warnings
- [ ] Existing search tests pass unchanged (default calendar preserves current behavior)
- [ ] Callers can pass a UTC calendar: `server.search(criteria: [...], calendar: utcCalendar)`

🤖 Generated with [Claude Code](https://claude.com/claude-code)