### PR TITLE
Add UID EXPUNGE support

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Commands/ServerCommands.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/ServerCommands.swift
@@ -109,4 +109,26 @@ struct ExpungeCommand: IMAPTaggedCommand {
     func toTaggedCommand(tag: String) -> TaggedCommand {
         return TaggedCommand(tag: tag, command: .expunge)
     }
-} 
+}
+
+/// Command for expunging specific deleted messages by UID.
+struct UIDExpungeCommand: IMAPTaggedCommand {
+    typealias ResultType = Void
+    typealias HandlerType = ExpungeHandler
+
+    let identifierSet: UIDSet
+
+    init(identifierSet: UIDSet) {
+        self.identifierSet = identifierSet
+    }
+
+    func validate() throws {
+        guard !identifierSet.isEmpty else {
+            throw IMAPError.emptyIdentifierSet
+        }
+    }
+
+    func toTaggedCommand(tag: String) -> TaggedCommand {
+        TaggedCommand(tag: tag, command: .uidExpunge(.set(identifierSet.toNIOSet())))
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -99,6 +99,10 @@ final class IMAPConnection {
         capabilities.contains(where: check)
     }
 
+    func replaceCapabilitiesForTesting(_ capabilities: Set<NIOIMAPCore.Capability>) {
+        self.capabilities = capabilities
+    }
+
     func connect() async throws {
         try await commandQueue.run { [self] in
             try await self.connectBody()

--- a/Sources/SwiftMail/IMAP/IMAPNamedConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPNamedConnection.swift
@@ -209,6 +209,16 @@ public actor IMAPNamedConnection {
         try await executeCommand(command)
     }
 
+    /// Expunge specific messages marked with `\Deleted` using UIDPLUS.
+    public func uidExpunge(messages identifierSet: UIDSet) async throws {
+        guard supportsUIDPlus else {
+            throw IMAPError.commandNotSupported("UID EXPUNGE command not supported by server")
+        }
+
+        let command = UIDExpungeCommand(identifierSet: identifierSet)
+        try await executeCommand(command)
+    }
+
     /// Move messages to another mailbox (uses MOVE if supported, otherwise COPY+STORE+EXPUNGE).
     public func move<T: MessageIdentifier>(messages identifierSet: MessageIdentifierSet<T>, to destinationMailbox: String) async throws {
         if capabilities.contains(.move) && (T.self != UID.self || capabilities.contains(.uidPlus)) {
@@ -290,6 +300,11 @@ public actor IMAPNamedConnection {
 
     private var capabilities: Set<NIOIMAPCore.Capability> {
         connection.capabilitiesSnapshot
+    }
+
+    /// Whether the server advertised UIDPLUS for this connection.
+    public var supportsUIDPlus: Bool {
+        capabilities.contains(.uidPlus)
     }
 
     private func ensureAuthenticated() async throws {

--- a/Sources/SwiftMail/IMAP/IMAPNamedConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPNamedConnection.swift
@@ -226,7 +226,7 @@ public actor IMAPNamedConnection {
         } else {
             try await copy(messages: identifierSet, to: destinationMailbox)
             try await store(flags: [.deleted], on: identifierSet, operation: .add)
-            try await expunge()
+            try await expungeMoveFallback(messages: identifierSet)
         }
     }
 
@@ -324,6 +324,15 @@ public actor IMAPNamedConnection {
     private func executeMove<T: MessageIdentifier>(messages identifierSet: MessageIdentifierSet<T>, to destinationMailbox: String) async throws {
         let command = MoveCommand(identifierSet: identifierSet, destinationMailbox: resolveMailboxPath(destinationMailbox))
         try await executeCommand(command)
+    }
+
+    private func expungeMoveFallback<T: MessageIdentifier>(messages identifierSet: MessageIdentifierSet<T>) async throws {
+        if T.self == UID.self && capabilities.contains(.uidPlus) {
+            let uidSet = UIDSet(identifierSet.toArray().map { UID($0.value) })
+            try await uidExpunge(messages: uidSet)
+        } else {
+            try await expunge()
+        }
     }
 
     private func resolveMailboxPath(_ mailboxName: String) -> String {

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -1137,10 +1137,10 @@ public actor IMAPServer {
         if capabilities.contains(.move) && (T.self != UID.self || capabilities.contains(.uidPlus)) {
             try await executeMove(messages: identifierSet, to: destinationMailbox)
         } else {
-            // Fall back to COPY + DELETE + EXPUNGE
+            // Fall back to COPY + DELETE + targeted expunge when UIDPLUS is available.
             try await copy(messages: identifierSet, to: destinationMailbox)
             try await store(flags: [.deleted], on: identifierSet, operation: .add)
-            try await expunge()
+            try await expungeMoveFallback(messages: identifierSet)
         }
     }
     
@@ -1356,6 +1356,15 @@ public actor IMAPServer {
 
         let command = UIDExpungeCommand(identifierSet: identifierSet)
         try await executeCommand(command)
+    }
+
+    private func expungeMoveFallback<T: MessageIdentifier>(messages identifierSet: MessageIdentifierSet<T>) async throws {
+        if T.self == UID.self && capabilities.contains(.uidPlus) {
+            let uidSet = UIDSet(identifierSet.toArray().map { UID($0.value) })
+            try await uidExpunge(messages: uidSet)
+        } else {
+            try await expunge()
+        }
     }
     
     /**

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -64,6 +64,11 @@ public actor IMAPServer {
     private var capabilities: Set<NIOIMAPCore.Capability> {
         primaryConnection.capabilitiesSnapshot
     }
+
+    /// Whether the primary connection advertised UIDPLUS.
+    public var supportsUIDPlus: Bool {
+        capabilities.contains(.uidPlus)
+    }
     
     /**
      Logger for IMAP operations
@@ -1340,6 +1345,16 @@ public actor IMAPServer {
      */
     public func expunge() async throws {
         let command = ExpungeCommand()
+        try await executeCommand(command)
+    }
+
+    /// Permanently removes specific deleted messages by UID when UIDPLUS is available.
+    public func uidExpunge(messages identifierSet: UIDSet) async throws {
+        guard supportsUIDPlus else {
+            throw IMAPError.commandNotSupported("UID EXPUNGE command not supported by server")
+        }
+
+        let command = UIDExpungeCommand(identifierSet: identifierSet)
         try await executeCommand(command)
     }
     

--- a/Tests/SwiftIMAPTests/IMAPNamedConnectionTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPNamedConnectionTests.swift
@@ -1,5 +1,6 @@
 import Foundation
 import NIO
+import NIOIMAPCore
 import Testing
 @testable import SwiftMail
 
@@ -42,5 +43,41 @@ struct IMAPNamedConnectionTests {
 
         let activity = await named.lastActivity
         #expect(activity == nil)
+    }
+
+    @Test
+    func uidExpungeRequiresUIDPlusCapability() async {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            Task {
+                try? await group.shutdownGracefully()
+            }
+        }
+
+        let connection = IMAPConnection(
+            host: "localhost",
+            port: 1,
+            group: group,
+            loggerLabel: "test.imap",
+            outboundLabel: "test.imap.out",
+            inboundLabel: "test.imap.in",
+            connectionID: "test-uidexpunge",
+            connectionRole: "test"
+        )
+        connection.replaceCapabilitiesForTesting([])
+        let named = IMAPNamedConnection(name: "test", connection: connection, authenticateOnConnection: { _ in })
+
+        do {
+            try await named.uidExpunge(messages: UIDSet(UID(7)))
+            Issue.record("Expected UID EXPUNGE to require UIDPLUS")
+        } catch let error as IMAPError {
+            guard case .commandNotSupported(let message) = error else {
+                Issue.record("Expected commandNotSupported, got \(error)")
+                return
+            }
+            #expect(message == "UID EXPUNGE command not supported by server")
+        } catch {
+            Issue.record("Expected IMAPError.commandNotSupported, got \(error)")
+        }
     }
 }

--- a/Tests/SwiftIMAPTests/SearchCommandTests.swift
+++ b/Tests/SwiftIMAPTests/SearchCommandTests.swift
@@ -82,4 +82,25 @@ struct SearchCommandTests {
         #expect(wire.contains("SEARCH"))
         #expect(wire.contains("1:2") || wire.contains("1,2"))
     }
+
+    @Test
+    func testUIDExpungeUsesUIDCommandWireFormat() async throws {
+        let channel = EmbeddedChannel()
+        defer { _ = try? channel.finish() }
+        try await channel.pipeline.addHandler(IMAPClientHandler())
+
+        let command = UIDExpungeCommand(identifierSet: UIDSet([UID(10), UID(20), UID(30)]))
+        let tagged = command.toTaggedCommand(tag: "S004")
+        let wrapped = IMAPClientHandler.OutboundIn.part(CommandStreamPart.tagged(tagged))
+        try await channel.writeAndFlush(wrapped)
+
+        guard var outbound = try channel.readOutbound(as: ByteBuffer.self) else {
+            Issue.record("Expected outbound bytes")
+            return
+        }
+        let wire = outbound.readString(length: outbound.readableBytes) ?? ""
+
+        #expect(wire.contains("UID EXPUNGE"))
+        #expect(wire.contains("10:30") || wire.contains("10,20,30"))
+    }
 }


### PR DESCRIPTION
## Summary
- add `UID EXPUNGE` support to `IMAPServer` and `IMAPNamedConnection`
- route the command through `IMAPConnection` using the `UID` command form
- use targeted `UID EXPUNGE` in the UID-based move fallback when `MOVE` is unavailable but `UIDPLUS` is present
- add coverage for wire format and capability gating

## Why
`UID EXPUNGE` is part of `UIDPLUS` and allows callers to permanently remove only the selected `\Deleted` messages by UID instead of expunging the entire selected mailbox. Exposing it directly is useful on its own, and using it in the UID-based move fallback avoids broad `EXPUNGE` behavior on servers that support `UIDPLUS` but not `MOVE`.

## Validation
- `swift test`