### PR TITLE
Expose IMAP threading headers in fetch metadata

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Handler/FetchMessageInfoHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/FetchMessageInfoHandler.swift
@@ -11,6 +11,9 @@ import NIOConcurrencyHelpers
 final class FetchMessageInfoHandler: BaseIMAPCommandHandler<[MessageInfo]>, IMAPCommandHandler, @unchecked Sendable {
     /// Collected email headers
     private var messageInfos: [MessageInfo] = []
+    private var currentSequenceNumber: SequenceNumber?
+    private var currentHeaderLiteral = Data()
+    private var collectingThreadingHeaders = false
     
     /// Handle a tagged OK response by succeeding the promise with the mailbox info
     /// - Parameter response: The tagged response
@@ -55,24 +58,63 @@ final class FetchMessageInfoHandler: BaseIMAPCommandHandler<[MessageInfo]>, IMAP
                 
             case .start(let sequenceNumber):
                 // Create a new header for this sequence number
+                currentSequenceNumber = SequenceNumber(sequenceNumber.rawValue)
+                currentHeaderLiteral.removeAll(keepingCapacity: true)
+                collectingThreadingHeaders = false
                 let messageInfo = MessageInfo(sequenceNumber: SequenceNumber(sequenceNumber.rawValue))
                 lock.withLock {
                     self.messageInfos.append(messageInfo)
                 }
                 
-            case .streamingBegin(_, _):
-                // We don't create headers for streamingBegin
-                // This avoids misinterpreting the byte count as a sequence number
-                break
+            case .streamingBegin(let kind, _):
+                collectingThreadingHeaders = Self.shouldCollectThreadingHeaders(for: kind)
+                if collectingThreadingHeaders {
+                    currentHeaderLiteral.removeAll(keepingCapacity: true)
+                }
                 
-            case .streamingBytes(_):
-                // Process streaming bytes if needed
-                // For headers, we typically don't need to process the raw header data
-                break
+            case .streamingBytes(let data):
+                guard collectingThreadingHeaders else { break }
+                currentHeaderLiteral.append(contentsOf: data.readableBytesView)
+
+            case .streamingEnd:
+                guard collectingThreadingHeaders else { break }
+                applyCollectedThreadingHeaders()
+                collectingThreadingHeaders = false
+                currentHeaderLiteral.removeAll(keepingCapacity: true)
+
+            case .finish:
+                currentSequenceNumber = nil
+                collectingThreadingHeaders = false
+                currentHeaderLiteral.removeAll(keepingCapacity: true)
                 
             default:
                 break
         }
+    }
+
+    private func applyCollectedThreadingHeaders() {
+        let parsedFields = Self.extractThreadingHeaders(from: currentHeaderLiteral)
+        guard !parsedFields.isEmpty else { return }
+
+        lock.withLock {
+            guard let index = currentMessageIndex() else { return }
+            var header = self.messageInfos[index]
+            var additionalFields = header.additionalFields ?? [:]
+            for (key, value) in parsedFields {
+                additionalFields[key] = value
+            }
+            header.additionalFields = additionalFields.isEmpty ? nil : additionalFields
+            self.messageInfos[index] = header
+        }
+    }
+
+    private func currentMessageIndex() -> Int? {
+        if let currentSequenceNumber,
+           let index = messageInfos.firstIndex(where: { $0.sequenceNumber == currentSequenceNumber }) {
+            return index
+        }
+
+        return messageInfos.indices.last
     }
     
     /// Process a message attribute and update the corresponding email header
@@ -248,4 +290,29 @@ final class FetchMessageInfoHandler: BaseIMAPCommandHandler<[MessageInfo]>, IMAP
                 return "\(groupName): \(members)"
         }
     }
