### PR TITLE
Recycle connection on raw NIO ChannelError

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -952,6 +952,15 @@ final class IMAPConnection {
             }
         }
 
+        // Raw NIO transport failure (e.g. writeAndFlush on a closed channel). The substring
+        // check below misses most ChannelError cases — `String(describing:)` returns just the
+        // case name (`alreadyClosed`, `ioOnClosedChannel`, `connectPending`, `inputClosed`,
+        // `outputClosed`), none of which match the literals we look for. Without this guard
+        // the dead channel stays in `self.channel` and the next command hits the same socket.
+        if error is ChannelError {
+            return true
+        }
+
         let description = String(describing: error).lowercased()
         return description.contains("decodererror")
             || description.contains("parsererror")


### PR DESCRIPTION
## Summary

`shouldRecycleConnection(for:)` falls through to a lowercase substring check on `String(describing: error)`. For a raw `NIOCore.ChannelError` that string is just the case name — `alreadyclosed`, `ioonclosedchannel`, `connectpending`, `inputclosed`, `outputclosed` — none of which match `decodererror`, `channel is not active`, `connection reset by peer`, `broken pipe`, `eof`, or `invalid state`.

So when `channel.writeAndFlush(...)` fails on a torn-down channel during the auth, IDLE, or command paths (the `catch` blocks at lines 658, 800, 851, 1048, 1106 already call `shouldRecycleConnection` to decide whether to `disconnectBody()`), the helper returns `false`. The dead channel stays in `self.channel`, and the next command hits the same closed socket.

This adds an `error is ChannelError` guard so any NIO transport failure triggers recycling.

The match is broader than strictly necessary (datagram-only cases like `writeMessageTooLarge` also pass), but those are unreachable on a TCP IMAP channel, and recycling on them would still be safe — the connection just gets re-established.

## Test plan

- [x] \`swift build\` clean
- [x] No existing unit tests for \`shouldRecycleConnection\` (it's private and exercised via integration); existing tests untouched
- [ ] Manual: drop the TCP connection mid-IDLE (e.g. firewall block / forced close on the server side), confirm the next command opens a fresh channel instead of reusing the dead one