### PR TITLE
Add SMTP SIZE support

### DIFF
--- a/Sources/SwiftMail/Extensions/Email+Content.swift
+++ b/Sources/SwiftMail/Extensions/Email+Content.swift
@@ -1,6 +1,10 @@
 import Foundation
 
 extension Email {
+    public func messageSizeOctets(use8BitMIME: Bool = false) -> Int {
+        constructContent(use8BitMIME: use8BitMIME).utf8.count
+    }
+
     /**
      Build the MIME encoded email body.
 

--- a/Sources/SwiftMail/Extensions/Email+Content.swift
+++ b/Sources/SwiftMail/Extensions/Email+Content.swift
@@ -1,8 +1,18 @@
 import Foundation
 
 extension Email {
+    struct PreparedContent {
+        let content: String
+        let messageSizeOctets: Int
+    }
+
+    func preparedContent(use8BitMIME: Bool = false) -> PreparedContent {
+        let content = constructContent(use8BitMIME: use8BitMIME)
+        return PreparedContent(content: content, messageSizeOctets: content.utf8.count)
+    }
+
     public func messageSizeOctets(use8BitMIME: Bool = false) -> Int {
-        constructContent(use8BitMIME: use8BitMIME).utf8.count
+        preparedContent(use8BitMIME: use8BitMIME).messageSizeOctets
     }
 
     /**

--- a/Sources/SwiftMail/SMTP/Commands/MailFromCommand.swift
+++ b/Sources/SwiftMail/SMTP/Commands/MailFromCommand.swift
@@ -17,6 +17,9 @@ struct MailFromCommand: SMTPCommand {
     
     /// Indicates if 8BITMIME is supported and should be used
     private let use8BitMIME: Bool
+
+    /// Optional RFC 1870 SIZE parameter value in octets
+    private let messageSizeOctets: Int?
     
     /// Default timeout in seconds
 	let timeoutSeconds: Int = 30
@@ -26,8 +29,13 @@ struct MailFromCommand: SMTPCommand {
      - Parameters:
        - senderAddress: The email address of the sender
        - use8BitMIME: Whether to use 8BITMIME extension if available
+       - messageSizeOctets: Optional SIZE extension value in octets
      */
-	init(senderAddress: String, use8BitMIME: Bool = false) throws {
+	init(
+        senderAddress: String,
+        use8BitMIME: Bool = false,
+        messageSizeOctets: Int? = nil
+    ) throws {
         // Validate email format
         guard senderAddress.isValidEmail() else {
             throw SMTPError.invalidEmailAddress("Invalid sender address: \(senderAddress)")
@@ -35,19 +43,21 @@ struct MailFromCommand: SMTPCommand {
         
         self.senderAddress = senderAddress
         self.use8BitMIME = use8BitMIME
+        self.messageSizeOctets = messageSizeOctets
     }
     
     /**
      Convert the command to a string that can be sent to the server
      */
 	func toCommandString() -> String {
+        var command = "MAIL FROM:<\(senderAddress)>"
         if use8BitMIME {
-            // Add the BODY=8BITMIME parameter when 8BITMIME is supported
-            return "MAIL FROM:<\(senderAddress)> BODY=8BITMIME"
-        } else {
-            // Standard MAIL FROM command
-            return "MAIL FROM:<\(senderAddress)>"
+            command += " BODY=8BITMIME"
         }
+        if let messageSizeOctets {
+            command += " SIZE=\(messageSizeOctets)"
+        }
+        return command
     }
     
     /**
@@ -56,6 +66,9 @@ struct MailFromCommand: SMTPCommand {
 	func validate() throws {
         guard !senderAddress.isEmpty else {
             throw SMTPError.sendFailed("Sender address cannot be empty")
+        }
+        if let messageSizeOctets, messageSizeOctets < 0 {
+            throw SMTPError.sendFailed("Message size cannot be negative")
         }
         
         // Use our cross-platform email validation method

--- a/Sources/SwiftMail/SMTP/Commands/SendContentCommand.swift
+++ b/Sources/SwiftMail/SMTP/Commands/SendContentCommand.swift
@@ -12,11 +12,8 @@ struct SendContentCommand: SMTPCommand {
     /// The handler type that will process responses for this command
 	typealias HandlerType = SendContentHandler
     
-    /// The email to send
-    private let email: Email
-    
-    /// Whether to use 8BITMIME if available
-    private let use8BitMIME: Bool
+    /// The fully constructed MIME message content to send
+    private let content: String
 	
 	/// Default timeout in seconds
 	let timeoutSeconds: Int = 10
@@ -24,20 +21,17 @@ struct SendContentCommand: SMTPCommand {
     /**
      Initialize a new SendContent command
      - Parameters:
-        - email: The email to send
-        - use8BitMIME: Whether to use 8BITMIME encoding
+        - content: The fully constructed MIME message content
      */
-	init(email: Email, use8BitMIME: Bool = false) {
-        self.email = email
-        self.use8BitMIME = use8BitMIME
+	init(content: String) {
+        self.content = content
     }
     
     /**
      Convert the command to a string that can be sent to the server
      */
 	func toCommandString() -> String {
-        // Construct email content and add terminating period on a line by itself
-        let content = email.constructContent(use8BitMIME: use8BitMIME)
+        // Add terminating period on a line by itself
         return content + "\r\n."
     }
 } 

--- a/Sources/SwiftMail/SMTP/SMTPError.swift
+++ b/Sources/SwiftMail/SMTP/SMTPError.swift
@@ -29,6 +29,9 @@ public enum SMTPError: Error {
     
     /// TLS negotiation failed
     case tlsFailed(String)
+
+    /// The message exceeds the server-advertised maximum size
+    case messageTooLarge(messageSizeOctets: Int, maximumMessageSizeOctets: Int)
     
     /// Unexpected response from server
     case unexpectedResponse(SMTPResponse)
@@ -52,6 +55,8 @@ extension SMTPError: CustomStringConvertible {
             return "SMTP invalid email address: \(reason)"
         case .tlsFailed(let reason):
             return "SMTP TLS failed: \(reason)"
+        case .messageTooLarge(let messageSizeOctets, let maximumMessageSizeOctets):
+            return "SMTP message too large: \(messageSizeOctets) bytes exceeds \(maximumMessageSizeOctets) byte limit"
         case .unexpectedResponse(let response):
             return "SMTP unexpected response: \(response.code) \(response.message)"
         }

--- a/Sources/SwiftMail/SMTP/SMTPServer.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer.swift
@@ -69,12 +69,21 @@ public actor SMTPServer {
     /** Server capabilities reported by EHLO command */
     private var capabilities: [String] = []
 
+    /// Whether the server advertised the `8BITMIME` extension in the most recent EHLO response.
     public var supports8BitMIME: Bool {
         capabilities.contains("8BITMIME")
     }
 
+    /// The server-advertised RFC 1870 `SIZE` limit from the most recent EHLO response, if present.
     public var maximumMessageSizeOctets: Int? {
         Self.maximumMessageSizeOctets(from: capabilities)
+    }
+
+    struct PreparedEmailForSend {
+        let use8BitMIME: Bool
+        let content: String
+        let emailSizeOctets: Int
+        let mailFromMessageSizeOctets: Int?
     }
     
     /** 
@@ -393,11 +402,9 @@ public actor SMTPServer {
             logger.debug("Email contains \(email.regularAttachments.count) regular attachments and \(email.inlineAttachments.count) inline attachments")
         }
         
-        // Check if the server supports 8BITMIME
-        let supports8BitMIME = self.supports8BitMIME
-        let announcedMessageSizeOctets = email.messageSizeOctets(use8BitMIME: supports8BitMIME)
+        let preparedEmail = try Self.prepareEmailForSend(email, capabilities: capabilities)
         
-        if supports8BitMIME {
+        if preparedEmail.use8BitMIME {
             self.logger.debug("Server supports 8BITMIME, using it for this email")
         }
         
@@ -405,8 +412,8 @@ public actor SMTPServer {
             // Create Mail From command using 8BITMIME if supported
             let mailFrom = try MailFromCommand(
                 senderAddress: email.sender.address,
-                use8BitMIME: supports8BitMIME,
-                messageSizeOctets: announcedMessageSizeOctets
+                use8BitMIME: preparedEmail.use8BitMIME,
+                messageSizeOctets: preparedEmail.mailFromMessageSizeOctets
             )
             _ = try await executeCommand(mailFrom)
             
@@ -421,7 +428,7 @@ public actor SMTPServer {
             _ = try await executeCommand(data)
             
             // Send content
-            let sendContent = SendContentCommand(email: email, use8BitMIME: supports8BitMIME)
+            let sendContent = SendContentCommand(content: preparedEmail.content)
             try await executeCommand(sendContent)
             
             self.logger.debug("Email sent successfully")
@@ -700,6 +707,27 @@ public actor SMTPServer {
             return octets
         }
         return nil
+    }
+
+    static func prepareEmailForSend(_ email: Email, capabilities: [String]) throws -> PreparedEmailForSend {
+        let use8BitMIME = capabilities.contains("8BITMIME")
+        let preparedContent = email.preparedContent(use8BitMIME: use8BitMIME)
+        let maximumMessageSizeOctets = maximumMessageSizeOctets(from: capabilities)
+
+        if let maximumMessageSizeOctets,
+           preparedContent.messageSizeOctets > maximumMessageSizeOctets {
+            throw SMTPError.messageTooLarge(
+                messageSizeOctets: preparedContent.messageSizeOctets,
+                maximumMessageSizeOctets: maximumMessageSizeOctets
+            )
+        }
+
+        return PreparedEmailForSend(
+            use8BitMIME: use8BitMIME,
+            content: preparedContent.content,
+            emailSizeOctets: preparedContent.messageSizeOctets,
+            mailFromMessageSizeOctets: maximumMessageSizeOctets == nil ? nil : preparedContent.messageSizeOctets
+        )
     }
     
     /**

--- a/Sources/SwiftMail/SMTP/SMTPServer.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer.swift
@@ -68,6 +68,14 @@ public actor SMTPServer {
     
     /** Server capabilities reported by EHLO command */
     private var capabilities: [String] = []
+
+    public var supports8BitMIME: Bool {
+        capabilities.contains("8BITMIME")
+    }
+
+    public var maximumMessageSizeOctets: Int? {
+        Self.maximumMessageSizeOctets(from: capabilities)
+    }
     
     /** 
      Logger for SMTP operations
@@ -386,7 +394,8 @@ public actor SMTPServer {
         }
         
         // Check if the server supports 8BITMIME
-        let supports8BitMIME = self.capabilities.contains("8BITMIME")
+        let supports8BitMIME = self.supports8BitMIME
+        let announcedMessageSizeOctets = email.messageSizeOctets(use8BitMIME: supports8BitMIME)
         
         if supports8BitMIME {
             self.logger.debug("Server supports 8BITMIME, using it for this email")
@@ -394,7 +403,11 @@ public actor SMTPServer {
         
         do {
             // Create Mail From command using 8BITMIME if supported
-            let mailFrom = try MailFromCommand(senderAddress: email.sender.address, use8BitMIME: supports8BitMIME)
+            let mailFrom = try MailFromCommand(
+                senderAddress: email.sender.address,
+                use8BitMIME: supports8BitMIME,
+                messageSizeOctets: announcedMessageSizeOctets
+            )
             _ = try await executeCommand(mailFrom)
             
             // RCPT TO commands
@@ -677,6 +690,16 @@ public actor SMTPServer {
         }
         
         return parsedCapabilities
+    }
+
+    static func maximumMessageSizeOctets(from capabilities: [String]) -> Int? {
+        for capability in capabilities {
+            guard capability.hasPrefix("SIZE ") else { continue }
+            let value = capability.dropFirst("SIZE ".count).trimmingCharacters(in: .whitespaces)
+            guard let octets = Int(value), octets > 0 else { continue }
+            return octets
+        }
+        return nil
     }
     
     /**

--- a/Tests/SwiftSMTPTests/SMTPTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPTests.swift
@@ -1,3 +1,4 @@
+import Foundation
 import Testing
 @testable import SwiftMail
 
@@ -89,5 +90,69 @@ struct SMTPTests {
 
         #expect(!SMTPServer.shouldFailClosedOnSTARTTLSFailure(port: 465, host: "smtp.gmail.com"))
         #expect(!SMTPServer.shouldFailClosedOnSTARTTLSFailure(port: 25, host: "smtp.example.com"))
+    }
+
+    @Test
+    func testMaximumMessageSizeOctetsParsesSIZECapability() {
+        #expect(
+            SMTPServer.maximumMessageSizeOctets(
+                from: ["PIPELINING", "SIZE 12345678", "AUTH PLAIN"]
+            ) == 12_345_678
+        )
+    }
+
+    @Test
+    func testMaximumMessageSizeOctetsIgnoresMalformedSIZECapability() {
+        #expect(SMTPServer.maximumMessageSizeOctets(from: ["SIZE nope"]) == nil)
+        #expect(SMTPServer.maximumMessageSizeOctets(from: ["SIZE 0"]) == nil)
+        #expect(SMTPServer.maximumMessageSizeOctets(from: ["AUTH PLAIN"]) == nil)
+    }
+
+    @Test
+    func testMailFromCommandFormatsSizeAnd8BitMIMEParameters() throws {
+        let plain = try MailFromCommand(senderAddress: "sender@example.com", messageSizeOctets: 4096)
+        #expect(plain.toCommandString() == "MAIL FROM:<sender@example.com> SIZE=4096")
+
+        let eightBit = try MailFromCommand(senderAddress: "sender@example.com", use8BitMIME: true)
+        #expect(eightBit.toCommandString() == "MAIL FROM:<sender@example.com> BODY=8BITMIME")
+
+        let combined = try MailFromCommand(
+            senderAddress: "sender@example.com",
+            use8BitMIME: true,
+            messageSizeOctets: 4096
+        )
+        #expect(combined.toCommandString() == "MAIL FROM:<sender@example.com> BODY=8BITMIME SIZE=4096")
+    }
+
+    @Test
+    func testMessageSizeOctetsTracksGeneratedContentForAttachments() {
+        let inlineAttachment = Attachment(
+            filename: "inline.png",
+            mimeType: "image/png",
+            data: Data(repeating: 0x42, count: 1024),
+            contentID: "inline-image",
+            isInline: true
+        )
+        let regularAttachment = Attachment(
+            filename: "report.pdf",
+            mimeType: "application/pdf",
+            data: Data(repeating: 0x5A, count: 2048)
+        )
+        let email = Email(
+            sender: EmailAddress(address: "sender@example.com"),
+            recipients: [EmailAddress(address: "recipient@example.com")],
+            subject: "Large",
+            textBody: "Hello",
+            htmlBody: "<p>Hello<img src=\"cid:inline-image\"></p>",
+            attachments: [inlineAttachment, regularAttachment]
+        )
+
+        let quotedPrintableSize = email.messageSizeOctets(use8BitMIME: false)
+        let eightBitSize = email.messageSizeOctets(use8BitMIME: true)
+
+        #expect(quotedPrintableSize > 0)
+        #expect(eightBitSize > 0)
+        #expect(quotedPrintableSize == email.constructContent(use8BitMIME: false).utf8.count)
+        #expect(eightBitSize == email.constructContent(use8BitMIME: true).utf8.count)
     }
 }

--- a/Tests/SwiftSMTPTests/SMTPTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPTests.swift
@@ -155,4 +155,58 @@ struct SMTPTests {
         #expect(quotedPrintableSize == email.constructContent(use8BitMIME: false).utf8.count)
         #expect(eightBitSize == email.constructContent(use8BitMIME: true).utf8.count)
     }
+
+    @Test
+    func testPrepareEmailForSendOmitsMailFromSizeWhenServerDoesNotAdvertiseSIZE() throws {
+        let email = Email(
+            sender: EmailAddress(address: "sender@example.com"),
+            recipients: [EmailAddress(address: "recipient@example.com")],
+            subject: "Hello",
+            textBody: "Body"
+        )
+
+        let prepared = try SMTPServer.prepareEmailForSend(
+            email,
+            capabilities: ["PIPELINING", "8BITMIME"]
+        )
+
+        #expect(prepared.use8BitMIME)
+        #expect(prepared.emailSizeOctets > 0)
+        #expect(prepared.mailFromMessageSizeOctets == nil)
+    }
+
+    @Test
+    func testPrepareEmailForSendUsesMailFromSizeWhenServerAdvertisesSIZE() throws {
+        let email = Email(
+            sender: EmailAddress(address: "sender@example.com"),
+            recipients: [EmailAddress(address: "recipient@example.com")],
+            subject: "Hello",
+            textBody: "Body"
+        )
+
+        let prepared = try SMTPServer.prepareEmailForSend(
+            email,
+            capabilities: ["PIPELINING", "SIZE 999999"]
+        )
+
+        #expect(prepared.emailSizeOctets > 0)
+        #expect(prepared.mailFromMessageSizeOctets == prepared.emailSizeOctets)
+    }
+
+    @Test
+    func testPrepareEmailForSendRejectsMessagesExceedingAdvertisedSIZE() {
+        let email = Email(
+            sender: EmailAddress(address: "sender@example.com"),
+            recipients: [EmailAddress(address: "recipient@example.com")],
+            subject: "Hello",
+            textBody: String(repeating: "A", count: 4096)
+        )
+
+        #expect(throws: SMTPError.self) {
+            try SMTPServer.prepareEmailForSend(
+                email,
+                capabilities: ["PIPELINING", "SIZE 128"]
+            )
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- expose parsed SMTP SIZE capability data on SMTPServer
- compute exact message octet counts from the generated MIME content on Email
- include SIZE=<octets> in MAIL FROM when sending mail
- add focused SMTP tests for SIZE parsing, command formatting, and message-size calculation

## Motivation
Some SMTP servers advertise a maximum accepted message size via the RFC 1870 SIZE extension. Exposing that capability and announcing the actual MIME payload size during MAIL FROM lets clients make better send decisions and align with server expectations without hard-coding provider-specific limits.

## Validation
- swift test --filter SMTPTests