-} 
+
+    static func shouldCollectThreadingHeaders(for kind: StreamingKind) -> Bool {
+        kind.sectionSpecifier.kind == .header
+    }
+
+    static func extractThreadingHeaders(from data: Data) -> [String: String] {
+        guard let headerBlock = String(data: data, encoding: .utf8) ?? String(data: data, encoding: .ascii) else {
+            return [:]
+        }
+
+        let parsedHeaders = EMLParser.parseHeaders(headerBlock)
+        var threadingHeaders: [String: String] = [:]
+
+        if let inReplyTo = parsedHeaders["in-reply-to"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !inReplyTo.isEmpty {
+            threadingHeaders["in-reply-to"] = inReplyTo
+        }
+
+        if let references = parsedHeaders["references"]?.trimmingCharacters(in: .whitespacesAndNewlines),
+           !references.isEmpty {
+            threadingHeaders["references"] = references
+        }
+
+        return threadingHeaders
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/FetchMessageInfoHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/FetchMessageInfoHandler.swift
@@ -93,17 +93,13 @@ final class FetchMessageInfoHandler: BaseIMAPCommandHandler<[MessageInfo]>, IMAP
     }
 
     private func applyCollectedThreadingHeaders() {
-        let parsedFields = Self.extractThreadingHeaders(from: currentHeaderLiteral)
-        guard !parsedFields.isEmpty else { return }
+        let references = Self.extractReferencesHeader(from: currentHeaderLiteral)
+        guard let references else { return }
 
         lock.withLock {
             guard let index = currentMessageIndex() else { return }
             var header = self.messageInfos[index]
-            var additionalFields = header.additionalFields ?? [:]
-            for (key, value) in parsedFields {
-                additionalFields[key] = value
-            }
-            header.additionalFields = additionalFields.isEmpty ? nil : additionalFields
+            header.references = references
             self.messageInfos[index] = header
         }
     }
@@ -295,24 +291,17 @@ final class FetchMessageInfoHandler: BaseIMAPCommandHandler<[MessageInfo]>, IMAP
         kind.sectionSpecifier.kind == .header
     }
 
-    static func extractThreadingHeaders(from data: Data) -> [String: String] {
+    static func extractReferencesHeader(from data: Data) -> String? {
         guard let headerBlock = String(data: data, encoding: .utf8) ?? String(data: data, encoding: .ascii) else {
-            return [:]
+            return nil
         }
 
         let parsedHeaders = EMLParser.parseHeaders(headerBlock)
-        var threadingHeaders: [String: String] = [:]
-
-        if let inReplyTo = parsedHeaders["in-reply-to"]?.trimmingCharacters(in: .whitespacesAndNewlines),
-           !inReplyTo.isEmpty {
-            threadingHeaders["in-reply-to"] = inReplyTo
-        }
-
         if let references = parsedHeaders["references"]?.trimmingCharacters(in: .whitespacesAndNewlines),
            !references.isEmpty {
-            threadingHeaders["references"] = references
+            return references
         }
 
-        return threadingHeaders
+        return nil
     }
 }

