### PR TITLE
Fix leaking EventLoopPromise in connect, IDLE, and SMTP

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -225,7 +225,15 @@ final class IMAPConnection {
                 }
             }
 
-        let channel = try await bootstrap.connect(host: host, port: port).get()
+        let channel: Channel
+        do {
+            channel = try await bootstrap.connect(host: host, port: port).get()
+        } catch {
+            // Fail the greeting promise before rethrowing — prevents NIO "leaking promise"
+            // fatal error when TCP connection fails (e.g. no internet).
+            greetingPromise.fail(error)
+            throw error
+        }
         self.channel = channel
         self.isSessionAuthenticated = false
         self.namespaces = nil
@@ -834,6 +842,8 @@ final class IMAPConnection {
         } catch {
             responseBuffer.hasActiveHandler = false
             idleHandler = nil
+            // Ensure the promise is resolved to prevent NIO "leaking promise" fatal error
+            promise.fail(error)
             if !handler.isCompleted {
                 try? await channel.pipeline.removeHandler(handler)
             }

--- a/Sources/SwiftMail/SMTP/SMTPServer.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer.swift
@@ -588,7 +588,10 @@ public actor SMTPServer {
 		} catch {
 			// Cancel the timeout
 			scheduledTask.cancel()
-			
+
+			// Ensure the promise is resolved to prevent NIO "leaking promise" fatal error
+			resultPromise.fail(error)
+
 			// If it's a timeout error, throw a more specific error
 			if error is SMTPError {
 				throw error


### PR DESCRIPTION
## Summary

Three places create an `EventLoopPromise` but fail to resolve it when an early error occurs, causing NIO's debug-mode `deinit` to `fatalError` with **"leaking promise created at ..."**.

- **`IMAPConnection.connectBody()`** — `greetingPromise` leaks when `bootstrap.connect()` throws (e.g. `NIOConnectionError` when offline). The promise is created before `connect()` so the greeting handler can be installed in `channelInitializer`, but if TCP fails the promise is never fulfilled.
- **`IMAPConnection.startIdleSession()`** — `promise` leaks when `addHandler` or `writeAndFlush` throws (connection died mid-IDLE setup).
- **`SMTPServer.executeCommand()`** — `resultPromise` leaks when `addHandler` or `writeAndFlush` throws. The IMAP equivalent (`executeCommand`) already had this fix; the SMTP version was missed.

All three fixes call `promise.fail(error)` before rethrowing. This is safe even if the promise was already resolved — NIO ignores redundant completions.

## Reproduction

1. Run an app using SwiftMail in **debug mode**
2. Disconnect from the internet (airplane mode / disable Wi-Fi)
3. Trigger an IMAP connection attempt
4. Crash: `fatalError("leaking promise created at (file: "SwiftMail/IMAPConnection.swift", line: 195)")`

## Test plan

- [ ] Verify app no longer crashes when connecting with no internet (airplane mode)
- [ ] Verify IDLE session setup failures don't crash on connection drop
- [ ] Verify SMTP command failures don't crash on connection drop
- [ ] Verify normal IMAP/SMTP operations still work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)