### PR TITLE
Fix NIO 'leaking promise' crash on inactive channel

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -425,7 +425,7 @@ final class IMAPConnection {
             try await connectBody()
         }
 
-        guard let channel = self.channel else {
+        guard let channel = self.channel, channel.isActive else {
             throw IMAPError.connectionFailed("Channel not initialized")
         }
 
@@ -720,7 +720,7 @@ final class IMAPConnection {
             try await connectBody()
         }
 
-        guard let channel = self.channel else {
+        guard let channel = self.channel, channel.isActive else {
             throw IMAPError.connectionFailed("Channel not initialized")
         }
 
@@ -751,6 +751,11 @@ final class IMAPConnection {
         } catch {
             scheduledTask.cancel()
             responseBuffer.hasActiveHandler = false
+
+            // Ensure the promise is always resolved — prevents NIO "leaking promise" fatal error
+            // when the channel becomes inactive between the guard and pipeline operations.
+            resultPromise.fail(error)
+
             await handleConnectionTerminationInResponses(handler.untaggedResponses)
             duplexLogger.flushInboundBuffer()
             if !handler.isCompleted {
@@ -776,7 +781,7 @@ final class IMAPConnection {
             try await connectBody()
         }
 
-        guard let channel = self.channel else {
+        guard let channel = self.channel, channel.isActive else {
             throw IMAPError.connectionFailed("Channel not initialized")
         }
 
@@ -804,6 +809,11 @@ final class IMAPConnection {
         } catch {
             scheduledTask.cancel()
             responseBuffer.hasActiveHandler = false
+
+            // Ensure the promise is always resolved — prevents NIO "leaking promise" fatal error
+            // when the channel becomes inactive between the guard and pipeline operations.
+            resultPromise.fail(error)
+
             await handleConnectionTerminationInResponses(handler.untaggedResponses)
             duplexLogger.flushInboundBuffer()
             if !handler.isCompleted {


### PR DESCRIPTION
## Summary

Three methods in `IMAPConnection` can crash with NIO's `fatalError("leaking promise")` when a channel becomes inactive between the nil-check and promise creation:

- `executeCommandBody` — used by all IMAP commands (FETCH, STORE, SEARCH, etc.)
- `executeHandlerOnly` — used by greeting handler
- `authenticateXOAUTH2Body` — used by XOAUTH2 authentication

### Root cause

Each method calls `clearInvalidChannel()` then checks `guard let channel = self.channel` — but only verifies the channel is non-nil, not that it's still active. If the server drops an idle connection (common during device sleep, network transitions, or long-running batch operations), the channel object still exists but `isActive` is false. Creating an `EventLoopPromise` on this dead channel means the handler never receives callbacks, the promise is never completed, and NIO's `EventLoopPromise.deinit` fires `fatalError("leaking promise")`.

### Fix

1. **Add `channel.isActive` to the guard** in all three methods, matching the existing pattern already used by `startIdleSession` (line 545). This is the primary prevention — an inactive channel triggers reconnection via the existing `connectBody()` retry path.

2. **Add `resultPromise.fail(error)` safety net** in the catch blocks of `executeCommandBody` and `executeHandlerOnly`, matching the pattern already added to `authenticateXOAUTH2Body` in the recent XOAUTH2 early-failure fix. This handles the narrow race where the channel becomes inactive *after* passing the guard but *before* pipeline operations complete.

### Reproduction

This crash occurs reliably when reusing IMAP connections across batch operations with idle gaps (e.g., fetching message bodies in chunks with processing time between batches). The server drops the idle connection, but the next command attempt finds a non-nil, inactive channel.

### Testing

- All 85 existing tests pass
- Build succeeds with zero warnings