### PR TITLE
Add certificateVerification parameter to IMAPServer

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -9,6 +9,7 @@ import NIOSSL
 final class IMAPConnection {
     private let host: String
     private let port: Int
+    private let certificateVerification: CertificateVerification
     private let group: EventLoopGroup
     private let connectionID: String
     private let connectionRole: String
@@ -29,6 +30,7 @@ final class IMAPConnection {
     init(
         host: String,
         port: Int,
+        certificateVerification: CertificateVerification = .fullVerification,
         group: EventLoopGroup,
         loggerLabel: String,
         outboundLabel: String,
@@ -38,6 +40,7 @@ final class IMAPConnection {
     ) {
         self.host = host
         self.port = port
+        self.certificateVerification = certificateVerification
         self.group = group
         self.connectionID = connectionID
         self.connectionRole = connectionRole
@@ -133,7 +136,9 @@ final class IMAPConnection {
         idleHandler = nil
         idleTerminationInProgress = false
 
-        let sslContext = try NIOSSLContext(configuration: TLSConfiguration.makeClientConfiguration())
+        var tlsConfig = TLSConfiguration.makeClientConfiguration()
+        tlsConfig.certificateVerification = self.certificateVerification
+        let sslContext = try NIOSSLContext(configuration: tlsConfig)
         let host = self.host
 
         let duplexLogger = self.duplexLogger

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -3,6 +3,7 @@ import Logging
 @preconcurrency import NIOIMAP
 import NIOIMAPCore
 import NIO
+import NIOSSL
 import OrderedCollections
 
 /**
@@ -32,10 +33,13 @@ public actor IMAPServer {
 
     /** The hostname of the IMAP server */
     private let host: String
-    
+
     /** The port number of the IMAP server */
     private let port: Int
-    
+
+    /** Whether to verify TLS certificates */
+    private let verifyCertificates: Bool
+
     /** The event loop group for handling asynchronous operations */
     private let group: EventLoopGroup
 
@@ -121,11 +125,12 @@ public actor IMAPServer {
      that may contain thousands of message IDs. This prevents PayloadTooLargeError when
      searching large mailboxes.
      */
-    public init(host: String, port: Int, numberOfThreads: Int = 1) {
+    public init(host: String, port: Int, verifyCertificates: Bool = true, numberOfThreads: Int = 1) {
         self.host = host
         self.port = port
+        self.verifyCertificates = verifyCertificates
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: numberOfThreads)
-        
+
         // Initialize loggers
         self.logger = Logging.Logger(label: "com.cocoanetics.SwiftMail.IMAPServer")
 
@@ -135,6 +140,7 @@ public actor IMAPServer {
         self.primaryConnection = IMAPConnection(
             host: host,
             port: port,
+            certificateVerification: verifyCertificates ? .fullVerification : .none,
             group: group,
             loggerLabel: primaryLoggerLabel,
             outboundLabel: outboundLabel,
@@ -346,6 +352,7 @@ public actor IMAPServer {
         return IMAPConnection(
             host: host,
             port: port,
+            certificateVerification: verifyCertificates ? .fullVerification : .none,
             group: group,
             loggerLabel: loggerLabel,
             outboundLabel: outboundLabel,
@@ -367,6 +374,7 @@ public actor IMAPServer {
         return IMAPConnection(
             host: host,
             port: port,
+            certificateVerification: verifyCertificates ? .fullVerification : .none,
             group: group,
             loggerLabel: loggerLabel,
             outboundLabel: outboundLabel,


### PR DESCRIPTION
I wanted to run a UI test against a local mock IMAP server but currently this needs valid TLS certificates. This option makes it possible to turn off certificate validation.

Allow callers to configure TLS certificate verification mode (e.g. .none for testing with self-signed certificates). Defaults to .fullVerification for backward compatibility.

Let me know if there's a preferable way to do this