### PR TITLE
Decode RFC2047 filename when available

### DIFF
--- a/Sources/SwiftMail/MIME/EMLParser.swift
+++ b/Sources/SwiftMail/MIME/EMLParser.swift
@@ -316,7 +316,7 @@ public struct EMLParser {
                     contentType: cleanContentType(partContentType),
                     disposition: extractDispositionType(from: partDisposition),
                     encoding: partEncoding?.trimmingCharacters(in: .whitespaces),
-                    filename: filename,
+                    filename: (filename != nil ? decodeRFC2047(filename!) : nil),
                     contentId: partContentId,
                     data: partBody
                 )


### PR DESCRIPTION
In rare cases the filename of an attachment can be RFC2047 encoded. This should take care of it.