### PR TITLE
Honor provided Message-ID headers without duplication

### DIFF
--- a/Sources/SwiftMail/Extensions/Email+Content.swift
+++ b/Sources/SwiftMail/Extensions/Email+Content.swift
@@ -43,13 +43,22 @@ extension Email {
 
         content += "Subject: \(self.subject)\r\n"
         content += "Date: \(Self.rfc2822Date())\r\n"
-        let msgID = self.messageID ?? resolvedMessageIDHeader() ?? .generate(domain: Self.senderDomain(from: self.sender))
-        content += "Message-Id: \(msgID)\r\n"
+        let resolvedAdditionalHeaderMessageID = resolvedMessageIDHeader()
+        let shouldSuppressAdditionalHeaderMessageID = self.messageID != nil || resolvedAdditionalHeaderMessageID != nil
+
+        if let msgID = self.messageID ?? resolvedAdditionalHeaderMessageID {
+            content += "Message-Id: \(msgID)\r\n"
+        } else if !hasMessageIDHeaderInAdditionalHeaders() {
+            let generatedMessageID = MessageID.generate(domain: Self.senderDomain(from: self.sender))
+            content += "Message-Id: \(generatedMessageID)\r\n"
+        }
         content += "MIME-Version: 1.0\r\n"
 
         if let additionalHeaders {
             for (key, value) in additionalHeaders.sorted(by: { $0.key < $1.key }) {
-                guard !Self.isMessageIDHeaderName(key) else { continue }
+                if shouldSuppressAdditionalHeaderMessageID && Self.isMessageIDHeaderName(key) {
+                    continue
+                }
                 content += "\(key): \(value)\r\n"
             }
         }
@@ -274,6 +283,11 @@ extension Email {
         }
 
         return nil
+    }
+
+    private func hasMessageIDHeaderInAdditionalHeaders() -> Bool {
+        guard let additionalHeaders else { return false }
+        return additionalHeaders.keys.contains(where: Self.isMessageIDHeaderName)
     }
 
     private static func isMessageIDHeaderName(_ key: String) -> Bool {

--- a/Sources/SwiftMail/Extensions/Email+Content.swift
+++ b/Sources/SwiftMail/Extensions/Email+Content.swift
@@ -43,12 +43,13 @@ extension Email {
 
         content += "Subject: \(self.subject)\r\n"
         content += "Date: \(Self.rfc2822Date())\r\n"
-        let msgID = self.messageID ?? .generate(domain: Self.senderDomain(from: self.sender))
+        let msgID = self.messageID ?? resolvedMessageIDHeader() ?? .generate(domain: Self.senderDomain(from: self.sender))
         content += "Message-Id: \(msgID)\r\n"
         content += "MIME-Version: 1.0\r\n"
 
         if let additionalHeaders {
             for (key, value) in additionalHeaders.sorted(by: { $0.key < $1.key }) {
+                guard !Self.isMessageIDHeaderName(key) else { continue }
                 content += "\(key): \(value)\r\n"
             }
         }
@@ -261,4 +262,24 @@ extension Email {
         }
         return "localhost"
     }
-} 
+
+    private func resolvedMessageIDHeader() -> MessageID? {
+        guard let additionalHeaders else { return nil }
+
+        for (key, value) in additionalHeaders where Self.isMessageIDHeaderName(key) {
+            let trimmedValue = value.trimmingCharacters(in: .whitespacesAndNewlines)
+            if let messageID = MessageID(trimmedValue) {
+                return messageID
+            }
+        }
+
+        return nil
+    }
+
+    private static func isMessageIDHeaderName(_ key: String) -> Bool {
+        key.trimmingCharacters(in: .whitespacesAndNewlines).compare(
+            "message-id",
+            options: [.caseInsensitive]
+        ) == .orderedSame
+    }
+}

--- a/Tests/SwiftSMTPTests/SMTPTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPTests.swift
@@ -315,4 +315,46 @@ struct SMTPTests {
         #expect(MessageID("local@") == nil)
         #expect(MessageID("") == nil)
     }
