### PR TITLE
fix: trim whitespace in MessageID parser before angle bracket check

### DIFF
--- a/Sources/SwiftMail/Core/Models/MessageID.swift
+++ b/Sources/SwiftMail/Core/Models/MessageID.swift
@@ -37,7 +37,8 @@ extension MessageID {
     /// Parse a Message-ID string in `<localPart@domain>` format.
     /// Returns `nil` if the string doesn't match the expected format.
     public init?(_ string: String) {
-        var s = string
+        // Trim whitespace first — IMAP ENVELOPE can return " <id@domain>" with leading space
+        var s = string.trimmingCharacters(in: .whitespaces)
         // Strip optional angle brackets
         if s.hasPrefix("<") { s.removeFirst() }
         if s.hasSuffix(">") { s.removeLast() }


### PR DESCRIPTION
## Summary

IMAP ENVELOPE responses can return Message-ID values with leading whitespace (e.g., `" <id@domain>"`). The current `MessageID.init?(_:)` parser checks `hasPrefix("<")` immediately, which fails when whitespace is present. This causes the angle brackets to remain in the parsed local part, producing malformed IDs.

**Fix:** Add `.trimmingCharacters(in: .whitespaces)` before the angle bracket stripping logic.

## Details

- **File:** `Sources/SwiftMail/Core/Models/MessageID.swift`
- **Root cause:** Some IMAP servers include whitespace before the `<` in ENVELOPE Message-ID fields
- **Impact:** Without trimming, `hasPrefix("<")` returns false, so `<` and `>` are kept as part of `localPart`/`domain`, breaking equality checks and thread matching
- **Change:** One line — trim whitespace before existing bracket logic

## Test plan

- [x] Verified with real IMAP servers that return whitespace-prefixed Message-IDs
- [ ] Existing `MessageIDTests` continue to pass (no behavior change for well-formed inputs)