### PR TITLE
fix: use let for unmutated challenge binding

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Handler/PlainAuthenticationHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/PlainAuthenticationHandler.swift
@@ -35,7 +35,7 @@ final class PlainAuthenticationHandler: BaseIMAPCommandHandler<[Capability]>, IM
     override func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let response = unwrapInboundIn(data)
 
-        if case .authenticationChallenge(var challenge) = response {
+        if case .authenticationChallenge(let challenge) = response {
             let challengeIsEmpty = challenge.readableBytes == 0 ||
                 (challenge.getString(at: challenge.readerIndex, length: challenge.readableBytes) ?? "")
                     .trimmingCharacters(in: .whitespacesAndNewlines).isEmpty


### PR DESCRIPTION
## Summary
- Changed `var challenge` to `let challenge` in `PlainAuthenticationHandler.channelRead` since the binding is never mutated
- Silences the Swift compiler warning: "Variable 'challenge' was never mutated; consider changing to 'let' constant"

## Test plan
- Existing tests pass — no behavioral change, just a binding keyword fix