+
+    @Test
+    func testConstructContentUsesAdditionalHeaderMessageIDExactlyOnce() {
+        var email = Email(
+            sender: EmailAddress(address: "sender@example.com"),
+            recipients: [EmailAddress(address: "recipient@example.com")],
+            subject: "Hello",
+            textBody: "Body"
+        )
+        email.additionalHeaders = [
+            "Message-ID": "<provided@example.com>",
+            "X-Test-Header": "present"
+        ]
+
+        let content = email.constructContent()
+        let messageIDHeaders = content
+            .components(separatedBy: "\r\n")
+            .filter { $0.lowercased().hasPrefix("message-id:") }
+
+        #expect(messageIDHeaders.count == 1)
+        #expect(messageIDHeaders.first == "Message-Id: <provided@example.com>")
+        #expect(content.contains("X-Test-Header: present"))
+    }
+
+    @Test
+    func testConstructContentTreatsAdditionalHeaderMessageIDCaseInsensitively() {
+        var email = Email(
+            sender: EmailAddress(address: "sender@example.com"),
+            recipients: [EmailAddress(address: "recipient@example.com")],
+            subject: "Hello",
+            textBody: "Body"
+        )
+        email.additionalHeaders = ["message-id": "<lowercase@example.com>"]
+
+        let content = email.constructContent()
+        let messageIDHeaders = content
+            .components(separatedBy: "\r\n")
+            .filter { $0.lowercased().hasPrefix("message-id:") }
+
+        #expect(messageIDHeaders.count == 1)
+        #expect(messageIDHeaders.first == "Message-Id: <lowercase@example.com>")
+    }
 }

--- a/Tests/SwiftSMTPTests/SMTPTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPTests.swift
@@ -357,4 +357,43 @@ struct SMTPTests {
         #expect(messageIDHeaders.count == 1)
         #expect(messageIDHeaders.first == "Message-Id: <lowercase@example.com>")
     }
+
+    @Test
+    func testConstructContentMessageIDPropertyWinsOverAdditionalHeaderMessageID() {
+        var email = Email(
+            sender: EmailAddress(address: "sender@example.com"),
+            recipients: [EmailAddress(address: "recipient@example.com")],
+            subject: "Hello",
+            textBody: "Body"
+        )
+        email.messageID = MessageID(localPart: "typed", domain: "example.com")
+        email.additionalHeaders = ["Message-ID": "<raw@example.com>"]
+
+        let content = email.constructContent()
+        let messageIDHeaders = content
+            .components(separatedBy: "\r\n")
+            .filter { $0.lowercased().hasPrefix("message-id:") }
+
+        #expect(messageIDHeaders.count == 1)
+        #expect(messageIDHeaders.first == "Message-Id: <typed@example.com>")
+    }
+
+    @Test
+    func testConstructContentPreservesRawAdditionalHeaderMessageIDWhenUnparseable() {
+        var email = Email(
+            sender: EmailAddress(address: "sender@example.com"),
+            recipients: [EmailAddress(address: "recipient@example.com")],
+            subject: "Hello",
+            textBody: "Body"
+        )
+        email.additionalHeaders = ["Message-ID": "not a valid message id"]
+
+        let content = email.constructContent()
+        let messageIDHeaders = content
+            .components(separatedBy: "\r\n")
+            .filter { $0.lowercased().hasPrefix("message-id:") }
+
+        #expect(messageIDHeaders.count == 1)
+        #expect(messageIDHeaders.first == "Message-ID: not a valid message id")
+    }
 }


### PR DESCRIPTION
## Summary
- honor `additionalHeaders["Message-ID"]` as a compatibility fallback when `email.messageID` is unset
- avoid re-emitting the provided header a second time during additional header serialization
- preserve raw `Message-ID` pass-through when the additional-header value is not parseable as a typed `MessageID`
- add tests for exact-once behavior, typed-property precedence, case-insensitive matching, and the unparseable-header case

## Why
PR #121 allowed callers to pre-set a `Message-Id` via `additionalHeaders`, but current `main` still writes the generated or typed `Message-Id` header first and then appends all additional headers verbatim. If a caller uses `additionalHeaders["Message-ID"]` without `email.messageID`, the serialized message can still contain duplicate `Message-Id` headers.

This keeps the newer `email.messageID` API as the preferred path while preserving the documented older behavior for existing callers, including raw additional-header pass-through when the value does not round-trip through the typed `MessageID` parser.

## Validation
- `swift test --filter SMTPTests`