--- a/Sources/SwiftMail/IMAP/Models/MessageInfo.swift
+++ b/Sources/SwiftMail/IMAP/Models/MessageInfo.swift
@@ -37,6 +37,9 @@ public struct MessageInfo: Codable, Sendable {
 
     /// The message ID this message replied to (from ENVELOPE In-Reply-To)
     public var inReplyTo: String?
+
+    /// The message IDs referenced by this message (from the References header)
+    public var references: String?
     
     /// The flags of the message
     public var flags: [Flag]
@@ -59,6 +62,7 @@ public struct MessageInfo: Codable, Sendable {
         case internalDate
         case messageId
         case inReplyTo
+        case references
         case flags
         case parts
         case additionalFields
@@ -90,6 +94,7 @@ public struct MessageInfo: Codable, Sendable {
         internalDate: Date? = nil,
         messageId: String? = nil,
         inReplyTo: String? = nil,
+        references: String? = nil,
         flags: [Flag] = [],
         parts: [MessagePart] = [],
         additionalFields: [String: String]? = nil
@@ -105,6 +110,7 @@ public struct MessageInfo: Codable, Sendable {
         self.internalDate = internalDate
         self.messageId = messageId
         self.inReplyTo = inReplyTo
+        self.references = references
         self.flags = flags
         self.parts = parts
         self.additionalFields = additionalFields
@@ -126,6 +132,7 @@ public extension MessageInfo {
         let internalDate = try container.decodeIfPresent(Date.self, forKey: .internalDate)
         let messageId = try container.decodeIfPresent(String.self, forKey: .messageId)
         let inReplyTo = try container.decodeIfPresent(String.self, forKey: .inReplyTo)
+        let references = try container.decodeIfPresent(String.self, forKey: .references)
         let flags = try container.decodeIfPresent([Flag].self, forKey: .flags) ?? []
         let parts = try container.decodeIfPresent([MessagePart].self, forKey: .parts) ?? []
         let additionalFields = try container.decodeIfPresent([String: String].self, forKey: .additionalFields)
@@ -142,6 +149,7 @@ public extension MessageInfo {
             internalDate: internalDate,
             messageId: messageId,
             inReplyTo: inReplyTo,
+            references: references,
             flags: flags,
             parts: parts,
             additionalFields: additionalFields

--- a/Tests/SwiftIMAPTests/FetchMessageInfoHandlerTests.swift
+++ b/Tests/SwiftIMAPTests/FetchMessageInfoHandlerTests.swift
@@ -1,0 +1,103 @@
+import Foundation
+import NIO
+import NIOEmbedded
+@preconcurrency import NIOIMAP
+@preconcurrency import NIOIMAPCore
+import Testing
+@testable import SwiftMail
+
+struct FetchMessageInfoHandlerTests {
+    @Test
+    func testSingleFetchPopulatesThreadingAdditionalFields() async throws {
+        let headerBlock = """
+        In-Reply-To: <root@example.com>\r
+        References: <root@example.com> <child@example.com>\r
+        \r
+        """
+
+        let infos = try await executeFetch(
+            [
+                fetchResponse(sequenceNumber: 1, headerBlock: headerBlock),
+                "A001 OK FETCH completed\r\n",
+            ]
+        )
+
+        #expect(infos.count == 1)
+        #expect(infos[0].additionalFields?["in-reply-to"] == "<root@example.com>")
+        #expect(infos[0].additionalFields?["references"] == "<root@example.com> <child@example.com>")
+    }
+
+    @Test
+    func testBulkFetchPopulatesThreadingAdditionalFieldsForEachMessage() async throws {
+        let firstHeader = """
+        In-Reply-To: <root-a@example.com>\r
+        References: <root-a@example.com>\r
+        \r
+        """
+        let secondHeader = """
+        References: <root-b@example.com> <child-b@example.com>\r
+        \r
+        """
+
+        let infos = try await executeFetch(
+            [
+                fetchResponse(sequenceNumber: 1, headerBlock: firstHeader),
+                fetchResponse(sequenceNumber: 2, headerBlock: secondHeader),
+                "A001 OK FETCH completed\r\n",
+            ]
+        )
+
+        #expect(infos.count == 2)
+        #expect(infos[0].additionalFields?["in-reply-to"] == "<root-a@example.com>")
+        #expect(infos[0].additionalFields?["references"] == "<root-a@example.com>")
+        #expect(infos[1].additionalFields?["in-reply-to"] == nil)
+        #expect(infos[1].additionalFields?["references"] == "<root-b@example.com> <child-b@example.com>")
+    }
+
+    @Test
+    func testMissingThreadingHeadersStayAbsent() async throws {
+        let headerBlock = """
+        Subject: No thread headers here\r
+        X-Test: value\r
+        \r
+        """
+
+        let infos = try await executeFetch(
+            [
+                fetchResponse(sequenceNumber: 1, headerBlock: headerBlock),
+                "A001 OK FETCH completed\r\n",
+            ]
+        )
+
+        #expect(infos.count == 1)
+        #expect(infos[0].additionalFields?["in-reply-to"] == nil)
+        #expect(infos[0].additionalFields?["references"] == nil)
+    }
+
+    private func executeFetch(_ rawResponses: [String]) async throws -> [MessageInfo] {
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+
+        try await channel.pipeline.addHandler(IMAPClientHandler())
+
+        let promise = channel.eventLoop.makePromise(of: [MessageInfo].self)
+        let handler = FetchMessageInfoHandler(commandTag: "A001", promise: promise)
+        try await channel.pipeline.addHandler(handler)
+
+        let command = TaggedCommand(tag: "A001", command: .noop)
+        try await channel.writeAndFlush(IMAPClientHandler.OutboundIn.part(.tagged(command)))
+        _ = try channel.readOutbound(as: ByteBuffer.self)
+
+        for rawResponse in rawResponses {
+            var buffer = channel.allocator.buffer(capacity: rawResponse.utf8.count)
+            buffer.writeString(rawResponse)
+            try channel.writeInbound(buffer)
+        }
+
+        return try await promise.futureResult.get()
+    }
+
+    private func fetchResponse(sequenceNumber: Int, headerBlock: String) -> String {
+        "* \(sequenceNumber) FETCH (BODY[HEADER] {\(headerBlock.utf8.count)}\r\n\(headerBlock))\r\n"
+    }
+}

--- a/Tests/SwiftIMAPTests/FetchMessageInfoHandlerTests.swift
+++ b/Tests/SwiftIMAPTests/FetchMessageInfoHandlerTests.swift
@@ -8,7 +8,7 @@ import Testing
 
 struct FetchMessageInfoHandlerTests {
     @Test
-    func testSingleFetchPopulatesThreadingAdditionalFields() async throws {
+    func testSingleFetchPopulatesThreadingProperties() async throws {
         let headerBlock = """
         In-Reply-To: <root@example.com>\r
         References: <root@example.com> <child@example.com>\r
@@ -17,18 +17,25 @@ struct FetchMessageInfoHandlerTests {
 
         let infos = try await executeFetch(
             [
-                fetchResponse(sequenceNumber: 1, headerBlock: headerBlock),
+                fetchResponse(
+                    sequenceNumber: 1,
+                    envelope: envelopeAttribute(
+                        messageId: "<reply@example.com>",
+                        inReplyTo: "<root@example.com>"
+                    ),
+                    headerBlock: headerBlock
+                ),
                 "A001 OK FETCH completed\r\n",
             ]
         )
 
         #expect(infos.count == 1)
-        #expect(infos[0].additionalFields?["in-reply-to"] == "<root@example.com>")
-        #expect(infos[0].additionalFields?["references"] == "<root@example.com> <child@example.com>")
+        #expect(infos[0].inReplyTo == "<root@example.com>")
+        #expect(infos[0].references == "<root@example.com> <child@example.com>")
     }
 
     @Test
-    func testBulkFetchPopulatesThreadingAdditionalFieldsForEachMessage() async throws {
+    func testBulkFetchPopulatesThreadingPropertiesForEachMessage() async throws {
         let firstHeader = """
         In-Reply-To: <root-a@example.com>\r
         References: <root-a@example.com>\r
@@ -41,17 +48,28 @@ struct FetchMessageInfoHandlerTests {
 
         let infos = try await executeFetch(
             [
-                fetchResponse(sequenceNumber: 1, headerBlock: firstHeader),
-                fetchResponse(sequenceNumber: 2, headerBlock: secondHeader),
+                fetchResponse(
+                    sequenceNumber: 1,
+                    envelope: envelopeAttribute(
+                        messageId: "<reply-a@example.com>",
+                        inReplyTo: "<root-a@example.com>"
+                    ),
+                    headerBlock: firstHeader
+                ),
+                fetchResponse(
+                    sequenceNumber: 2,
+                    envelope: envelopeAttribute(messageId: "<reply-b@example.com>"),
+                    headerBlock: secondHeader
+                ),
                 "A001 OK FETCH completed\r\n",
             ]
         )
 
         #expect(infos.count == 2)
-        #expect(infos[0].additionalFields?["in-reply-to"] == "<root-a@example.com>")
-        #expect(infos[0].additionalFields?["references"] == "<root-a@example.com>")
-        #expect(infos[1].additionalFields?["in-reply-to"] == nil)
-        #expect(infos[1].additionalFields?["references"] == "<root-b@example.com> <child-b@example.com>")
+        #expect(infos[0].inReplyTo == "<root-a@example.com>")
+        #expect(infos[0].references == "<root-a@example.com>")
+        #expect(infos[1].inReplyTo == nil)
+        #expect(infos[1].references == "<root-b@example.com> <child-b@example.com>")
     }
 
     @Test
@@ -64,14 +82,18 @@ struct FetchMessageInfoHandlerTests {
 
         let infos = try await executeFetch(
             [
-                fetchResponse(sequenceNumber: 1, headerBlock: headerBlock),
+                fetchResponse(
+                    sequenceNumber: 1,
+                    envelope: envelopeAttribute(messageId: "<loner@example.com>"),
+                    headerBlock: headerBlock
+                ),
                 "A001 OK FETCH completed\r\n",
             ]
         )
 
         #expect(infos.count == 1)
-        #expect(infos[0].additionalFields?["in-reply-to"] == nil)
-        #expect(infos[0].additionalFields?["references"] == nil)
+        #expect(infos[0].inReplyTo == nil)
+        #expect(infos[0].references == nil)
     }
 
     private func executeFetch(_ rawResponses: [String]) async throws -> [MessageInfo] {
@@ -97,7 +119,12 @@ struct FetchMessageInfoHandlerTests {
         return try await promise.futureResult.get()
     }
 
-    private func fetchResponse(sequenceNumber: Int, headerBlock: String) -> String {
-        "* \(sequenceNumber) FETCH (BODY[HEADER] {\(headerBlock.utf8.count)}\r\n\(headerBlock))\r\n"
+    private func fetchResponse(sequenceNumber: Int, envelope: String, headerBlock: String) -> String {
+        "* \(sequenceNumber) FETCH (ENVELOPE \(envelope) BODY[HEADER] {\(headerBlock.utf8.count)}\r\n\(headerBlock))\r\n"
+    }
+
+    private func envelopeAttribute(messageId: String, inReplyTo: String? = nil) -> String {
+        let inReplyToValue = inReplyTo.map { "\"\($0)\"" } ?? "NIL"
+        return "(NIL NIL NIL NIL NIL NIL NIL NIL \(inReplyToValue) \"\(messageId)\")"
     }
 }


### PR DESCRIPTION
## Summary
- capture BODY[HEADER] and RFC822.HEADER literal streams in FetchMessageInfoHandler
- parse In-Reply-To and References into MessageInfo.additionalFields
- preserve the existing dynamic XOAUTH2 token reauth support required by KestrelMail
- add single and bulk fetch tests covering threading header extraction

## Testing
- swift test --filter FetchMessageInfoHandlerTests --package-path /tmp/SwiftMail-header-threading
- swift test --filter SwiftIMAPTests --package-path /tmp/SwiftMail-header-threading