### PR TITLE
fix: respect IMAP APPENDLIMIT capability for preflight APPEND size checks

### DIFF
--- a/Sources/SwiftMail/IMAP/Capability+AppendLimit.swift
+++ b/Sources/SwiftMail/IMAP/Capability+AppendLimit.swift
@@ -1,0 +1,18 @@
+import NIOIMAPCore
+
+extension Set where Element == NIOIMAPCore.Capability {
+    /// Returns the global server-wide APPENDLIMIT in bytes, if advertised.
+    ///
+    /// Per RFC 7889, a server may advertise `APPENDLIMIT=<n>` (with a numeric value) in its
+    /// CAPABILITY response to declare the maximum accepted APPEND payload size. A bare
+    /// `APPENDLIMIT` (without a value) indicates per-mailbox limits only and does **not**
+    /// impose a global ceiling — this property returns `nil` in that case.
+    var globalAppendLimit: Int? {
+        for cap in self where cap.name == "APPENDLIMIT" {
+            if let value = cap.value, let limit = Int(value) {
+                return limit
+            }
+        }
+        return nil
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAPError.swift
+++ b/Sources/SwiftMail/IMAP/IMAPError.swift
@@ -23,6 +23,10 @@ public enum IMAPError: Error {
     case commandNotSupported(String)
     case authFailed(String)
     case unsupportedAuthMechanism(String)
+    /// The APPEND payload exceeds the server-advertised APPENDLIMIT.
+    ///
+    /// Associated values: `(payloadSize, limit)` — both in bytes.
+    case appendLimitExceeded(Int, Int)
 }
 
 // Add CustomStringConvertible conformance for better error messages
@@ -65,6 +69,8 @@ extension IMAPError: CustomStringConvertible {
             return "Authentication failed: \(reason)"
         case .unsupportedAuthMechanism(let reason):
             return "Unsupported authentication mechanism: \(reason)"
+        case .appendLimitExceeded(let payloadSize, let limit):
+            return "Append payload (\(payloadSize) bytes) exceeds server APPENDLIMIT (\(limit) bytes)"
         }
     }
 }
@@ -113,6 +119,8 @@ extension IMAPError: LocalizedError {
             return "The IMAP authentication failed: \(reason)"
         case .unsupportedAuthMechanism(let reason):
             return "The server does not support the requested authentication mechanism: \(reason)"
+        case .appendLimitExceeded(let payloadSize, let limit):
+            return "The message (\(payloadSize) bytes) is too large for the server limit of \(limit) bytes"
         }
     }
 

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -1386,6 +1386,12 @@ public actor IMAPServer {
     }
 
     private func append(rawMessage: String, to mailbox: String, flags: [Flag], internalDate: Date?) async throws -> AppendResult {
+        if let limit = capabilities.globalAppendLimit {
+            let payloadSize = rawMessage.utf8.count
+            if payloadSize > limit {
+                throw IMAPError.appendLimitExceeded(payloadSize, limit)
+            }
+        }
         let serverDate = internalDate.flatMap(makeInternalDate(from:))
         let command = AppendCommand(
             mailboxName: mailbox,

--- a/Tests/SwiftIMAPTests/AppendLimitTests.swift
+++ b/Tests/SwiftIMAPTests/AppendLimitTests.swift
@@ -1,0 +1,66 @@
+import Testing
+import NIOIMAPCore
+@testable import SwiftMail
+
+struct AppendLimitTests {
+
+    // MARK: - globalAppendLimit extraction
+
+    @Test("Returns nil when capability set is empty")
+    func globalAppendLimit_emptySet() {
+        let caps: Set<NIOIMAPCore.Capability> = []
+        #expect(caps.globalAppendLimit == nil)
+    }
+
+    @Test("Returns nil when only bare APPENDLIMIT (no value) is present")
+    func globalAppendLimit_bareCapability() {
+        // .mailboxSpecificAppendLimit == "APPENDLIMIT" with no value
+        let caps: Set<NIOIMAPCore.Capability> = [.mailboxSpecificAppendLimit]
+        #expect(caps.globalAppendLimit == nil)
+    }
+
+    @Test("Returns correct limit when APPENDLIMIT=<n> is advertised")
+    func globalAppendLimit_withValue() {
+        let caps: Set<NIOIMAPCore.Capability> = [.appendLimit(10_485_760)]
+        #expect(caps.globalAppendLimit == 10_485_760)
+    }
+
+    @Test("Returns limit ignoring other capabilities in the set")
+    func globalAppendLimit_mixedCapabilities() {
+        let caps: Set<NIOIMAPCore.Capability> = [
+            .uidPlus,
+            .idle,
+            .appendLimit(5_000_000),
+            .move,
+        ]
+        #expect(caps.globalAppendLimit == 5_000_000)
+    }
+
+    @Test("Returns nil when APPENDLIMIT is absent but other capabilities exist")
+    func globalAppendLimit_absent() {
+        let caps: Set<NIOIMAPCore.Capability> = [.uidPlus, .idle, .move]
+        #expect(caps.globalAppendLimit == nil)
+    }
+
+    // MARK: - IMAPError.appendLimitExceeded descriptions
+
+    @Test("Error description includes payload and limit sizes")
+    func appendLimitExceeded_description() {
+        let error = IMAPError.appendLimitExceeded(6_000_000, 5_000_000)
+        let desc = error.description
+        #expect(desc.contains("6000000"))
+        #expect(desc.contains("5000000"))
+    }
+
+    @Test("errorDescription is non-nil and matches description")
+    func appendLimitExceeded_errorDescription() {
+        let error = IMAPError.appendLimitExceeded(1024, 512)
+        #expect(error.errorDescription == error.description)
+    }
+
+    @Test("failureReason is non-nil for appendLimitExceeded")
+    func appendLimitExceeded_failureReason() {
+        let error = IMAPError.appendLimitExceeded(2048, 1024)
+        #expect(error.failureReason != nil)
+    }
+}


### PR DESCRIPTION
Closes #98

## Changes

- **`Capability+AppendLimit.swift`** — Extension on `Set<Capability>` adding `globalAppendLimit: Int?`. Parses `APPENDLIMIT=<n>` from server capabilities per RFC 7889. Returns `nil` for bare `APPENDLIMIT` (per-mailbox only).

- **`IMAPError.swift`** — New `.appendLimitExceeded(payloadSize, limit)` error case with `description` and `LocalizedError` conformance.

- **`IMAPServer.swift`** — Preflight check in `append(rawMessage:to:flags:internalDate:)`: compares `rawMessage.utf8.count` against the global append limit before sending APPEND. Throws early if exceeded.

- **`AppendLimitTests.swift`** — 8 tests covering capability parsing (empty, bare, valued, mixed, absent) and error descriptions.

## Behavior

- If server advertises `APPENDLIMIT=<n>`: payload size is checked before APPEND; throws `.appendLimitExceeded` if too large.
- If `APPENDLIMIT` is bare (no value) or absent: existing behavior unchanged.