### PR TITLE
fix: prevent NIO promise leak crash in SMTP disconnect

### DIFF
--- a/Sources/SwiftMail/SMTP/SMTPServer.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer.swift
@@ -347,17 +347,20 @@ public actor SMTPServer {
             logger.warning("Attempted to disconnect when channel was already nil")
             return
         }
-        
-		// Use QuitCommand instead of directly sending a string
-		let quitCommand = QuitCommand()
-		
-		// Execute the QUIT command - it has its own timeout set to 10 seconds
-		try await executeCommand(quitCommand)
-        
+
+		// Send QUIT as a courtesy — ignore failures since the email is already sent.
+		// The channel close below will clean up regardless.
+		do {
+			let quitCommand = QuitCommand()
+			try await executeCommand(quitCommand)
+		} catch {
+			logger.warning("QUIT command failed (non-fatal): \(error)")
+		}
+
         // Close the channel regardless of QUIT command result
-        channel.close(promise: nil)
+        try? await channel.close().get()
         self.channel = nil
-        
+
         logger.info("Disconnected from SMTP server")
     }
     


### PR DESCRIPTION
## Summary
- `disconnect()` sends QUIT as a courtesy but previously let failures propagate
- If the channel closed before the QUIT response arrived, the unfulfilled `EventLoopPromise` triggered `fatalError` in NIO's `deinit` ("leaking promise")
- Now QUIT failures are caught and logged as warnings (non-fatal), and channel close uses `try? await channel.close().get()` instead of fire-and-forget

## Context
This crashed the app after every successful SMTP send. The email was delivered, but the crash during disconnect prevented the caller from recording success, leading to duplicate sends on retry.

## Test plan
- [ ] Send an email via SMTP and verify no crash on disconnect
- [ ] Verify QUIT command still sent when server responds in time
- [ ] Verify graceful handling when server drops connection before QUIT response

🤖 Generated with [Claude Code](https://claude.com/claude-code)