### PR TITLE
Fix SMTP LOGIN auth: dispatch lifecycle methods to subclasses

### DIFF
--- a/Sources/SwiftMail/SMTP/Handlers/BaseSMTPHandler.swift
+++ b/Sources/SwiftMail/SMTP/Handlers/BaseSMTPHandler.swift
@@ -103,14 +103,35 @@ class BaseSMTPHandler<T: Sendable>: ChannelInboundHandler, RemovableChannelHandl
     public func errorCaught(context: ChannelHandlerContext, error: Error) {
         // Fail the promise with the error
         promise.fail(error)
-        
+
         // Remove this handler from the pipeline
         context.pipeline.removeHandler(self, promise: nil)
-        
+
         // Forward the error to the next handler
         context.fireErrorCaught(error)
     }
-    
+
+    // These four lifecycle methods are implemented here so subclasses can `override` them.
+    // Without an implementation on this class, the protocol witness table for any subclass
+    // points at the `ChannelInboundHandler` default implementations, and methods declared
+    // on the subclass (without `override`) silently never get called.
+
+    /// Called when the handler is added to a channel pipeline. Default no-op.
+    public func handlerAdded(context: ChannelHandlerContext) {}
+
+    /// Called when the handler is removed from a channel pipeline. Default no-op.
+    public func handlerRemoved(context: ChannelHandlerContext) {}
+
+    /// Called when the channel is registered with its EventLoop. Default propagates the event.
+    public func channelRegistered(context: ChannelHandlerContext) {
+        context.fireChannelRegistered()
+    }
+
+    /// Called when the channel becomes active. Default propagates the event.
+    public func channelActive(context: ChannelHandlerContext) {
+        context.fireChannelActive()
+    }
+
     // MARK: - Helper Methods
     
     /// Fulfill the promise with the result

--- a/Sources/SwiftMail/SMTP/Handlers/LoginAuthHandler.swift
+++ b/Sources/SwiftMail/SMTP/Handlers/LoginAuthHandler.swift
@@ -67,24 +67,24 @@ final class LoginAuthHandler: BaseSMTPHandler<AuthResult>, @unchecked Sendable {
     private var context: ChannelHandlerContext?
     
     /// Store the context when added to the pipeline
-	func channelRegistered(context: ChannelHandlerContext) {
+    override public func channelRegistered(context: ChannelHandlerContext) {
         self.context = context
         context.fireChannelRegistered()
     }
-    
+
     /// Store the context when handler is added to the pipeline (alternative to channelRegistered)
-	func handlerAdded(context: ChannelHandlerContext) {
+    override public func handlerAdded(context: ChannelHandlerContext) {
         self.context = context
     }
-    
+
     /// Store the context when the channel becomes active
-	func channelActive(context: ChannelHandlerContext) {
+    override public func channelActive(context: ChannelHandlerContext) {
         self.context = context
         context.fireChannelActive()
     }
-    
+
     /// Clear the context when removed from the pipeline
-	func handlerRemoved(context: ChannelHandlerContext) {
+    override public func handlerRemoved(context: ChannelHandlerContext) {
         self.context = nil
     }
 } 


### PR DESCRIPTION
## Summary

`LoginAuthHandler` defines `channelRegistered`, `handlerAdded`, `channelActive`, `handlerRemoved` to capture the `ChannelHandlerContext` into a stored property, but `BaseSMTPHandler` does not implement these methods. The protocol witness table for any subclass of `BaseSMTPHandler` therefore points at the `ChannelInboundHandler` default implementations, and methods declared on the subclass without `override` silently never run.

Result: when SMTP servers require `AUTH LOGIN`, the credential closure fires with `self.context == nil` and the promise fails with `connectionFailed("Channel context is nil")`.

## Reproduction

Connect to any SMTP server that advertises `AUTH LOGIN` (e.g. typical IMAP/SMTP providers: Mailo, Infomaniak, OVH, many self-hosted setups). Call `loginAuth(username:password:)`. The promise fails immediately when SwiftMail tries to send the base64-encoded username — `self.context` is nil.

## Fix

- **`BaseSMTPHandler.swift`** — implement the four lifecycle methods with sensible defaults (no-op for `handlerAdded`/`handlerRemoved`, `fireXxx` propagation for `channelRegistered`/`channelActive`). This places them in the witness table, so subclasses can override them.
- **`LoginAuthHandler.swift`** — mark the four methods `override public` so the subclass versions actually get dispatched.

The same latent bug would affect any other subclass of `BaseSMTPHandler` that overrides these lifecycle methods; this fix prevents it for all subclasses going forward.

## Test plan

- [ ] Verify SMTP `AUTH LOGIN` against a server that requires it (e.g. Mailo)
- [ ] Verify SMTP `AUTH PLAIN` still works (no regression)
- [ ] Verify normal IMAP flows (which do not depend on this code path)