### PR TITLE
feat: automatic chunking for large FETCH operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ SwiftMail is a powerful email package that enables you to work with email protoc
 ### IMAPServer
 Handles IMAP server connections for retrieving and managing emails. Implements key IMAP capabilities including:
 - Mailbox operations (SELECT, LIST, COPY, MOVE)
-- Message operations (FETCH headers/parts/structure, STORE flags)
+- Message operations (FETCH headers/parts/structure, STORE flags) with automatic chunking for large sets
 - Special-use mailbox support
 - Creating new messages via APPEND (draft-friendly)
 - Namespace-aware mailbox resolution (NAMESPACE)

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -24,9 +24,12 @@ import OrderedCollections
  2. Search for "process:com.cocoanetics.SwiftMail"
  3. Adjust the "Action" menu to show Debug and Info messages
  */
+/// Maximum number of identifiers per IMAP FETCH command when chunking large sets.
+private let defaultFetchChunkSize = 50
+
 public actor IMAPServer {
     // MARK: - Properties
-    
+
     /** The hostname of the IMAP server */
     private let host: String
     
@@ -1022,6 +1025,11 @@ public actor IMAPServer {
     }
     
     /// Stream message headers for a set of identifiers
+    ///
+    /// Large identifier sets are automatically split into chunks of
+    /// `defaultFetchChunkSize` so that no single IMAP FETCH command is
+    /// too large. Results are yielded one at a time as they arrive.
+    ///
     /// - Parameter identifierSet: The set of message identifiers to fetch
     /// - Returns: An AsyncThrowingStream yielding MessageInfo one at a time
     public nonisolated func fetchMessageInfos<T: MessageIdentifier>(using identifierSet: MessageIdentifierSet<T>) -> AsyncThrowingStream<MessageInfo, Error> {
@@ -1032,23 +1040,24 @@ public actor IMAPServer {
                     guard !identifierSet.isEmpty else {
                         throw IMAPError.emptyIdentifierSet
                     }
-                    
-                    for identifier in identifierSet.toArray() {
+
+                    let chunks = identifierSet.chunked(size: defaultFetchChunkSize)
+
+                    for chunk in chunks {
                         try Task.checkCancellation()
-                        let singleSet = MessageIdentifierSet<T>(identifier)
-                        let command = FetchMessageInfoCommand(identifierSet: singleSet)
+                        let command = FetchMessageInfoCommand(identifierSet: chunk)
                         let result = try await executeCommand(command)
                         for header in result {
                             continuation.yield(header)
                         }
                     }
-                    
+
                     continuation.finish()
                 } catch {
                     continuation.finish(throwing: error)
                 }
             }
-            
+
             continuation.onTermination = { @Sendable _ in
                 task.cancel()
             }
@@ -1058,9 +1067,10 @@ public actor IMAPServer {
     /// Fetch complete messages with all parts using a message identifier set as a stream
     ///
     /// This method returns an `AsyncThrowingStream` that yields complete `Message` objects one at a time.
-    /// It retrieves each message's headers and body sequentially, ensuring IMAP commands
-    /// are executed in strict order. The sequence supports cancellation, allowing the
-    /// caller to stop fetching early without waiting for all messages to be downloaded.
+    /// Large identifier sets are automatically split into chunks of `defaultFetchChunkSize`
+    /// for the header fetch phase. Message bodies are then fetched individually.
+    /// The sequence supports cancellation, allowing the caller to stop fetching early
+    /// without waiting for all messages to be downloaded.
     ///
     /// - Parameter identifierSet: The set of message identifiers to fetch
     /// - Returns: An `AsyncThrowingStream` yielding `Message` instances with all parts
@@ -1072,9 +1082,15 @@ public actor IMAPServer {
                         throw IMAPError.emptyIdentifierSet
                     }
 
-                    for identifier in identifierSet.toArray() {
+                    let chunks = identifierSet.chunked(size: defaultFetchChunkSize)
+
+                    for chunk in chunks {
                         try Task.checkCancellation()
-                        if let header = try await fetchMessageInfo(for: identifier) {
+                        let command = FetchMessageInfoCommand(identifierSet: chunk)
+                        let headers = try await executeCommand(command)
+
+                        for header in headers {
+                            try Task.checkCancellation()
                             let email = try await fetchMessage(from: header)
                             continuation.yield(email)
                         }

--- a/Sources/SwiftMail/IMAP/Models/MessageIdentifierSet.swift
+++ b/Sources/SwiftMail/IMAP/Models/MessageIdentifierSet.swift
@@ -240,6 +240,34 @@ public struct MessageIdentifierSet<Identifier: MessageIdentifier>: Sendable {
     }
 }
 
+// MARK: - Chunking
+
+extension MessageIdentifierSet {
+    /// Splits this set into an array of smaller sets of the given maximum size.
+    ///
+    /// - Parameter size: The maximum number of identifiers per chunk.
+    ///   If zero or negative, returns a single chunk containing all elements.
+    /// - Returns: An array of `MessageIdentifierSet` chunks.
+    internal func chunked(size: Int) -> [MessageIdentifierSet<Identifier>] {
+        guard !isEmpty else { return [] }
+        guard size > 0 else { return [self] }
+        guard count > size else { return [self] }
+
+        let allIdentifiers = toArray()
+        var chunks: [MessageIdentifierSet<Identifier>] = []
+        var offset = 0
+
+        while offset < allIdentifiers.count {
+            let end = Swift.min(offset + size, allIdentifiers.count)
+            let slice = Array(allIdentifiers[offset..<end])
+            chunks.append(MessageIdentifierSet<Identifier>(slice))
+            offset = end
+        }
+
+        return chunks
+    }
+}
+
 // MARK: - Type Aliases
 
 /// A type-safe set of UIDs

--- a/Tests/SwiftIMAPTests/MessageChunkingTests.swift
+++ b/Tests/SwiftIMAPTests/MessageChunkingTests.swift
@@ -1,0 +1,150 @@
+import Testing
+@testable import SwiftMail
+
+@Suite("MessageIdentifierSet Chunking")
+struct MessageChunkingTests {
+
+    // MARK: - Empty Set
+
+    @Test("Empty set produces no chunks")
+    func emptySet() {
+        let set = MessageIdentifierSet<SwiftMail.UID>()
+        let chunks = set.chunked(size: 10)
+        #expect(chunks.isEmpty)
+    }
+
+    // MARK: - Single Element
+
+    @Test("Single element produces one chunk")
+    func singleElement() {
+        let set = MessageIdentifierSet<SwiftMail.UID>(SwiftMail.UID(42))
+        let chunks = set.chunked(size: 10)
+        #expect(chunks.count == 1)
+        #expect(chunks[0].count == 1)
+        #expect(chunks[0].contains(SwiftMail.UID(42)))
+    }
+
+    // MARK: - Set Smaller Than Chunk Size
+
+    @Test("Set smaller than chunk size produces one chunk")
+    func smallerThanChunkSize() {
+        let uids = (1...5).map { SwiftMail.UID(UInt32($0)) }
+        let set = MessageIdentifierSet<SwiftMail.UID>(uids)
+        let chunks = set.chunked(size: 10)
+        #expect(chunks.count == 1)
+        #expect(chunks[0].count == 5)
+    }
+
+    // MARK: - Set Exactly Equal to Chunk Size
+
+    @Test("Set exactly equal to chunk size produces one chunk")
+    func exactlyChunkSize() {
+        let uids = (1...10).map { SwiftMail.UID(UInt32($0)) }
+        let set = MessageIdentifierSet<SwiftMail.UID>(uids)
+        let chunks = set.chunked(size: 10)
+        #expect(chunks.count == 1)
+        #expect(chunks[0].count == 10)
+    }
+
+    // MARK: - Set Larger Than Chunk Size
+
+    @Test("Set larger than chunk size produces correct number of chunks")
+    func largerThanChunkSize() {
+        let uids = (1...25).map { SwiftMail.UID(UInt32($0)) }
+        let set = MessageIdentifierSet<SwiftMail.UID>(uids)
+        let chunks = set.chunked(size: 10)
+        #expect(chunks.count == 3)
+        #expect(chunks[0].count == 10)
+        #expect(chunks[1].count == 10)
+        #expect(chunks[2].count == 5)
+    }
+
+    @Test("All original elements are present across chunks")
+    func allElementsPreserved() {
+        let uids = (1...23).map { SwiftMail.UID(UInt32($0)) }
+        let set = MessageIdentifierSet<SwiftMail.UID>(uids)
+        let chunks = set.chunked(size: 7)
+
+        let totalCount = chunks.reduce(0) { $0 + $1.count }
+        #expect(totalCount == 23)
+
+        for uid in uids {
+            let found = chunks.contains { $0.contains(uid) }
+            #expect(found, "UID \(uid.value) should be in one of the chunks")
+        }
+    }
+
+    // MARK: - Non-Contiguous UIDs
+
+    @Test("Non-contiguous UIDs are preserved correctly")
+    func nonContiguousUIDs() {
+        // UIDs: 1, 2, 3, 10, 11, 12, 50, 51
+        var set = MessageIdentifierSet<SwiftMail.UID>()
+        set.insert(range: SwiftMail.UID(1)...SwiftMail.UID(3))
+        set.insert(range: SwiftMail.UID(10)...SwiftMail.UID(12))
+        set.insert(SwiftMail.UID(50))
+        set.insert(SwiftMail.UID(51))
+        #expect(set.count == 8)
+
+        let chunks = set.chunked(size: 5)
+        #expect(chunks.count == 2)
+        #expect(chunks[0].count == 5)
+        #expect(chunks[1].count == 3)
+
+        // First chunk: 1, 2, 3, 10, 11
+        #expect(chunks[0].contains(SwiftMail.UID(1)))
+        #expect(chunks[0].contains(SwiftMail.UID(3)))
+        #expect(chunks[0].contains(SwiftMail.UID(10)))
+
+        // Second chunk: 12, 50, 51
+        #expect(chunks[1].contains(SwiftMail.UID(12)))
+        #expect(chunks[1].contains(SwiftMail.UID(50)))
+        #expect(chunks[1].contains(SwiftMail.UID(51)))
+    }
+
+    // MARK: - SequenceNumber
+
+    @Test("Works with SequenceNumber identifiers")
+    func sequenceNumbers() {
+        let seqs = (1...12).map { SwiftMail.SequenceNumber(UInt32($0)) }
+        let set = MessageIdentifierSet<SwiftMail.SequenceNumber>(seqs)
+        let chunks = set.chunked(size: 5)
+        #expect(chunks.count == 3)
+        #expect(chunks[0].count == 5)
+        #expect(chunks[1].count == 5)
+        #expect(chunks[2].count == 2)
+    }
+
+    // MARK: - Zero / Negative Chunk Size
+
+    @Test("Zero chunk size returns single chunk with all elements")
+    func zeroChunkSize() {
+        let uids = (1...10).map { SwiftMail.UID(UInt32($0)) }
+        let set = MessageIdentifierSet<SwiftMail.UID>(uids)
+        let chunks = set.chunked(size: 0)
+        #expect(chunks.count == 1)
+        #expect(chunks[0].count == 10)
+    }
+
+    @Test("Negative chunk size returns single chunk with all elements")
+    func negativeChunkSize() {
+        let uids = (1...10).map { SwiftMail.UID(UInt32($0)) }
+        let set = MessageIdentifierSet<SwiftMail.UID>(uids)
+        let chunks = set.chunked(size: -5)
+        #expect(chunks.count == 1)
+        #expect(chunks[0].count == 10)
+    }
+
+    // MARK: - Chunk Size of 1
+
+    @Test("Chunk size of 1 produces one chunk per element")
+    func chunkSizeOne() {
+        let uids = (1...4).map { SwiftMail.UID(UInt32($0)) }
+        let set = MessageIdentifierSet<SwiftMail.UID>(uids)
+        let chunks = set.chunked(size: 1)
+        #expect(chunks.count == 4)
+        for chunk in chunks {
+            #expect(chunk.count == 1)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Closes #118

- Added internal `MessageIdentifierSet.chunked(size:)` method that splits large identifier sets into smaller chunks, handling edge cases (empty set, size ≤ 0, set smaller than chunk size)
- Modified `fetchMessageInfos(using:)` and `fetchMessages(using:)` to automatically chunk large identifier sets (default chunk size: 50) — callers need no changes
- Added 11 tests covering all chunking scenarios using Swift Testing (`@Suite`, `@Test`, `#expect`)

## Test plan

- [x] `swift build` produces no errors or warnings
- [x] `swift test` passes all 136 tests (125 existing + 11 new chunking tests)
- [x] Tests cover: empty set, single element, smaller/equal/larger than chunk size, non-contiguous UIDs, SequenceNumber support, zero/negative chunk size, chunk size of 1

🤖 Generated with [Claude Code](https://claude.com/claude-code)