### PR TITLE
feat: add LocalizedError conformance to SMTPError

### DIFF
--- a/Sources/SwiftMail/SMTP/SMTPError.swift
+++ b/Sources/SwiftMail/SMTP/SMTPError.swift
@@ -37,6 +37,11 @@ public enum SMTPError: Error {
     case unexpectedResponse(SMTPResponse)
 }
 
+// LocalizedError so .localizedDescription returns the real message (not just "error N")
+extension SMTPError: LocalizedError {
+    public var errorDescription: String? { description }
+}
+
 // Add CustomStringConvertible conformance for better error messages
 extension SMTPError: CustomStringConvertible {
     public var description: String {

--- a/Tests/SwiftSMTPTests/SMTPTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPTests.swift
@@ -396,4 +396,30 @@ struct SMTPTests {
         #expect(messageIDHeaders.count == 1)
         #expect(messageIDHeaders.first == "Message-ID: not a valid message id")
     }
+
+    // MARK: - SMTPError LocalizedError
+
+    @Test
+    func testSMTPErrorLocalizedDescriptionReturnsRealMessage() {
+        let error: Error = SMTPError.connectionFailed("Connection refused")
+        #expect(error.localizedDescription == "SMTP connection failed: Connection refused")
+    }
+
+    @Test
+    func testSMTPErrorLocalizedDescriptionForAllCases() {
+        let cases: [(SMTPError, String)] = [
+            (.connectionFailed("timeout"), "SMTP connection failed: timeout"),
+            (.invalidResponse("garbled"), "SMTP invalid response: garbled"),
+            (.sendFailed("broken pipe"), "SMTP send failed: broken pipe"),
+            (.authenticationFailed("bad creds"), "SMTP authentication failed: bad creds"),
+            (.commandFailed("550 denied"), "SMTP command failed: 550 denied"),
+            (.invalidEmailAddress("bad@"), "SMTP invalid email address: bad@"),
+            (.tlsFailed("handshake"), "SMTP TLS failed: handshake"),
+            (.messageTooLarge(messageSizeOctets: 100, maximumMessageSizeOctets: 50), "SMTP message too large: 100 bytes exceeds 50 byte limit"),
+        ]
+        for (error, expected) in cases {
+            let asError: Error = error
+            #expect(asError.localizedDescription == expected)
+        }
+    }
 }


### PR DESCRIPTION
## Summary
- `SMTPError` had `CustomStringConvertible` but not `LocalizedError`
- Swift's `.localizedDescription` ignores `description` and returns generic "The operation couldn't be completed. (SwiftMail.SMTPError error 0.)" — the case index, not the message
- Added `LocalizedError` conformance that delegates `errorDescription` to the existing `description`

## Context
When catching `SMTPError` as `Error` and logging `.localizedDescription`, the actual error reason (e.g., "SMTP connection failed: timeout") was lost. This made SMTP failures impossible to diagnose from error logs.

## Test plan
- [ ] Catch an `SMTPError` as `Error` and verify `.localizedDescription` returns the real message
- [ ] Verify `String(describing:)` still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)