### PR TITLE
Fix crash in decodeQuotedPrintable on truncated input

### DIFF
--- a/Sources/SwiftMail/Extensions/String+QuotedPrintable.swift
+++ b/Sources/SwiftMail/Extensions/String+QuotedPrintable.swift
@@ -56,8 +56,11 @@ extension String {
 
             if char == "=" {
                 let nextIndex = withoutSoftBreaks.index(after: index)
-                guard nextIndex < withoutSoftBreaks.endIndex,
-                      let nextNextIndex = withoutSoftBreaks.index(nextIndex, offsetBy: 1, limitedBy: withoutSoftBreaks.endIndex) else {
+                guard nextIndex < withoutSoftBreaks.endIndex else {
+                    return nil
+                }
+                let nextNextIndex = withoutSoftBreaks.index(after: nextIndex)
+                guard nextNextIndex < withoutSoftBreaks.endIndex else {
                     return nil
                 }
                 let hex = String(withoutSoftBreaks[nextIndex...nextNextIndex])

--- a/Sources/SwiftMail/IMAP/Models/MessagePart.swift
+++ b/Sources/SwiftMail/IMAP/Models/MessagePart.swift
@@ -96,7 +96,7 @@ public struct MessagePart: Sendable {
 			
 			// If the part encoding is quoted-printable, decode the base64 result
 			if encoding?.lowercased() == "quoted-printable" {
-				return base64Text.decodeQuotedPrintable()
+				return base64Text.decodeQuotedPrintable() ?? base64Text.decodeQuotedPrintableLossy()
 			} else {
 				return base64Text
 			}
@@ -104,11 +104,10 @@ public struct MessagePart: Sendable {
 		
 		// Try direct UTF-8 decoding
 		if let text = String(data: partData, encoding: .utf8) {
-			let decodedText = encoding?.lowercased() == "quoted-printable" ?
-				text.decodeQuotedPrintable() :
-				text
-
-			return decodedText
+			if encoding?.lowercased() == "quoted-printable" {
+				return text.decodeQuotedPrintable() ?? text.decodeQuotedPrintableLossy()
+			}
+			return text
 		}
 		
 		return nil

--- a/Tests/SwiftIMAPTests/QuotedPrintableTests.swift
+++ b/Tests/SwiftIMAPTests/QuotedPrintableTests.swift
@@ -180,19 +180,34 @@ struct QuotedPrintableTests {
     func edgeCasesAndMalformedInput() {
         // Test empty string
         #expect("".decodeQuotedPrintable() == "")
-        
+
         // Test string without encoding
         #expect("Plain text".decodeQuotedPrintable() == "Plain text")
-        
+
         // Test malformed encoding (incomplete hex) - should return nil for invalid input
         let malformed = "Hello=2World"  // Missing second hex digit
         let result = malformed.decodeQuotedPrintable()
         #expect(result == nil, "Should return nil for malformed input")
-        
+
         // Test with invalid hex characters - should return nil for invalid input
         let invalidHex = "Hello=ZZ"
         let invalidResult = invalidHex.decodeQuotedPrintable()
         #expect(invalidResult == nil, "Should return nil for invalid hex")
+
+        // Test = followed by only one character (previously crashed with String index out of bounds)
+        let equalsOneChar = "Hello=X"
+        #expect(equalsOneChar.decodeQuotedPrintable() == nil, "Should return nil for = with only one trailing char")
+        #expect(equalsOneChar.decodeQuotedPrintableLossy() == "Hello=X", "Lossy should preserve = with one trailing char")
+
+        // Test = as the very last character
+        let trailingEquals = "Hello="
+        #expect(trailingEquals.decodeQuotedPrintable() == nil, "Should return nil for trailing =")
+        #expect(trailingEquals.decodeQuotedPrintableLossy() == "Hello=", "Lossy should preserve trailing =")
+
+        // Test = at second-to-last position with valid first hex digit
+        let equalsOneHex = "Hello=A"
+        #expect(equalsOneHex.decodeQuotedPrintable() == nil, "Should return nil for = with only one hex digit")
+        #expect(equalsOneHex.decodeQuotedPrintableLossy() == "Hello=A", "Lossy should preserve incomplete hex")
     }
 
     @Test("Lossy decoding handles invalid sequences", .tags(.decoding))


### PR DESCRIPTION
## Summary

- Fixes a crash in `decodeQuotedPrintable()` when `=` appears near the end of input (e.g. `"Hello=X"`, `"Hello="`)
- Wires up `decodeQuotedPrintableLossy()` as a fallback in `MessagePart.textContent` for graceful degradation

## Root Cause

`index(_:offsetBy:limitedBy:)` returns `endIndex` (not `nil`) when the offset lands exactly on the limit. Using that index in a closed range subscript (`nextIndex...endIndex`) reads past the buffer, causing a `String index out of range` crash.

The `decodeQuotedPrintableLossy()` method added in #76f10df correctly handles these cases, but the strict `decodeQuotedPrintable()` still crashes on truncated input.

## Fix

Replace `index(_:offsetBy:limitedBy:)` with two sequential `index(after:)` + `< endIndex` guards that are correct by construction.

Also add lossy fallback in `MessagePart.textContent` (both the base64-decoded and direct UTF-8 paths) so malformed QP bodies return degraded content instead of `nil`.

## Test plan

- [x] `swift build` succeeds
- [x] All 70 tests pass (`swift test`)
- [x] New test cases cover: `"Hello=X"`, `"Hello="`, `"Hello=A"` — all previously crashed

🤖 Generated with [Claude Code](https://claude.com/claude-code)