### PR TITLE
[codex] Finish IMAP SORT integration

### DIFF
--- a/Demos/SwiftIMAPCLI/main.swift
+++ b/Demos/SwiftIMAPCLI/main.swift
@@ -448,6 +448,9 @@ struct Search: ParsableCommand {
     
     @ArgumentParser.Flag(help: "Use OR instead of AND across all criteria")
     var any: Bool = false
+
+    @Option(help: "Sort key (repeatable). Prefix with '-' for descending, e.g. --sort -date --sort subject")
+    var sort: [String] = []
     
     @Option(help: "Attachment file extension to match (repeatable, e.g. pdf, docx)")
     var attachment: [String] = []
@@ -549,6 +552,44 @@ struct Search: ParsableCommand {
         )
     }
 
+    private func buildSortCriteria() throws -> [SortCriterion] {
+        try sort.map { rawValue in
+            let trimmed = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+            guard !trimmed.isEmpty else {
+                throw ValidationError("Empty --sort value is not allowed.")
+            }
+
+            let descending = trimmed.hasPrefix("-")
+            let normalized = (descending ? String(trimmed.dropFirst()) : trimmed).lowercased()
+
+            let key: SortCriterion.Key
+            switch normalized {
+            case "arrival":
+                key = .arrival
+            case "cc":
+                key = .cc
+            case "date":
+                key = .date
+            case "from":
+                key = .from
+            case "size":
+                key = .size
+            case "subject":
+                key = .subject
+            case "to":
+                key = .to
+            case "displayfrom", "display-from":
+                key = .displayFrom
+            case "displayto", "display-to":
+                key = .displayTo
+            default:
+                throw ValidationError("Unsupported --sort value: \(rawValue). Supported values: arrival, cc, date, from, size, subject, to, displayfrom, displayto. Prefix with '-' for descending.")
+            }
+
+            return descending ? .descending(key) : .ascending(key)
+        }
+    }
+
     func run() throws {
         runAsyncBlock {
             try await withServer { server in
@@ -556,15 +597,29 @@ struct Search: ParsableCommand {
                 
                 print("Building search criteria...")
                 let criteria = try buildCriteria()
-                print("Running IMAP SEARCH...")
-                let uids: MessageIdentifierSet<UID> = try await server.search(criteria: criteria)
+                let sortCriteria = try buildSortCriteria()
+                let sortDescription = sortCriteria.isEmpty ? "none" : sort.map { $0 }.joined(separator: ", ")
+                print("Running IMAP SEARCH (sort: \(sortDescription))...")
+                let searchResult: ExtendedSearchResult<UID> = try await server.extendedSearch(
+                    criteria: criteria,
+                    sortCriteria: sortCriteria
+                )
+                let uids = searchResult.all ?? MessageIdentifierSet<UID>()
                 let attachmentExts = attachmentExtensions()
                 let criteriaDescription = any ? "OR" : "AND"
                 print("Found \(uids.count) messages matching \(criteriaDescription) criteria")
                 
                 if !uids.isEmpty {
-                     print("Fetching messages for results...")
-                     for try await message in server.fetchMessages(using: uids) {
+                    let orderedUIDs = searchResult.ordered ?? uids.toArray()
+                    print("Fetching messages for results...")
+                    for uid in orderedUIDs {
+                        guard let header = try await server.fetchMessageInfo(for: uid) else {
+                            continue
+                        }
+                        let message = try await server.fetchMessage(from: header)
+                        if message.uid == nil {
+                            continue
+                        }
                         if !attachmentExts.isEmpty {
                             let hasMatch = message.attachments.contains { part in
                                 guard let filename = part.filename?.lowercased() else { return false }
@@ -574,8 +629,8 @@ struct Search: ParsableCommand {
                                 continue
                             }
                         }
-                        
-                        let uidValue = message.uid?.value ?? 0
+
+                        let uidValue = message.uid?.value ?? uid.value
                         print("--- UID \(uidValue) ---")
                         print("From: \(message.from ?? "")")
                         let toList = message.to.joined(separator: ", ")

--- a/Package.resolved
+++ b/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-imap",
       "state" : {
-        "revision" : "0a471f59b2632d04a5f4274e3b94db0d2fc7c839",
-        "version" : "0.2.0"
+        "branch" : "main",
+        "revision" : "9c56edfa19397712b5d9f088cf674a5f5dcec4c4"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -27,7 +27,7 @@ let package = Package(
         .package(url: "https://github.com/thebarndog/swift-dotenv", from: "2.1.0"),
 		.package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.0.0"),
-        .package(url: "https://github.com/apple/swift-nio-imap", from: "0.2.0"),
+        .package(url: "https://github.com/apple/swift-nio-imap", branch: "main"),
         .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-testing", exact: "0.12.0"),

--- a/Sources/SwiftMail/IMAP/Capability+Sort.swift
+++ b/Sources/SwiftMail/IMAP/Capability+Sort.swift
@@ -1,0 +1,13 @@
+import NIOIMAPCore
+
+extension Set where Element == NIOIMAPCore.Capability {
+    func supportsSort(criteria: [SortCriterion]) -> Bool {
+        guard !criteria.isEmpty else { return false }
+
+        if criteria.contains(where: \.requiresDisplaySortCapability) {
+            return self.contains(.sort(.display))
+        }
+
+        return self.contains(.sort(nil)) || self.contains(.sort(.display))
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAP/Commands/ExtendedSearchCommand.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/ExtendedSearchCommand.swift
@@ -17,8 +17,14 @@ struct ExtendedSearchCommand<T: MessageIdentifier>: IMAPTaggedCommand, Sendable 
     let identifierSet: MessageIdentifierSet<T>?
     /// Criteria that all messages must satisfy.
     let criteria: [SearchCriteria]
+    /// Optional server-side sort criteria.
+    let sortCriteria: [SortCriterion]
+    /// Charset used when emitting `SORT`.
+    let sortCharset: String
     /// Calendar used for date-to-day conversions.
     let calendar: Calendar
+    /// Whether to issue SORT/UID SORT instead of SEARCH/UID SEARCH.
+    let useSort: Bool
     /// Whether the server supports ESEARCH (determines which command is sent).
     let useEsearch: Bool
     /// Optional window for paged (PARTIAL) results. Only used when `useEsearch` is true.
@@ -30,13 +36,19 @@ struct ExtendedSearchCommand<T: MessageIdentifier>: IMAPTaggedCommand, Sendable 
     init(
         identifierSet: MessageIdentifierSet<T>? = nil,
         criteria: [SearchCriteria],
+        sortCriteria: [SortCriterion] = [],
+        sortCharset: String = "UTF-8",
         calendar: Calendar = Calendar(identifier: .gregorian),
+        useSort: Bool = false,
         useEsearch: Bool,
         partialRange: NIOIMAPCore.PartialRange? = nil
     ) {
         self.identifierSet = identifierSet
         self.criteria = criteria
+        self.sortCriteria = sortCriteria
+        self.sortCharset = sortCharset
         self.calendar = calendar
+        self.useSort = useSort
         self.useEsearch = useEsearch
         self.partialRange = partialRange
     }
@@ -44,6 +56,9 @@ struct ExtendedSearchCommand<T: MessageIdentifier>: IMAPTaggedCommand, Sendable 
     func validate() throws {
         guard !criteria.isEmpty else {
             throw IMAPError.invalidArgument("Search criteria cannot be empty")
+        }
+        guard !useSort || !sortCriteria.isEmpty else {
+            throw IMAPError.invalidArgument("Sort criteria cannot be empty when SORT is enabled")
         }
         for criterion in criteria { try criterion.validate() }
     }
@@ -74,7 +89,13 @@ struct ExtendedSearchCommand<T: MessageIdentifier>: IMAPTaggedCommand, Sendable 
             returnOptions = []
         }
 
-        if T.self == UID.self {
+        if useSort {
+            if T.self == UID.self {
+                return TaggedCommand(tag: tag, command: .uidSort(criteria: sortCriteria, charset: sortCharset, key: key, returnOptions: returnOptions))
+            } else {
+                return TaggedCommand(tag: tag, command: .sort(criteria: sortCriteria, charset: sortCharset, key: key, returnOptions: returnOptions))
+            }
+        } else if T.self == UID.self {
             return TaggedCommand(tag: tag, command: .uidSearch(key: key, returnOptions: returnOptions))
         } else {
             return TaggedCommand(tag: tag, command: .search(key: key, returnOptions: returnOptions))

--- a/Sources/SwiftMail/IMAP/IMAP/Commands/SearchCommand.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/SearchCommand.swift
@@ -20,6 +20,12 @@ struct SearchCommand<T: MessageIdentifier>: IMAPTaggedCommand, Sendable {
     let identifierSet: MessageIdentifierSet<T>?
     /// Criteria that all messages must satisfy.
     let criteria: [SearchCriteria]
+    /// Optional server-side sort criteria.
+    let sortCriteria: [SortCriterion]
+    /// Charset used when emitting `SORT`.
+    let sortCharset: String
+    /// Whether the server-side `SORT` command should be used.
+    let useSort: Bool
     /// Calendar used for date-to-day conversions in search criteria.
     let calendar: Calendar
 
@@ -33,9 +39,19 @@ struct SearchCommand<T: MessageIdentifier>: IMAPTaggedCommand, Sendable {
        - criteria: The search criteria to apply.
        - calendar: The calendar used for date-to-day conversions. Defaults to the Gregorian calendar.
      */
-    init(identifierSet: MessageIdentifierSet<T>? = nil, criteria: [SearchCriteria], calendar: Calendar = Calendar(identifier: .gregorian)) {
+    init(
+        identifierSet: MessageIdentifierSet<T>? = nil,
+        criteria: [SearchCriteria],
+        sortCriteria: [SortCriterion] = [],
+        sortCharset: String = "UTF-8",
+        useSort: Bool = false,
+        calendar: Calendar = Calendar(identifier: .gregorian)
+    ) {
         self.identifierSet = identifierSet
         self.criteria = criteria
+        self.sortCriteria = sortCriteria
+        self.sortCharset = sortCharset
+        self.useSort = useSort
         self.calendar = calendar
     }
 
@@ -43,6 +59,9 @@ struct SearchCommand<T: MessageIdentifier>: IMAPTaggedCommand, Sendable {
     func validate() throws {
         guard !criteria.isEmpty else {
             throw IMAPError.invalidArgument("Search criteria cannot be empty")
+        }
+        guard !useSort || !sortCriteria.isEmpty else {
+            throw IMAPError.invalidArgument("Sort criteria cannot be empty when SORT is enabled")
         }
         for criterion in criteria { try criterion.validate() }
     }
@@ -64,10 +83,18 @@ struct SearchCommand<T: MessageIdentifier>: IMAPTaggedCommand, Sendable {
             nioCriteria.insert(scopeKey, at: 0)
         }
 
-        if T.self == UID.self {
-            return TaggedCommand(tag: tag, command: .uidSearch(key: .and(nioCriteria)))
+        let key = SearchKey.and(nioCriteria)
+
+        if useSort {
+            if T.self == UID.self {
+                return TaggedCommand(tag: tag, command: .uidSort(criteria: sortCriteria, charset: sortCharset, key: key))
+            } else {
+                return TaggedCommand(tag: tag, command: .sort(criteria: sortCriteria, charset: sortCharset, key: key))
+            }
+        } else if T.self == UID.self {
+            return TaggedCommand(tag: tag, command: .uidSearch(key: key))
         } else {
-            return TaggedCommand(tag: tag, command: .search(key: .and(nioCriteria)))
+            return TaggedCommand(tag: tag, command: .search(key: key))
         }
     }
 }

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/ExtendedSearchHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/ExtendedSearchHandler.swift
@@ -17,6 +17,7 @@ final class ExtendedSearchHandler<T: MessageIdentifier>: BaseIMAPCommandHandler<
 
     // Accumulated results from a plain SEARCH response (fallback path).
     private var fallbackIdentifiers: [T] = []
+    private var fallbackOrderedIdentifiers: [T] = []
 
     // Results accumulated from an ESEARCH response.
     private var esearchCount: Int?
@@ -77,6 +78,15 @@ final class ExtendedSearchHandler<T: MessageIdentifier>: BaseIMAPCommandHandler<
            case let .search(ids, _) = mailboxData {
             let converted = ids.map { T(UInt32($0)) }
             fallbackIdentifiers.append(contentsOf: converted)
+            fallbackOrderedIdentifiers.append(contentsOf: converted)
+        }
+
+        if case let .untagged(untagged) = response,
+           case let .mailboxData(mailboxData) = untagged,
+           case let .sort(ids, _) = mailboxData {
+            let converted = ids.map { T(UInt32($0)) }
+            fallbackIdentifiers.append(contentsOf: converted)
+            fallbackOrderedIdentifiers.append(contentsOf: converted)
         }
 
         return handled
@@ -106,7 +116,8 @@ final class ExtendedSearchHandler<T: MessageIdentifier>: BaseIMAPCommandHandler<
                 count: count,
                 min: fallbackIdentifiers.min(),
                 max: fallbackIdentifiers.max(),
-                all: identifierSet.isEmpty ? nil : identifierSet
+                all: identifierSet.isEmpty ? nil : identifierSet,
+                ordered: fallbackOrderedIdentifiers.isEmpty ? nil : fallbackOrderedIdentifiers
             )
         }
 

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/IdleHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/IdleHandler.swift
@@ -85,6 +85,8 @@ final class IdleHandler: BaseIMAPCommandHandler<Void>, IMAPCommandHandler, @unch
                 idleLogger.debug("IdleHandler: ignoring unsolicited STATUS for mailbox '\(name)'")
             case .search:
                 idleLogger.debug("IdleHandler: ignoring unsolicited SEARCH response during IDLE")
+            case .sort:
+                idleLogger.debug("IdleHandler: ignoring unsolicited SORT response during IDLE")
             case .list:
                 idleLogger.debug("IdleHandler: ignoring unsolicited LIST response during IDLE")
             case .lsub:
@@ -93,8 +95,6 @@ final class IdleHandler: BaseIMAPCommandHandler<Void>, IMAPCommandHandler, @unch
                 idleLogger.debug("IdleHandler: ignoring unsolicited ESEARCH response during IDLE")
             case .namespace:
                 idleLogger.debug("IdleHandler: ignoring unsolicited NAMESPACE response during IDLE")
-            case .searchSort:
-                idleLogger.debug("IdleHandler: ignoring unsolicited SEARCH SORT response during IDLE")
             case .uidBatches:
                 idleLogger.debug("IdleHandler: ignoring unsolicited UIDBATCHES response during IDLE")
             }

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/NoopHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/NoopHandler.swift
@@ -73,6 +73,8 @@ final class NoopHandler: BaseIMAPCommandHandler<[IMAPServerEvent]>, IMAPCommandH
                 noopLogger.debug("NoopHandler: ignoring unsolicited STATUS for mailbox '\(name)'")
             case .search:
                 noopLogger.debug("NoopHandler: ignoring unsolicited SEARCH response")
+            case .sort:
+                noopLogger.debug("NoopHandler: ignoring unsolicited SORT response")
             case .list:
                 noopLogger.debug("NoopHandler: ignoring unsolicited LIST response")
             case .lsub:
@@ -81,8 +83,6 @@ final class NoopHandler: BaseIMAPCommandHandler<[IMAPServerEvent]>, IMAPCommandH
                 noopLogger.debug("NoopHandler: ignoring unsolicited ESEARCH response")
             case .namespace:
                 noopLogger.debug("NoopHandler: ignoring unsolicited NAMESPACE response")
-            case .searchSort:
-                noopLogger.debug("NoopHandler: ignoring unsolicited SEARCH SORT response")
             case .uidBatches:
                 noopLogger.debug("NoopHandler: ignoring unsolicited UIDBATCHES response")
             }

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/SearchHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/SearchHandler.swift
@@ -39,14 +39,19 @@ final class SearchHandler<T: MessageIdentifier>: BaseIMAPCommandHandler<MessageI
             }
         }
         
-		// Check for search response data using proper pattern matching
-		if case let .untagged(untagged) = response,
-		   case let .mailboxData(mailboxData) = untagged,
-		   case let .search(ids, _) = mailboxData {
-			// Convert the IDs to the appropriate MessageIdentifier type
-			let results = ids.map { T.init(UInt32($0)) }
-			searchResults.append(contentsOf: results)
-		}
+        if case let .untagged(untagged) = response,
+           case let .mailboxData(mailboxData) = untagged {
+            switch mailboxData {
+            case .search(let ids, _):
+                let results = ids.map { T.init(UInt32($0)) }
+                searchResults.append(contentsOf: results)
+            case .sort(let ids, _):
+                let results = ids.map { T.init(UInt32($0)) }
+                searchResults.append(contentsOf: results)
+            default:
+                break
+            }
+        }
         
         return handled
     }

--- a/Sources/SwiftMail/IMAP/IMAPNamedConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPNamedConnection.swift
@@ -1,4 +1,5 @@
 import Foundation
+@preconcurrency import NIOIMAP
 @preconcurrency import NIOIMAPCore
 
 /// A user-controlled, reusable IMAP connection managed by ``IMAPServer``.
@@ -11,6 +12,7 @@ public actor IMAPNamedConnection {
 
     private let connection: IMAPConnection
     private let authenticateOnConnection: @Sendable (IMAPConnection) async throws -> Void
+    private var selectedMailboxPath: String?
 
     /// The timestamp of the last successfully completed command on this connection.
     /// Useful for implementing staleness checks in ephemeral connection patterns.
@@ -61,8 +63,11 @@ public actor IMAPNamedConnection {
         // Authenticate first so namespacesSnapshot is populated (or repopulated
         // after a reconnect) before we resolve the mailbox path.
         try await ensureAuthenticated()
-        let command = SelectMailboxCommand(mailboxName: resolveMailboxPath(mailboxName))
-        return try await executeCommand(command)
+        let resolvedMailboxPath = resolveMailboxPath(mailboxName)
+        let command = SelectMailboxCommand(mailboxName: resolvedMailboxPath)
+        let selection = try await executeCommand(command)
+        selectedMailboxPath = resolvedMailboxPath
+        return selection
     }
 
     /// Compatibility alias for selecting a mailbox.
@@ -75,6 +80,7 @@ public actor IMAPNamedConnection {
     public func closeMailbox() async throws {
         let command = CloseCommand()
         try await executeCommand(command)
+        selectedMailboxPath = nil
     }
 
     /// Unselect the currently selected mailbox without expunging.
@@ -85,6 +91,7 @@ public actor IMAPNamedConnection {
 
         let command = UnselectCommand()
         try await executeCommand(command)
+        selectedMailboxPath = nil
     }
 
     /// Start IDLE and receive server events.
@@ -179,12 +186,52 @@ public actor IMAPNamedConnection {
     }
 
     /// Search within the selected mailbox.
+    @available(
+        *,
+        deprecated,
+        message: "Use extendedSearch(...) for structured results or search(..., sortCriteria:) for ordered results."
+    )
     public func search<T: MessageIdentifier>(
         identifierSet: MessageIdentifierSet<T>? = nil,
-        criteria: [SearchCriteria]
+        criteria: [SearchCriteria],
+        calendar: Calendar = Calendar(identifier: .gregorian)
     ) async throws -> MessageIdentifierSet<T> {
-        let command = SearchCommand(identifierSet: identifierSet, criteria: criteria)
+        if criteria.contains(where: { $0.requiresWithin }) && !capabilities.contains(.within) {
+            throw IMAPError.commandNotSupported("WITHIN extension not supported by server (required for OLDER/YOUNGER search)")
+        }
+        let command = SearchCommand(
+            identifierSet: identifierSet,
+            criteria: criteria,
+            calendar: calendar
+        )
         return try await executeCommand(command)
+    }
+
+    /// Search within the selected mailbox and preserve server sort order.
+    public func search<T: MessageIdentifier>(
+        identifierSet: MessageIdentifierSet<T>? = nil,
+        criteria: [SearchCriteria],
+        sortCriteria: [SortCriterion],
+        sortCharset: String = "UTF-8",
+        calendar: Calendar = Calendar(identifier: .gregorian)
+    ) async throws -> [T] {
+        let result = try await extendedSearch(
+            identifierSet: identifierSet,
+            criteria: criteria,
+            sortCriteria: sortCriteria,
+            sortCharset: sortCharset,
+            calendar: calendar
+        )
+
+        if let ordered = result.ordered {
+            return ordered
+        }
+
+        if let partial = result.partial {
+            return partial.results.toArray()
+        }
+
+        return result.all?.toArray() ?? []
     }
 
     /// Search within the selected mailbox, returning structured ESEARCH results (RFC 4731).
@@ -196,12 +243,63 @@ public actor IMAPNamedConnection {
     public func extendedSearch<T: MessageIdentifier>(
         identifierSet: MessageIdentifierSet<T>? = nil,
         criteria: [SearchCriteria],
+        sortCriteria: [SortCriterion] = [],
+        sortCharset: String = "UTF-8",
         calendar: Calendar = Calendar(identifier: .gregorian),
         partialRange: PartialRange? = nil
     ) async throws -> ExtendedSearchResult<T> {
-        let useEsearch = capabilities.contains(.extendedSearch)
-        let command = ExtendedSearchCommand<T>(identifierSet: identifierSet, criteria: criteria, calendar: calendar, useEsearch: useEsearch, partialRange: partialRange)
-        return try await executeCommand(command)
+        if criteria.contains(where: { $0.requiresWithin }) && !capabilities.contains(.within) {
+            throw IMAPError.commandNotSupported("WITHIN extension not supported by server (required for OLDER/YOUNGER search)")
+        }
+        let useSort = capabilities.supportsSort(criteria: sortCriteria)
+        if !useSort && sortCriteria.contains(where: \.requiresDisplaySortCapability) {
+            throw IMAPError.commandNotSupported("DISPLAY sort requires SORT=DISPLAY capability")
+        }
+        let useEsearch = capabilities.contains(.extendedSearch) && (!useSort || partialRange != nil)
+        let command = ExtendedSearchCommand<T>(
+            identifierSet: identifierSet,
+            criteria: criteria,
+            sortCriteria: sortCriteria,
+            sortCharset: sortCharset,
+            calendar: calendar,
+            useSort: useSort,
+            useEsearch: useEsearch,
+            partialRange: partialRange
+        )
+        do {
+            return try await executeCommand(command)
+        } catch {
+            guard useSort, LocalSortFallback.isSortResponseDecodeFailure(error) else {
+                throw error
+            }
+
+            try await reselectMailboxIfNeeded()
+            let fallback = SearchCommand(
+                identifierSet: identifierSet,
+                criteria: criteria,
+                calendar: calendar
+            )
+            let identifiers: MessageIdentifierSet<T> = try await executeCommand(fallback)
+            guard !identifiers.isEmpty else {
+                return ExtendedSearchResult(count: 0, ordered: [])
+            }
+            let infos = try await fetchMessageInfosBulk(using: identifiers)
+            return try LocalSortFallback.makeExtendedSearchResult(
+                from: infos,
+                as: T.self,
+                sortCriteria: sortCriteria,
+                partialRange: partialRange
+            )
+        }
+    }
+
+    private func reselectMailboxIfNeeded() async throws {
+        guard let selectedMailboxPath else {
+            return
+        }
+
+        let command = SelectMailboxCommand(mailboxName: selectedMailboxPath)
+        _ = try await executeCommand(command)
     }
 
     /// Copy messages to another mailbox.

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -38,6 +38,7 @@ public actor IMAPServer {
 
     /// Explicit TLS preference. `nil` means infer from the standard IMAP port.
     private let useTLS: Bool?
+    private var selectedMailboxPath: String?
     
     /** The event loop group for handling asynchronous operations */
     private let group: EventLoopGroup
@@ -467,8 +468,11 @@ public actor IMAPServer {
      To get the count of unseen messages, use `mailboxStatus("INBOX").unseenCount` instead.
      */
     @discardableResult public func selectMailbox(_ mailboxName: String) async throws -> Mailbox.Selection {
-        let command = SelectMailboxCommand(mailboxName: resolveMailboxPath(mailboxName))
-        return try await executeCommand(command)
+        let resolvedMailboxPath = resolveMailboxPath(mailboxName)
+        let command = SelectMailboxCommand(mailboxName: resolvedMailboxPath)
+        let selection = try await executeCommand(command)
+        selectedMailboxPath = resolvedMailboxPath
+        return selection
     }
     
     /**
@@ -485,6 +489,7 @@ public actor IMAPServer {
     public func closeMailbox() async throws {
         let command = CloseCommand()
         try await executeCommand(command)
+        selectedMailboxPath = nil
     }
     
     /**
@@ -507,6 +512,7 @@ public actor IMAPServer {
         
         let command = UnselectCommand()
         try await executeCommand(command)
+        selectedMailboxPath = nil
     }
     
     // MARK: - Idle
@@ -1238,12 +1244,52 @@ public actor IMAPServer {
      - `IMAPError.connectionFailed` if not connected
      - Note: Logs search operations at debug level with criteria count and results count
      */
-    public func search<T: MessageIdentifier>(identifierSet: MessageIdentifierSet<T>? = nil, criteria: [SearchCriteria], calendar: Calendar = Calendar(identifier: .gregorian)) async throws -> MessageIdentifierSet<T> {
+    @available(
+        *,
+        deprecated,
+        message: "Use extendedSearch(...) for structured results or search(..., sortCriteria:) for ordered results."
+    )
+    public func search<T: MessageIdentifier>(
+        identifierSet: MessageIdentifierSet<T>? = nil,
+        criteria: [SearchCriteria],
+        calendar: Calendar = Calendar(identifier: .gregorian)
+    ) async throws -> MessageIdentifierSet<T> {
         if criteria.contains(where: { $0.requiresWithin }) && !capabilities.contains(.within) {
             throw IMAPError.commandNotSupported("WITHIN extension not supported by server (required for OLDER/YOUNGER search)")
         }
-        let command = SearchCommand(identifierSet: identifierSet, criteria: criteria, calendar: calendar)
+        let command = SearchCommand(
+            identifierSet: identifierSet,
+            criteria: criteria,
+            calendar: calendar
+        )
         return try await executeCommand(command)
+    }
+
+    /// Search the selected mailbox and preserve server sort order.
+    public func search<T: MessageIdentifier>(
+        identifierSet: MessageIdentifierSet<T>? = nil,
+        criteria: [SearchCriteria],
+        sortCriteria: [SortCriterion],
+        sortCharset: String = "UTF-8",
+        calendar: Calendar = Calendar(identifier: .gregorian)
+    ) async throws -> [T] {
+        let result = try await extendedSearch(
+            identifierSet: identifierSet,
+            criteria: criteria,
+            sortCriteria: sortCriteria,
+            sortCharset: sortCharset,
+            calendar: calendar
+        )
+
+        if let ordered = result.ordered {
+            return ordered
+        }
+
+        if let partial = result.partial {
+            return partial.results.toArray()
+        }
+
+        return result.all?.toArray() ?? []
     }
 
     /**
@@ -1270,13 +1316,66 @@ public actor IMAPServer {
        - `IMAPError.commandFailed` if the search operation fails
        - `IMAPError.connectionFailed` if not connected
      */
-    public func extendedSearch<T: MessageIdentifier>(identifierSet: MessageIdentifierSet<T>? = nil, criteria: [SearchCriteria], calendar: Calendar = Calendar(identifier: .gregorian), partialRange: PartialRange? = nil) async throws -> ExtendedSearchResult<T> {
+    public func extendedSearch<T: MessageIdentifier>(
+        identifierSet: MessageIdentifierSet<T>? = nil,
+        criteria: [SearchCriteria],
+        sortCriteria: [SortCriterion] = [],
+        sortCharset: String = "UTF-8",
+        calendar: Calendar = Calendar(identifier: .gregorian),
+        partialRange: PartialRange? = nil
+    ) async throws -> ExtendedSearchResult<T> {
         if criteria.contains(where: { $0.requiresWithin }) && !capabilities.contains(.within) {
             throw IMAPError.commandNotSupported("WITHIN extension not supported by server (required for OLDER/YOUNGER search)")
         }
-        let useEsearch = capabilities.contains(.extendedSearch)
-        let command = ExtendedSearchCommand<T>(identifierSet: identifierSet, criteria: criteria, calendar: calendar, useEsearch: useEsearch, partialRange: partialRange)
-        return try await executeCommand(command)
+        let useSort = capabilities.supportsSort(criteria: sortCriteria)
+        if !useSort && sortCriteria.contains(where: \.requiresDisplaySortCapability) {
+            throw IMAPError.commandNotSupported("DISPLAY sort requires SORT=DISPLAY capability")
+        }
+        let useEsearch = capabilities.contains(.extendedSearch) && (!useSort || partialRange != nil)
+        let command = ExtendedSearchCommand<T>(
+            identifierSet: identifierSet,
+            criteria: criteria,
+            sortCriteria: sortCriteria,
+            sortCharset: sortCharset,
+            calendar: calendar,
+            useSort: useSort,
+            useEsearch: useEsearch,
+            partialRange: partialRange
+        )
+        do {
+            return try await executeCommand(command)
+        } catch {
+            guard useSort, LocalSortFallback.isSortResponseDecodeFailure(error) else {
+                throw error
+            }
+
+            try await reselectMailboxIfNeeded()
+            let fallback = SearchCommand(
+                identifierSet: identifierSet,
+                criteria: criteria,
+                calendar: calendar
+            )
+            let identifiers: MessageIdentifierSet<T> = try await executeCommand(fallback)
+            guard !identifiers.isEmpty else {
+                return ExtendedSearchResult(count: 0, ordered: [])
+            }
+            let infos = try await fetchMessageInfosBulk(using: identifiers)
+            return try LocalSortFallback.makeExtendedSearchResult(
+                from: infos,
+                as: T.self,
+                sortCriteria: sortCriteria,
+                partialRange: partialRange
+            )
+        }
+    }
+
+    private func reselectMailboxIfNeeded() async throws {
+        guard let selectedMailboxPath else {
+            return
+        }
+
+        let command = SelectMailboxCommand(mailboxName: selectedMailboxPath)
+        _ = try await executeCommand(command)
     }
 
 

--- a/Sources/SwiftMail/IMAP/LocalSortFallback.swift
+++ b/Sources/SwiftMail/IMAP/LocalSortFallback.swift
@@ -1,0 +1,222 @@
+import Foundation
+@preconcurrency import NIOIMAP
+import NIOIMAPCore
+
+enum LocalSortFallback {
+    static func isSortResponseDecodeFailure(_ error: Error) -> Bool {
+        guard let decoderError = error as? IMAPDecoderError else {
+            return false
+        }
+
+        var buffer = decoderError.buffer
+        let prefixLength = min(buffer.readableBytes, 32)
+        guard let prefix = buffer.readString(length: prefixLength) else {
+            return false
+        }
+
+        return prefix.hasPrefix("* SORT\r\n") || prefix.hasPrefix("* SORT ")
+    }
+
+    static func makeExtendedSearchResult<T: MessageIdentifier>(
+        from infos: [MessageInfo],
+        as identifierType: T.Type,
+        sortCriteria: [SortCriterion],
+        partialRange: PartialRange? = nil
+    ) throws -> ExtendedSearchResult<T> {
+        if sortCriteria.contains(where: { criterion in
+            if case let .ascending(key) = criterion, key == .size {
+                return true
+            }
+            if case let .descending(key) = criterion, key == .size {
+                return true
+            }
+            return false
+        }) {
+            throw IMAPError.commandFailed("Local SORT fallback does not support SIZE sort criteria")
+        }
+
+        let sortable = try infos.enumerated().map { index, info in
+            let identifier = try identifier(from: info, as: identifierType)
+            return SortableMessage(identifier: identifier, info: info, originalIndex: index)
+        }
+
+        let ordered = sortable.sorted { lhs, rhs in
+            for criterion in sortCriteria {
+                let result = compare(lhs.info, rhs.info, criterion: criterion)
+                if result != .orderedSame {
+                    switch criterion {
+                    case .ascending:
+                        return result == .orderedAscending
+                    case .descending:
+                        return result == .orderedDescending
+                    }
+                }
+            }
+
+            return lhs.originalIndex < rhs.originalIndex
+        }.map(\.identifier)
+
+        let all = MessageIdentifierSet<T>(ordered)
+        let partial = partialRange.map { range in
+            let slice = apply(range, to: ordered)
+            return ExtendedSearchResult<T>.PartialResult(range: range, results: MessageIdentifierSet<T>(slice))
+        }
+
+        return ExtendedSearchResult(
+            count: ordered.count,
+            min: ordered.min(),
+            max: ordered.max(),
+            all: partial == nil ? (all.isEmpty ? nil : all) : nil,
+            ordered: ordered,
+            partial: partial
+        )
+    }
+
+    private struct SortableMessage<T: MessageIdentifier> {
+        let identifier: T
+        let info: MessageInfo
+        let originalIndex: Int
+    }
+
+    private static func identifier<T: MessageIdentifier>(from info: MessageInfo, as _: T.Type) throws -> T {
+        if T.self == UID.self {
+            guard let uid = info.uid else {
+                throw IMAPError.commandFailed("Local SORT fallback requires UIDs for UID-based results")
+            }
+            return T(uid.value)
+        }
+
+        return T(info.sequenceNumber.value)
+    }
+
+    private static func compare(_ lhs: MessageInfo, _ rhs: MessageInfo, criterion: SortCriterion) -> ComparisonResult {
+        let key: SortCriterion.Key
+
+        switch criterion {
+        case .ascending(let sortKey):
+            key = sortKey
+        case .descending(let sortKey):
+            key = sortKey
+        }
+
+        return compare(lhs, rhs, key: key)
+    }
+
+    private static func compare(_ lhs: MessageInfo, _ rhs: MessageInfo, key: SortCriterion.Key) -> ComparisonResult {
+        switch key {
+        case .arrival:
+            return compare(lhs.internalDate, rhs.internalDate)
+        case .cc:
+            return compareStrings(addressMailbox(lhs.cc.first), addressMailbox(rhs.cc.first))
+        case .date:
+            return compare(lhs.date ?? lhs.internalDate, rhs.date ?? rhs.internalDate)
+        case .from:
+            return compareStrings(addressMailbox(lhs.from), addressMailbox(rhs.from))
+        case .size:
+            return .orderedSame
+        case .subject:
+            return compareStrings(baseSubject(lhs.subject), baseSubject(rhs.subject))
+        case .to:
+            return compareStrings(addressMailbox(lhs.to.first), addressMailbox(rhs.to.first))
+        case .displayFrom:
+            return compareStrings(addressDisplay(lhs.from), addressDisplay(rhs.from))
+        case .displayTo:
+            return compareStrings(addressDisplay(lhs.to.first), addressDisplay(rhs.to.first))
+        }
+    }
+
+    private static func compare(_ lhs: Date?, _ rhs: Date?) -> ComparisonResult {
+        let left = lhs ?? .distantPast
+        let right = rhs ?? .distantPast
+
+        if left < right {
+            return .orderedAscending
+        } else if left > right {
+            return .orderedDescending
+        } else {
+            return .orderedSame
+        }
+    }
+
+    private static func compareStrings(_ lhs: String, _ rhs: String) -> ComparisonResult {
+        lhs.caseInsensitiveCompare(rhs)
+    }
+
+    private static func addressMailbox(_ rawValue: String?) -> String {
+        let components = addressComponents(rawValue)
+        return components.mailbox
+    }
+
+    private static func addressDisplay(_ rawValue: String?) -> String {
+        let components = addressComponents(rawValue)
+        return components.display
+    }
+
+    private static func addressComponents(_ rawValue: String?) -> (display: String, mailbox: String) {
+        let value = rawValue?
+            .trimmingCharacters(in: .whitespacesAndNewlines) ?? ""
+
+        guard
+            let leftBracket = value.lastIndex(of: "<"),
+            let rightBracket = value.lastIndex(of: ">"),
+            leftBracket < rightBracket
+        else {
+            return (display: value.lowercased(), mailbox: value.lowercased())
+        }
+
+        let display = value[..<leftBracket]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .trimmingCharacters(in: CharacterSet(charactersIn: "\""))
+            .lowercased()
+        let mailbox = value[value.index(after: leftBracket)..<rightBracket]
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+            .lowercased()
+
+        return (
+            display: display.isEmpty ? mailbox : display,
+            mailbox: mailbox
+        )
+    }
+
+    private static func baseSubject(_ rawValue: String?) -> String {
+        guard let rawValue else {
+            return ""
+        }
+
+        var subject = rawValue.trimmingCharacters(in: .whitespacesAndNewlines)
+        let prefixPattern = "^(?:(?:re|fw|fwd):\\s*)+"
+
+        while let range = subject.range(of: prefixPattern, options: [.regularExpression, .caseInsensitive]) {
+            subject.removeSubrange(range)
+            subject = subject.trimmingCharacters(in: .whitespacesAndNewlines)
+        }
+
+        return subject.lowercased()
+    }
+
+    private static func apply<T>(_ range: PartialRange, to ordered: [T]) -> [T] {
+        guard !ordered.isEmpty else {
+            return []
+        }
+
+        switch range {
+        case .first(let sequenceRange):
+            let start = max(Int(sequenceRange.range.lowerBound.rawValue) - 1, 0)
+            let end = min(Int(sequenceRange.range.upperBound.rawValue), ordered.count)
+            guard start < end else {
+                return []
+            }
+            return Array(ordered[start..<end])
+
+        case .last(let sequenceRange):
+            let lower = Int(sequenceRange.range.lowerBound.rawValue)
+            let upper = Int(sequenceRange.range.upperBound.rawValue)
+            let start = max(ordered.count - upper, 0)
+            let end = min(max(ordered.count - lower + 1, 0), ordered.count)
+            guard start < end else {
+                return []
+            }
+            return Array(ordered[start..<end])
+        }
+    }
+}

--- a/Sources/SwiftMail/IMAP/Models/ExtendedSearchResult.swift
+++ b/Sources/SwiftMail/IMAP/Models/ExtendedSearchResult.swift
@@ -24,6 +24,13 @@ public struct ExtendedSearchResult<T: MessageIdentifier>: Sendable {
     /// All message identifiers matching the search criteria, if requested.
     public let all: MessageIdentifierSet<T>?
 
+    /// Message identifiers in the order returned by the server.
+    ///
+    /// This is populated when SwiftMail synthesises the result from a plain
+    /// `SEARCH` or `SORT` response. For `SORT`, the array preserves the server's
+    /// requested sort order.
+    public let ordered: [T]?
+
     /// A paged subset of results returned when PARTIAL was requested.
     ///
     /// Non-nil only when the command was issued with a ``PartialRange`` and the
@@ -45,12 +52,14 @@ public struct ExtendedSearchResult<T: MessageIdentifier>: Sendable {
         min: T? = nil,
         max: T? = nil,
         all: MessageIdentifierSet<T>? = nil,
+        ordered: [T]? = nil,
         partial: PartialResult? = nil
     ) {
         self.count = count
         self.min = min
         self.max = max
         self.all = all
+        self.ordered = ordered
         self.partial = partial
     }
 }

--- a/Sources/SwiftMail/IMAP/Models/SortCriterion.swift
+++ b/Sources/SwiftMail/IMAP/Models/SortCriterion.swift
@@ -1,0 +1,17 @@
+import NIOIMAPCore
+
+/// Re-exports ``NIOIMAPCore/SortCriterion`` so callers can request server-side
+/// sorting without importing NIOIMAPCore directly.
+public typealias SortCriterion = NIOIMAPCore.SortCriterion
+
+extension NIOIMAPCore.SortCriterion {
+    var requiresDisplaySortCapability: Bool {
+        switch self {
+        case .ascending(.displayFrom), .ascending(.displayTo),
+             .descending(.displayFrom), .descending(.displayTo):
+            return true
+        default:
+            return false
+        }
+    }
+}

--- a/Tests/SwiftIMAPTests/ExtendedSearchHandlerTests.swift
+++ b/Tests/SwiftIMAPTests/ExtendedSearchHandlerTests.swift
@@ -127,6 +127,22 @@ struct ExtendedSearchHandlerTests {
         #expect(result.min?.value == 4)
         #expect(result.max?.value == 10)
         #expect(result.all != nil)
+        #expect(result.ordered?.map(\.value) == [4, 7, 10])
+    }
+
+    @Test
+    func testFallbackSortPreservesServerOrder() async throws {
+        let channel = NIOAsyncTestingChannel()
+        let promise = channel.eventLoop.makePromise(of: ExtendedSearchResult<UID>.self)
+        let handler = ExtendedSearchHandler<UID>(commandTag: "A003B", promise: promise)
+        _ = handler.processResponse(.untagged(.mailboxData(.sort([10, 7, 4], 123))))
+        handler.handleTaggedOKResponse(.init(tag: "A003B", state: .ok(.init(text: "Sort complete"))))
+
+        let result = try await promise.futureResult.get()
+
+        #expect(result.count == 3)
+        #expect(result.ordered?.map(\.value) == [10, 7, 4])
+        #expect(result.all?.toArray().map(\.value) == [4, 7, 10])
     }
 
     // MARK: - Empty ESEARCH result
@@ -184,6 +200,34 @@ struct ExtendedSearchHandlerTests {
         #expect(wireString.contains("MIN"))
         #expect(wireString.contains("MAX"))
         #expect(wireString.contains("ALL"))
+    }
+
+    @Test
+    func testSortedCommandWireFormatUsesUIDSort() async throws {
+        let channel = NIOAsyncTestingChannel()
+
+        try await channel.pipeline.addHandler(IMAPClientHandler())
+
+        let command = ExtendedSearchCommand<UID>(
+            criteria: [SearchCriteria.all],
+            sortCriteria: [.descending(.date)],
+            useSort: true,
+            useEsearch: false
+        )
+        let tagged = command.toTaggedCommand(tag: "C001A")
+        let wrapped = IMAPClientHandler.OutboundIn.part(CommandStreamPart.tagged(tagged))
+        try await channel.writeAndFlush(wrapped)
+
+        guard var outbound = try await channel.readOutbound(as: ByteBuffer.self) else {
+            Issue.record("Expected outbound bytes")
+            return
+        }
+        let wireString = outbound.readString(length: outbound.readableBytes) ?? ""
+
+        #expect(wireString.contains("UID SORT"))
+        #expect(wireString.contains("(REVERSE DATE)"))
+        #expect(wireString.contains("UTF-8"))
+        #expect(!wireString.contains("RETURN"))
     }
 
     @Test

--- a/Tests/SwiftIMAPTests/LocalSortFallbackTests.swift
+++ b/Tests/SwiftIMAPTests/LocalSortFallbackTests.swift
@@ -1,0 +1,48 @@
+import Foundation
+import NIO
+@preconcurrency import NIOIMAP
+@preconcurrency import NIOIMAPCore
+import Testing
+@testable import SwiftMail
+
+@Suite(.serialized, .timeLimit(.minutes(1)))
+struct LocalSortFallbackTests {
+    @Test
+    func sortsDatesDescendingLocally() throws {
+        let infos: [MessageInfo] = [
+            MessageInfo(
+                sequenceNumber: SequenceNumber(1),
+                uid: UID(11),
+                subject: "First",
+                from: "\"Alice\" <alice@example.com>",
+                date: Date(timeIntervalSince1970: 100),
+                internalDate: Date(timeIntervalSince1970: 100)
+            ),
+            MessageInfo(
+                sequenceNumber: SequenceNumber(2),
+                uid: UID(22),
+                subject: "Second",
+                from: "\"Bob\" <bob@example.com>",
+                date: Date(timeIntervalSince1970: 300),
+                internalDate: Date(timeIntervalSince1970: 300)
+            ),
+            MessageInfo(
+                sequenceNumber: SequenceNumber(3),
+                uid: UID(33),
+                subject: "Third",
+                from: "\"Carol\" <carol@example.com>",
+                date: Date(timeIntervalSince1970: 200),
+                internalDate: Date(timeIntervalSince1970: 200)
+            ),
+        ]
+
+        let result = try LocalSortFallback.makeExtendedSearchResult(
+            from: infos,
+            as: UID.self,
+            sortCriteria: [.descending(.date)]
+        )
+
+        #expect(result.count == 3)
+        #expect(result.ordered?.map(\.value) == [22, 33, 11])
+    }
+}

--- a/Tests/SwiftIMAPTests/SearchCommandTests.swift
+++ b/Tests/SwiftIMAPTests/SearchCommandTests.swift
@@ -36,6 +36,34 @@ struct SearchCommandTests {
     }
 
     @Test
+    func testUIDSortWireFormatUsesSortCommand() async throws {
+        let channel = NIOAsyncTestingChannel()
+        try await channel.pipeline.addHandler(IMAPClientHandler())
+
+        let ids = MessageIdentifierSet<UID>([UID(10), UID(20), UID(30)])
+        let command = SearchCommand<UID>(
+            identifierSet: ids,
+            criteria: [SearchCriteria.unseen],
+            sortCriteria: [.descending(.date)],
+            useSort: true
+        )
+        let tagged = command.toTaggedCommand(tag: "S001A")
+        let wrapped = IMAPClientHandler.OutboundIn.part(CommandStreamPart.tagged(tagged))
+        try await channel.writeAndFlush(wrapped)
+
+        guard var outbound = try await channel.readOutbound(as: ByteBuffer.self) else {
+            Issue.record("Expected outbound bytes")
+            return
+        }
+        let wire = outbound.readString(length: outbound.readableBytes) ?? ""
+
+        #expect(wire.contains("UID SORT"))
+        #expect(wire.contains("(REVERSE DATE)"))
+        #expect(wire.contains("UTF-8"))
+        #expect(wire.contains("UID 10:30") || wire.contains("UID 10,20,30"))
+    }
+
+    @Test
     func testNoIdentifierSetSearchesEntireMailbox() async throws {
         let channel = NIOAsyncTestingChannel()
         try await channel.pipeline.addHandler(IMAPClientHandler())


### PR DESCRIPTION
## What changed

This finishes the current IMAP SORT integration work for SwiftMail.

- updates `swift-nio-imap` to current `main`, including the merged SORT response parser fix
- wires SwiftMail handlers to consume upstream `MailboxData.sort(...)` responses
- adds public `SortCriterion` re-export and capability helpers for `SORT` / `SORT=DISPLAY`
- adds sorted search support to `search` / `extendedSearch`
- deprecates the plain set-returning `search(...)` overload and adds an ordered overload:
  - `search(..., sortCriteria: ...) -> [T]`
- preserves ordered results through `ExtendedSearchResult.ordered`
- adds local fallback sorting for environments where SORT decoding still fails or for compatibility fallback paths
- updates the IMAP CLI demo to expose `--sort`

## Why it changed

Issue #11 is about completing SwiftMail's SORT support on top of SwiftNIO IMAP.

The previous implementation could emit SORT commands, but the return shape for `search` was still set-based and the integration was incomplete around ordered results and CLI usage. With upstream now parsing untagged `* SORT` responses on `main`, SwiftMail can consume those results directly and expose a better sorted-search API.

## User and developer impact

Users can now:

- run sorted IMAP searches through the public API
- get ordered identifier results from `search(..., sortCriteria: ...)`
- get structured sorted search metadata from `extendedSearch(...)`
- exercise SORT in the demo CLI with `SwiftIMAPCLI search --sort ...`

Developers also get a deprecation warning on the old plain `search(...)` overload that points them toward the ordered or structured alternatives.

## Root cause

There were two mismatches in the earlier state:

- upstream `swift-nio-imap` did not yet parse raw `* SORT` responses on the resolved dependency revision
- SwiftMail's public `search(..., sortCriteria:)` shape still returned `MessageIdentifierSet<T>`, which discarded sort order even when SORT succeeded

This PR updates the dependency and aligns SwiftMail's API and handlers with the merged upstream response model.

## Validation

- `swift build --product SwiftIMAPCLI`
- `swift test --filter SwiftIMAPTests`
- live repro against `mail.drobnik.com`:
  - `SwiftIMAPCLI search --mailbox INBOX --since 2026-04-01 --sort=-date`
