### PR TITLE
Add explicit IMAP and SMTP transport security

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -80,7 +80,8 @@ let package = Package(
             name: "SwiftSMTPTests",
             dependencies: [
                 "SwiftMail",
-                .product(name: "Testing", package: "swift-testing")
+                .product(name: "Testing", package: "swift-testing"),
+                .product(name: "NIOEmbedded", package: "swift-nio")
             ]
         ),
         .testTarget(

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -10,12 +10,13 @@ final class IMAPConnection {
     enum TLSTransportMode: Equatable {
         case implicitTLS
         case plainText
-        case startTLSIfAvailable(requireTLS: Bool)
+        case startTLSIfAvailable
+        case startTLSRequired
     }
 
     private let host: String
     private let port: Int
-    private let useTLS: Bool?
+    private let transportSecurity: MailTransportSecurity
     private let group: EventLoopGroup
     private let connectionID: String
     private let connectionRole: String
@@ -36,7 +37,7 @@ final class IMAPConnection {
     init(
         host: String,
         port: Int,
-        useTLS: Bool? = nil,
+        transportSecurity: MailTransportSecurity = .automatic,
         group: EventLoopGroup,
         loggerLabel: String,
         outboundLabel: String,
@@ -46,7 +47,7 @@ final class IMAPConnection {
     ) {
         self.host = host
         self.port = port
-        self.useTLS = useTLS
+        self.transportSecurity = transportSecurity
         self.group = group
         self.connectionID = connectionID
         self.connectionRole = connectionRole
@@ -77,41 +78,82 @@ final class IMAPConnection {
         )
     }
 
-    static func resolveTLSTransportMode(port: Int, useTLS: Bool?) throws -> TLSTransportMode {
-        if let useTLS {
-            if port == 143 && useTLS {
-                return .startTLSIfAvailable(requireTLS: true)
-            }
+    convenience init(
+        host: String,
+        port: Int,
+        useTLS: Bool?,
+        group: EventLoopGroup,
+        loggerLabel: String,
+        outboundLabel: String,
+        inboundLabel: String,
+        connectionID: String,
+        connectionRole: String
+    ) {
+        self.init(
+            host: host,
+            port: port,
+            transportSecurity: Self.resolveLegacyTransportSecurity(port: port, useTLS: useTLS),
+            group: group,
+            loggerLabel: loggerLabel,
+            outboundLabel: outboundLabel,
+            inboundLabel: inboundLabel,
+            connectionID: connectionID,
+            connectionRole: connectionRole
+        )
+    }
 
-            return useTLS ? .implicitTLS : .plainText
+    private static func resolveLegacyTransportSecurity(port: Int, useTLS: Bool?) -> MailTransportSecurity {
+        guard let useTLS else {
+            return .automatic
         }
 
-        switch port {
-        case 993:
+        if useTLS {
+            return port == 143 ? .startTLS : .implicitTLS
+        }
+
+        return .plainText
+    }
+
+    static func resolveTLSTransportMode(
+        port: Int,
+        transportSecurity: MailTransportSecurity
+    ) -> TLSTransportMode {
+        switch transportSecurity {
+        case .automatic:
+            switch port {
+            case 993:
+                return .implicitTLS
+            case 143:
+                return .startTLSIfAvailable
+            default:
+                return .plainText
+            }
+        case .implicitTLS:
             return .implicitTLS
-        case 143:
-            return .startTLSIfAvailable(requireTLS: false)
-        default:
-            throw IMAPError.invalidArgument(
-                "Port \(port) requires explicit useTLS because SwiftMail cannot infer whether to use implicit TLS or plain text"
-            )
+        case .startTLS:
+            return .startTLSRequired
+        case .plainText:
+            return .plainText
         }
     }
 
     static func requiresSTARTTLSUpgrade(
-        port: Int,
         tlsTransportMode: TLSTransportMode,
         capabilities: [Capability]
     ) -> Bool {
-        guard port == 143 else {
+        switch tlsTransportMode {
+        case .startTLSIfAvailable, .startTLSRequired:
+            return capabilities.contains(.startTLS)
+        case .implicitTLS, .plainText:
             return false
         }
+    }
 
-        guard case .startTLSIfAvailable = tlsTransportMode else {
-            return false
-        }
-
-        return capabilities.contains(.startTLS)
+    static func requiresMissingSTARTTLSError(
+        tlsTransportMode: TLSTransportMode,
+        capabilities: [Capability]
+    ) -> Bool {
+        tlsTransportMode == .startTLSRequired && !capabilities.contains(.startTLS)
     }
 
     var isConnected: Bool {
@@ -183,7 +225,7 @@ final class IMAPConnection {
         idleHandler = nil
         idleTerminationInProgress = false
 
-        let tlsTransportMode = try Self.resolveTLSTransportMode(port: port, useTLS: useTLS)
+        let tlsTransportMode = Self.resolveTLSTransportMode(port: port, transportSecurity: transportSecurity)
         let initialTLSMode = tlsTransportMode
         let host = self.host
         let duplexLogger = self.duplexLogger
@@ -524,14 +566,13 @@ final class IMAPConnection {
         tlsTransportMode: TLSTransportMode,
         capabilities: [Capability]
     ) async throws {
-        if Self.requiresSTARTTLSUpgrade(port: port, tlsTransportMode: tlsTransportMode, capabilities: capabilities) {
-            try await startTLS()
-            return
-        }
-
-        if case .startTLSIfAvailable(let requireTLS) = tlsTransportMode, requireTLS {
+        if Self.requiresMissingSTARTTLSError(tlsTransportMode: tlsTransportMode, capabilities: capabilities) {
             try? await disconnectBody()
             throw IMAPError.connectionFailed("Server did not advertise STARTTLS on port \(port)")
+        }
+
+        if Self.requiresSTARTTLSUpgrade(tlsTransportMode: tlsTransportMode, capabilities: capabilities) {
+            try await startTLS()
         }
     }
 

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -586,7 +586,8 @@ final class IMAPConnection {
             certificateVerificationPolicy: certificateVerificationPolicy
         )
         let context = try NIOSSLContext(configuration: configuration)
-        return try NIOSSLClientHandler(context: context, serverHostname: host)
+        let serverHostname = MailTLSConfiguration.serverHostnameForTLSHandler(host: host)
+        return try NIOSSLClientHandler(context: context, serverHostname: serverHostname)
     }
 
     func applyPostGreetingTLSPolicy(

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -30,6 +30,7 @@ final class IMAPConnection {
     private var idleTerminationInProgress: Bool = false
     private let commandQueue = IMAPCommandQueue()
     private let responseBuffer = UntaggedResponseBuffer()
+    private var startTLSUpgradeOverrideForTesting: (() async throws -> Void)?
 
     private let logger: Logging.Logger
     private let duplexLogger: IMAPLogger
@@ -193,6 +194,10 @@ final class IMAPConnection {
 
     func replaceChannelForTesting(_ channel: Channel?) {
         self.channel = channel
+    }
+
+    func replaceStartTLSUpgradeForTesting(_ upgrade: (() async throws -> Void)?) {
+        self.startTLSUpgradeOverrideForTesting = upgrade
     }
 
     func connect() async throws {
@@ -387,6 +392,8 @@ final class IMAPConnection {
         guard let channel = self.channel else {
             logger.warning("\(connectionContext) Attempted to disconnect when channel was already nil")
             isSessionAuthenticated = false
+            capabilities = []
+            namespaces = nil
             responseBuffer.reset()
             idleHandler = nil
             idleTerminationInProgress = false
@@ -400,6 +407,7 @@ final class IMAPConnection {
         }
         self.channel = nil
         self.isSessionAuthenticated = false
+        self.capabilities = []
         self.namespaces = nil
         self.idleHandler = nil
         self.idleTerminationInProgress = false
@@ -582,10 +590,16 @@ final class IMAPConnection {
     }
 
     func closeAndClearChannelAfterSTARTTLSPolicyFailure() async {
+        capabilities = []
         try? await disconnectBody()
     }
 
     private func startTLS() async throws {
+        if let startTLSUpgradeOverrideForTesting {
+            try await startTLSUpgradeOverrideForTesting()
+            return
+        }
+
         let command = IMAPStartTLSCommand()
         let accepted = try await executeCommandBody(command)
 

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -567,13 +567,22 @@ final class IMAPConnection {
         capabilities: [Capability]
     ) async throws {
         if Self.requiresMissingSTARTTLSError(tlsTransportMode: tlsTransportMode, capabilities: capabilities) {
-            try? await disconnectBody()
+            await closeAndClearChannelAfterSTARTTLSPolicyFailure()
             throw IMAPError.connectionFailed("Server did not advertise STARTTLS on port \(port)")
         }
 
         if Self.requiresSTARTTLSUpgrade(tlsTransportMode: tlsTransportMode, capabilities: capabilities) {
-            try await startTLS()
+            do {
+                try await startTLS()
+            } catch {
+                await closeAndClearChannelAfterSTARTTLSPolicyFailure()
+                throw error
+            }
         }
+    }
+
+    func closeAndClearChannelAfterSTARTTLSPolicyFailure() async {
+        try? await disconnectBody()
     }
 
     private func startTLS() async throws {

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -17,6 +17,7 @@ final class IMAPConnection {
     private let host: String
     private let port: Int
     private let transportSecurity: MailTransportSecurity
+    private let certificateVerificationPolicy: MailCertificateVerificationPolicy
     private let group: EventLoopGroup
     private let connectionID: String
     private let connectionRole: String
@@ -39,6 +40,7 @@ final class IMAPConnection {
         host: String,
         port: Int,
         transportSecurity: MailTransportSecurity = .automatic,
+        certificateVerificationPolicy: MailCertificateVerificationPolicy = .fullVerification,
         group: EventLoopGroup,
         loggerLabel: String,
         outboundLabel: String,
@@ -49,6 +51,7 @@ final class IMAPConnection {
         self.host = host
         self.port = port
         self.transportSecurity = transportSecurity
+        self.certificateVerificationPolicy = certificateVerificationPolicy
         self.group = group
         self.connectionID = connectionID
         self.connectionRole = connectionRole
@@ -94,6 +97,7 @@ final class IMAPConnection {
             host: host,
             port: port,
             transportSecurity: Self.resolveLegacyTransportSecurity(port: port, useTLS: useTLS),
+            certificateVerificationPolicy: .fullVerification,
             group: group,
             loggerLabel: loggerLabel,
             outboundLabel: outboundLabel,
@@ -168,6 +172,10 @@ final class IMAPConnection {
         capabilities
     }
 
+    var certificateVerificationPolicyForTesting: MailCertificateVerificationPolicy {
+        certificateVerificationPolicy
+    }
+
     var namespacesSnapshot: NamespaceResponse? {
         namespaces
     }
@@ -233,6 +241,7 @@ final class IMAPConnection {
         let tlsTransportMode = try Self.resolveTLSTransportMode(port: port, transportSecurity: transportSecurity)
         let initialTLSMode = tlsTransportMode
         let host = self.host
+        let certificateVerificationPolicy = self.certificateVerificationPolicy
         let duplexLogger = self.duplexLogger
         let responseBuffer = self.responseBuffer
         
@@ -255,7 +264,11 @@ final class IMAPConnection {
                     )
 
                     if case .implicitTLS = initialTLSMode {
-                        let sslHandler = try Self.makeTLSHandler(for: channel, host: host)
+                        let sslHandler = try Self.makeTLSHandler(
+                            for: channel,
+                            host: host,
+                            certificateVerificationPolicy: certificateVerificationPolicy
+                        )
                         try channel.pipeline.syncOperations.addHandler(sslHandler)
                     }
 
@@ -564,8 +577,14 @@ final class IMAPConnection {
         try await fetchCapabilities()
     }
 
-    private static func makeTLSHandler(for channel: Channel, host: String) throws -> NIOSSLClientHandler {
-        let configuration = TLSConfiguration.makeClientConfiguration()
+    private static func makeTLSHandler(
+        for channel: Channel,
+        host: String,
+        certificateVerificationPolicy: MailCertificateVerificationPolicy
+    ) throws -> NIOSSLClientHandler {
+        let configuration = MailTLSConfiguration.makeClientConfiguration(
+            certificateVerificationPolicy: certificateVerificationPolicy
+        )
         let context = try NIOSSLContext(configuration: configuration)
         return try NIOSSLClientHandler(context: context, serverHostname: host)
     }
@@ -612,8 +631,13 @@ final class IMAPConnection {
         }
 
         let host = self.host
+        let certificateVerificationPolicy = self.certificateVerificationPolicy
         try await channel.eventLoop.submit {
-            let sslHandler = try Self.makeTLSHandler(for: channel, host: host)
+            let sslHandler = try Self.makeTLSHandler(
+                for: channel,
+                host: host,
+                certificateVerificationPolicy: certificateVerificationPolicy
+            )
             try channel.pipeline.syncOperations.addHandler(sslHandler, position: .first)
         }.get()
 

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -117,7 +117,7 @@ final class IMAPConnection {
     static func resolveTLSTransportMode(
         port: Int,
         transportSecurity: MailTransportSecurity
-    ) -> TLSTransportMode {
+    ) throws -> TLSTransportMode {
         switch transportSecurity {
         case .automatic:
             switch port {
@@ -126,7 +126,7 @@ final class IMAPConnection {
             case 143:
                 return .startTLSIfAvailable
             default:
-                return .plainText
+                throw IMAPError.invalidArgument("Port \(port) requires explicit useTLS because TLS mode cannot be inferred")
             }
         case .implicitTLS:
             return .implicitTLS
@@ -225,7 +225,7 @@ final class IMAPConnection {
         idleHandler = nil
         idleTerminationInProgress = false
 
-        let tlsTransportMode = Self.resolveTLSTransportMode(port: port, transportSecurity: transportSecurity)
+        let tlsTransportMode = try Self.resolveTLSTransportMode(port: port, transportSecurity: transportSecurity)
         let initialTLSMode = tlsTransportMode
         let host = self.host
         let duplexLogger = self.duplexLogger

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -127,7 +127,7 @@ final class IMAPConnection {
             case 143:
                 return .startTLSIfAvailable
             default:
-                throw IMAPError.invalidArgument("Port \(port) requires explicit useTLS because TLS mode cannot be inferred")
+                throw IMAPError.invalidArgument("Port \(port) requires explicit transportSecurity because TLS mode cannot be inferred")
             }
         case .implicitTLS:
             return .implicitTLS

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -118,6 +118,7 @@ public actor IMAPServer {
      - Parameters:
      - host: The hostname of the IMAP server
      - port: The port number of the IMAP server (typically 993 for SSL)
+     - transportSecurity: The transport security policy to use. `.automatic` infers from standard IMAP ports; explicit values override that inference.
      - numberOfThreads: The number of threads to use for the event loop group
      
      - Note: The connection is configured with a 1MB buffer limit to handle large SEARCH responses

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -38,6 +38,9 @@ public actor IMAPServer {
 
     /// Explicit TLS preference. `.automatic` infers from the standard IMAP ports.
     private let transportSecurity: MailTransportSecurity
+
+    /// Certificate verification preference used by all TLS transports for this server.
+    private let certificateVerificationPolicy: MailCertificateVerificationPolicy
     
     /** The event loop group for handling asynchronous operations */
     private let group: EventLoopGroup
@@ -71,6 +74,10 @@ public actor IMAPServer {
     /// Whether the primary connection advertised UIDPLUS.
     public var supportsUIDPlus: Bool {
         capabilities.contains(.uidPlus)
+    }
+
+    var primaryConnectionCertificateVerificationPolicyForTesting: MailCertificateVerificationPolicy {
+        primaryConnection.certificateVerificationPolicyForTesting
     }
     
     /**
@@ -119,6 +126,7 @@ public actor IMAPServer {
      - host: The hostname of the IMAP server
      - port: The port number of the IMAP server (typically 993 for SSL)
      - transportSecurity: The transport security policy to use. `.automatic` infers from standard IMAP ports; explicit values override that inference.
+     - certificateVerificationPolicy: The certificate verification policy to use for TLS connections.
      - numberOfThreads: The number of threads to use for the event loop group
      
      - Note: The connection is configured with a 1MB buffer limit to handle large SEARCH responses
@@ -129,11 +137,13 @@ public actor IMAPServer {
         host: String,
         port: Int,
         transportSecurity: MailTransportSecurity = .automatic,
+        certificateVerificationPolicy: MailCertificateVerificationPolicy = .fullVerification,
         numberOfThreads: Int = 1
     ) {
         self.host = host
         self.port = port
         self.transportSecurity = transportSecurity
+        self.certificateVerificationPolicy = certificateVerificationPolicy
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: numberOfThreads)
         
         // Initialize loggers
@@ -146,6 +156,7 @@ public actor IMAPServer {
             host: host,
             port: port,
             transportSecurity: transportSecurity,
+            certificateVerificationPolicy: certificateVerificationPolicy,
             group: group,
             loggerLabel: primaryLoggerLabel,
             outboundLabel: outboundLabel,
@@ -160,6 +171,7 @@ public actor IMAPServer {
             host: host,
             port: port,
             transportSecurity: Self.resolveLegacyTransportSecurity(port: port, useTLS: useTLS),
+            certificateVerificationPolicy: .fullVerification,
             numberOfThreads: numberOfThreads
         )
     }
@@ -379,6 +391,7 @@ public actor IMAPServer {
             host: host,
             port: port,
             transportSecurity: transportSecurity,
+            certificateVerificationPolicy: certificateVerificationPolicy,
             group: group,
             loggerLabel: loggerLabel,
             outboundLabel: outboundLabel,
@@ -401,6 +414,7 @@ public actor IMAPServer {
             host: host,
             port: port,
             transportSecurity: transportSecurity,
+            certificateVerificationPolicy: certificateVerificationPolicy,
             group: group,
             loggerLabel: loggerLabel,
             outboundLabel: outboundLabel,

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -36,8 +36,8 @@ public actor IMAPServer {
     /** The port number of the IMAP server */
     private let port: Int
 
-    /// Explicit TLS preference. `nil` means infer from the standard IMAP port.
-    private let useTLS: Bool?
+    /// Explicit TLS preference. `.automatic` infers from the standard IMAP ports.
+    private let transportSecurity: MailTransportSecurity
     
     /** The event loop group for handling asynchronous operations */
     private let group: EventLoopGroup
@@ -124,10 +124,15 @@ public actor IMAPServer {
      that may contain thousands of message IDs. This prevents PayloadTooLargeError when
      searching large mailboxes.
      */
-    public init(host: String, port: Int, useTLS: Bool? = nil, numberOfThreads: Int = 1) {
+    public init(
+        host: String,
+        port: Int,
+        transportSecurity: MailTransportSecurity = .automatic,
+        numberOfThreads: Int = 1
+    ) {
         self.host = host
         self.port = port
-        self.useTLS = useTLS
+        self.transportSecurity = transportSecurity
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: numberOfThreads)
         
         // Initialize loggers
@@ -139,7 +144,7 @@ public actor IMAPServer {
         self.primaryConnection = IMAPConnection(
             host: host,
             port: port,
-            useTLS: useTLS,
+            transportSecurity: transportSecurity,
             group: group,
             loggerLabel: primaryLoggerLabel,
             outboundLabel: outboundLabel,
@@ -147,6 +152,27 @@ public actor IMAPServer {
             connectionID: "primary",
             connectionRole: "primary"
         )
+    }
+
+    public init(host: String, port: Int, useTLS: Bool?, numberOfThreads: Int = 1) {
+        self.init(
+            host: host,
+            port: port,
+            transportSecurity: Self.resolveLegacyTransportSecurity(port: port, useTLS: useTLS),
+            numberOfThreads: numberOfThreads
+        )
+    }
+
+    private static func resolveLegacyTransportSecurity(port: Int, useTLS: Bool?) -> MailTransportSecurity {
+        guard let useTLS else {
+            return .automatic
+        }
+
+        if useTLS {
+            return port == 143 ? .startTLS : .implicitTLS
+        }
+
+        return .plainText
     }
     
     deinit {
@@ -163,8 +189,7 @@ public actor IMAPServer {
      
      This method establishes the IMAP transport connection and retrieves
      its capabilities. Port `993` defaults to implicit TLS, port `143` defaults to
-     plain text with opportunistic STARTTLS, and other ports require an explicit
-     `useTLS` decision.
+     plain text with opportunistic STARTTLS.
      
      - Throws:
      - `IMAPError.connectionFailed` if the connection cannot be established
@@ -352,7 +377,7 @@ public actor IMAPServer {
         return IMAPConnection(
             host: host,
             port: port,
-            useTLS: useTLS,
+            transportSecurity: transportSecurity,
             group: group,
             loggerLabel: loggerLabel,
             outboundLabel: outboundLabel,
@@ -374,7 +399,7 @@ public actor IMAPServer {
         return IMAPConnection(
             host: host,
             port: port,
-            useTLS: useTLS,
+            transportSecurity: transportSecurity,
             group: group,
             loggerLabel: loggerLabel,
             outboundLabel: outboundLabel,

--- a/Sources/SwiftMail/MailTransportSecurity.swift
+++ b/Sources/SwiftMail/MailTransportSecurity.swift
@@ -1,3 +1,4 @@
+import NIO
 import NIOSSL
 
 /// Transport-security policy for IMAP and SMTP connections.
@@ -40,5 +41,18 @@ enum MailTLSConfiguration {
             configuration.certificateVerification = .none
         }
         return configuration
+    }
+
+    static func serverHostnameForTLSHandler(host: String) -> String? {
+        let normalizedHost = if host.hasPrefix("[") && host.hasSuffix("]") {
+            String(host.dropFirst().dropLast())
+        } else {
+            host
+        }
+
+        if (try? SocketAddress(ipAddress: normalizedHost, port: 0)) != nil {
+            return nil
+        }
+        return host
     }
 }

--- a/Sources/SwiftMail/MailTransportSecurity.swift
+++ b/Sources/SwiftMail/MailTransportSecurity.swift
@@ -1,0 +1,6 @@
+public enum MailTransportSecurity: Sendable, Equatable {
+    case automatic
+    case implicitTLS
+    case startTLS
+    case plainText
+}

--- a/Sources/SwiftMail/MailTransportSecurity.swift
+++ b/Sources/SwiftMail/MailTransportSecurity.swift
@@ -1,3 +1,5 @@
+import NIOSSL
+
 /// Transport-security policy for IMAP and SMTP connections.
 public enum MailTransportSecurity: Sendable, Equatable {
     /// Infer transport security from the server port, preserving SwiftMail's legacy defaults.
@@ -11,4 +13,32 @@ public enum MailTransportSecurity: Sendable, Equatable {
 
     /// Use plaintext transport without TLS.
     case plainText
+}
+
+/// Certificate-verification policy for TLS connections.
+public enum MailCertificateVerificationPolicy: Sendable, Equatable {
+    /// Validate the server certificate against trusted roots and the requested hostname.
+    case fullVerification
+
+    /// Do not validate the server certificate.
+    ///
+    /// Use only when the caller has explicitly chosen to trust an endpoint that presents a
+    /// self-signed or otherwise locally untrusted certificate.
+    case noVerification
+}
+
+enum MailTLSConfiguration {
+    static func makeClientConfiguration(
+        certificateVerificationPolicy: MailCertificateVerificationPolicy
+    ) -> TLSConfiguration {
+        var configuration = TLSConfiguration.makeClientConfiguration()
+        switch certificateVerificationPolicy {
+        case .fullVerification:
+            configuration.certificateVerification = .fullVerification
+            configuration.trustRoots = .default
+        case .noVerification:
+            configuration.certificateVerification = .none
+        }
+        return configuration
+    }
 }

--- a/Sources/SwiftMail/MailTransportSecurity.swift
+++ b/Sources/SwiftMail/MailTransportSecurity.swift
@@ -1,6 +1,14 @@
+/// Transport-security policy for IMAP and SMTP connections.
 public enum MailTransportSecurity: Sendable, Equatable {
+    /// Infer transport security from the server port, preserving SwiftMail's legacy defaults.
     case automatic
+
+    /// Start the connection inside TLS from the first byte.
     case implicitTLS
+
+    /// Require STARTTLS after the plaintext greeting or EHLO capability exchange.
     case startTLS
+
+    /// Use plaintext transport without TLS.
     case plainText
 }

--- a/Sources/SwiftMail/SMTP/SMTPServer.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer.swift
@@ -56,6 +56,9 @@ public actor SMTPServer {
     
     /** The port number of the SMTP server */
     private let port: Int
+
+    /** The requested SMTP transport security policy */
+    private let transportSecurity: MailTransportSecurity
     
     /** The event loop group for handling asynchronous operations */
     private let group: EventLoopGroup
@@ -125,6 +128,7 @@ public actor SMTPServer {
      - Parameters:
        - host: The hostname of the SMTP server
        - port: The port number of the SMTP server
+       - transportSecurity: The transport security policy to use for this connection
        - numberOfThreads: The number of threads to use for the event loop group
      
      The port number determines the initial security mode:
@@ -134,9 +138,15 @@ public actor SMTPServer {
      
      - Note: Logs initialization at debug level with connection details
      */
-    public init(host: String, port: Int, numberOfThreads: Int = 1) {
+    public init(
+        host: String,
+        port: Int,
+        transportSecurity: MailTransportSecurity = .automatic,
+        numberOfThreads: Int = 1
+    ) {
         self.host = host
         self.port = port
+        self.transportSecurity = transportSecurity
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: numberOfThreads)
 		
 		let outboundLogger = Logger(label: "com.cocoanetics.SwiftMail.SMTP_OUT")
@@ -170,15 +180,18 @@ public actor SMTPServer {
     public func connect() async throws {
         logger.debug("Connecting to SMTP server at \(host):\(port)")
         
-        // Determine if we should use SSL based on the port
-        let useSSL = (port == 465) // SMTPS port
+        let resolvedTransportSecurity = Self.resolveTransportSecurity(
+            port: port,
+            transportSecurity: transportSecurity
+        )
+        let useImplicitTLS = resolvedTransportSecurity == .implicitTLS
         
         // Create the bootstrap
         let bootstrap = ClientBootstrap(group: group)
             .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
             .channelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
             .channelInitializer { channel in
-                if useSSL {
+                if useImplicitTLS {
                     do {
                         // Create SSL context with proper configuration for secure connection
                         var tlsConfig = TLSConfiguration.makeClientConfiguration()
@@ -229,17 +242,23 @@ public actor SMTPServer {
         // Fetch capabilities using our new method
         let capabilities = try await fetchCapabilities()
         
-        // Upgrade submission connections to TLS when advertised.
-        if Self.requiresSTARTTLSUpgrade(port: port, useSSL: useSSL, capabilities: capabilities) {
+        if Self.requiresMissingSTARTTLSError(
+            transportSecurity: resolvedTransportSecurity,
+            capabilities: capabilities
+        ) {
+            logger.error("STARTTLS required for \(host):\(port) but was not advertised. Cannot continue without encryption.")
+            throw SMTPError.tlsFailed("STARTTLS required but not advertised by server")
+        }
+
+        if Self.requiresSTARTTLSUpgrade(
+            transportSecurity: resolvedTransportSecurity,
+            capabilities: capabilities
+        ) {
             do {
                 try await startTLS()
             } catch {
-                if Self.shouldFailClosedOnSTARTTLSFailure(port: port, host: host) {
-                    logger.error("STARTTLS failed for \(host): \(error.localizedDescription). Cannot continue without encryption.")
-                    throw SMTPError.tlsFailed("STARTTLS required on port 587 but failed: \(error.localizedDescription)")
-                }
-
-                logger.warning("STARTTLS failed: \(error.localizedDescription). Continuing without encryption.")
+                logger.error("STARTTLS failed for \(host):\(port): \(error.localizedDescription). Cannot continue without encryption.")
+                throw SMTPError.tlsFailed("STARTTLS required but failed: \(error.localizedDescription)")
             }
         }
         
@@ -320,8 +339,52 @@ public actor SMTPServer {
         }
     }
 
+    static func resolveTransportSecurity(
+        port: Int,
+        transportSecurity: MailTransportSecurity
+    ) -> MailTransportSecurity {
+        switch transportSecurity {
+        case .automatic:
+            switch port {
+            case 465:
+                return .implicitTLS
+            case 587:
+                return .startTLS
+            default:
+                return .plainText
+            }
+        case .implicitTLS, .startTLS, .plainText:
+            return transportSecurity
+        }
+    }
+
+    static func requiresSTARTTLSUpgrade(
+        transportSecurity: MailTransportSecurity,
+        capabilities: [String]
+    ) -> Bool {
+        transportSecurity == .startTLS && capabilities.contains("STARTTLS")
+    }
+
+    static func requiresMissingSTARTTLSError(
+        transportSecurity: MailTransportSecurity,
+        capabilities: [String]
+    ) -> Bool {
+        transportSecurity == .startTLS && !capabilities.contains("STARTTLS")
+    }
+
     static func requiresSTARTTLSUpgrade(port: Int, useSSL: Bool, capabilities: [String]) -> Bool {
-        !useSSL && port == 587 && capabilities.contains("STARTTLS")
+        guard !useSSL else {
+            return false
+        }
+
+        let transportSecurity = resolveTransportSecurity(
+            port: port,
+            transportSecurity: .automatic
+        )
+        return requiresSTARTTLSUpgrade(
+            transportSecurity: transportSecurity,
+            capabilities: capabilities
+        )
     }
 
     static func shouldFailClosedOnSTARTTLSFailure(port: Int, host: String) -> Bool {

--- a/Sources/SwiftMail/SMTP/SMTPServer.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer.swift
@@ -49,6 +49,13 @@ import Musl
    - Trace: Raw SMTP protocol communication
  */
 public actor SMTPServer {
+    enum SMTPTransportMode: Sendable, Equatable {
+        case implicitTLS
+        case plainText
+        case startTLSIfAvailable
+        case startTLSRequired
+    }
+
     // MARK: - Properties
     
     /** The hostname of the SMTP server */
@@ -180,11 +187,11 @@ public actor SMTPServer {
     public func connect() async throws {
         logger.debug("Connecting to SMTP server at \(host):\(port)")
         
-        let resolvedTransportSecurity = Self.resolveTransportSecurity(
+        let transportMode = Self.resolveTransportMode(
             port: port,
             transportSecurity: transportSecurity
         )
-        let useImplicitTLS = resolvedTransportSecurity == .implicitTLS
+        let useImplicitTLS = transportMode == .implicitTLS
         
         // Create the bootstrap
         let bootstrap = ClientBootstrap(group: group)
@@ -243,7 +250,7 @@ public actor SMTPServer {
         let capabilities = try await fetchCapabilities()
         
         if Self.requiresMissingSTARTTLSError(
-            transportSecurity: resolvedTransportSecurity,
+            transportMode: transportMode,
             capabilities: capabilities
         ) {
             logger.error("STARTTLS required for \(host):\(port) but was not advertised. Cannot continue without encryption.")
@@ -251,14 +258,14 @@ public actor SMTPServer {
         }
 
         if Self.requiresSTARTTLSUpgrade(
-            transportSecurity: resolvedTransportSecurity,
+            transportMode: transportMode,
             capabilities: capabilities
         ) {
             do {
                 try await startTLS()
             } catch {
                 logger.error("STARTTLS failed for \(host):\(port): \(error.localizedDescription). Cannot continue without encryption.")
-                throw SMTPError.tlsFailed("STARTTLS required but failed: \(error.localizedDescription)")
+                throw SMTPError.tlsFailed("STARTTLS upgrade failed: \(error.localizedDescription)")
             }
         }
         
@@ -339,37 +346,46 @@ public actor SMTPServer {
         }
     }
 
-    static func resolveTransportSecurity(
+    static func resolveTransportMode(
         port: Int,
         transportSecurity: MailTransportSecurity
-    ) -> MailTransportSecurity {
+    ) -> SMTPTransportMode {
         switch transportSecurity {
         case .automatic:
             switch port {
             case 465:
                 return .implicitTLS
             case 587:
-                return .startTLS
+                return .startTLSIfAvailable
             default:
                 return .plainText
             }
-        case .implicitTLS, .startTLS, .plainText:
-            return transportSecurity
+        case .implicitTLS:
+            return .implicitTLS
+        case .startTLS:
+            return .startTLSRequired
+        case .plainText:
+            return .plainText
         }
     }
 
     static func requiresSTARTTLSUpgrade(
-        transportSecurity: MailTransportSecurity,
+        transportMode: SMTPTransportMode,
         capabilities: [String]
     ) -> Bool {
-        transportSecurity == .startTLS && capabilities.contains("STARTTLS")
+        switch transportMode {
+        case .startTLSIfAvailable, .startTLSRequired:
+            return capabilities.contains("STARTTLS")
+        case .implicitTLS, .plainText:
+            return false
+        }
     }
 
     static func requiresMissingSTARTTLSError(
-        transportSecurity: MailTransportSecurity,
+        transportMode: SMTPTransportMode,
         capabilities: [String]
     ) -> Bool {
-        transportSecurity == .startTLS && !capabilities.contains("STARTTLS")
+        transportMode == .startTLSRequired && !capabilities.contains("STARTTLS")
     }
 
     /**

--- a/Sources/SwiftMail/SMTP/SMTPServer.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer.swift
@@ -66,6 +66,9 @@ public actor SMTPServer {
 
     /** The requested SMTP transport security policy */
     private let transportSecurity: MailTransportSecurity
+
+    /** The certificate verification policy for TLS connections */
+    private let certificateVerificationPolicy: MailCertificateVerificationPolicy
     
     /** The event loop group for handling asynchronous operations */
     private let group: EventLoopGroup
@@ -136,6 +139,7 @@ public actor SMTPServer {
        - host: The hostname of the SMTP server
        - port: The port number of the SMTP server
        - transportSecurity: The transport security policy to use for this connection
+       - certificateVerificationPolicy: The certificate verification policy to use for TLS connections
        - numberOfThreads: The number of threads to use for the event loop group
      
      `.automatic` infers the initial security mode from the port:
@@ -150,11 +154,13 @@ public actor SMTPServer {
         host: String,
         port: Int,
         transportSecurity: MailTransportSecurity = .automatic,
+        certificateVerificationPolicy: MailCertificateVerificationPolicy = .fullVerification,
         numberOfThreads: Int = 1
     ) {
         self.host = host
         self.port = port
         self.transportSecurity = transportSecurity
+        self.certificateVerificationPolicy = certificateVerificationPolicy
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: numberOfThreads)
 		
 		let outboundLogger = Logger(label: "com.cocoanetics.SwiftMail.SMTP_OUT")
@@ -193,6 +199,9 @@ public actor SMTPServer {
             transportSecurity: transportSecurity
         )
         let useImplicitTLS = transportMode == .implicitTLS
+        let host = self.host
+        let certificateVerificationPolicy = self.certificateVerificationPolicy
+        let duplexLogger = self.duplexLogger
         
         // Create the bootstrap
         let bootstrap = ClientBootstrap(group: group)
@@ -202,18 +211,18 @@ public actor SMTPServer {
                 if useImplicitTLS {
                     do {
                         // Create SSL context with proper configuration for secure connection
-                        var tlsConfig = TLSConfiguration.makeClientConfiguration()
-                        tlsConfig.certificateVerification = .fullVerification
-                        tlsConfig.trustRoots = .default
+                        let tlsConfig = MailTLSConfiguration.makeClientConfiguration(
+                            certificateVerificationPolicy: certificateVerificationPolicy
+                        )
                         
                         let sslContext = try NIOSSLContext(configuration: tlsConfig)
-                        let sslHandler = try NIOSSLClientHandler(context: sslContext, serverHostname: self.host)
+                        let sslHandler = try NIOSSLClientHandler(context: sslContext, serverHostname: host)
                         
                         // Add SSL handler first, then SMTP handlers using syncOperations
                         try! channel.pipeline.syncOperations.addHandler(sslHandler)
                         try! channel.pipeline.syncOperations.addHandlers([
 							ByteToMessageHandler(SMTPLineBasedFrameDecoder()),
-							self.duplexLogger,
+							duplexLogger,
 							SMTPResponseHandler()
 						])
                         
@@ -225,7 +234,7 @@ public actor SMTPServer {
                     // Just add SMTP handlers without SSL using syncOperations
                     try! channel.pipeline.syncOperations.addHandlers([
 						ByteToMessageHandler(SMTPLineBasedFrameDecoder()),
-						self.duplexLogger,
+						duplexLogger,
 						SMTPResponseHandler()
 					])
                     
@@ -408,6 +417,10 @@ public actor SMTPServer {
 
     var hasChannelForTesting: Bool {
         channel != nil
+    }
+
+    var certificateVerificationPolicyForTesting: MailCertificateVerificationPolicy {
+        certificateVerificationPolicy
     }
 
     func replaceChannelForTesting(_ channel: Channel?) {
@@ -805,17 +818,18 @@ public actor SMTPServer {
         }
         
         // Create SSL context with proper configuration for secure connection
-        var tlsConfig = TLSConfiguration.makeClientConfiguration()
-        tlsConfig.certificateVerification = .fullVerification
-        tlsConfig.trustRoots = .default
+        let tlsConfig = MailTLSConfiguration.makeClientConfiguration(
+            certificateVerificationPolicy: certificateVerificationPolicy
+        )
         
         // Capture the configuration before the closure to avoid concurrency issues
         let finalTlsConfig = tlsConfig
+        let host = self.host
         
         // Add SSL handler to the pipeline using EventLoop submission to ensure correct thread
         try await channel.eventLoop.submit {
             let sslContext = try NIOSSLContext(configuration: finalTlsConfig)
-            let sslHandler = try NIOSSLClientHandler(context: sslContext, serverHostname: self.host)
+            let sslHandler = try NIOSSLClientHandler(context: sslContext, serverHostname: host)
             try channel.pipeline.syncOperations.addHandler(sslHandler, position: .first)
         }.get()
         

--- a/Sources/SwiftMail/SMTP/SMTPServer.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer.swift
@@ -372,26 +372,6 @@ public actor SMTPServer {
         transportSecurity == .startTLS && !capabilities.contains("STARTTLS")
     }
 
-    static func requiresSTARTTLSUpgrade(port: Int, useSSL: Bool, capabilities: [String]) -> Bool {
-        guard !useSSL else {
-            return false
-        }
-
-        let transportSecurity = resolveTransportSecurity(
-            port: port,
-            transportSecurity: .automatic
-        )
-        return requiresSTARTTLSUpgrade(
-            transportSecurity: transportSecurity,
-            capabilities: capabilities
-        )
-    }
-
-    static func shouldFailClosedOnSTARTTLSFailure(port: Int, host: String) -> Bool {
-        _ = host
-        return port == 587
-    }
-
     /**
      Disconnect from the SMTP server
      

--- a/Sources/SwiftMail/SMTP/SMTPServer.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer.swift
@@ -138,10 +138,11 @@ public actor SMTPServer {
        - transportSecurity: The transport security policy to use for this connection
        - numberOfThreads: The number of threads to use for the event loop group
      
-     The port number determines the initial security mode:
+     `.automatic` infers the initial security mode from the port:
      - Port 25: Plain SMTP (not recommended)
      - Port 587: STARTTLS (recommended)
      - Port 465: SMTPS (implicit TLS)
+     Passing an explicit `transportSecurity` value overrides this port-inferred behavior.
      
      - Note: Logs initialization at debug level with connection details
      */
@@ -254,6 +255,7 @@ public actor SMTPServer {
             capabilities: capabilities
         ) {
             logger.error("STARTTLS required for \(host):\(port) but was not advertised. Cannot continue without encryption.")
+            await closeAndClearChannelAfterSTARTTLSPolicyFailure()
             throw SMTPError.tlsFailed("STARTTLS required but not advertised by server")
         }
 
@@ -265,6 +267,7 @@ public actor SMTPServer {
                 try await startTLS()
             } catch {
                 logger.error("STARTTLS failed for \(host):\(port): \(error.localizedDescription). Cannot continue without encryption.")
+                await closeAndClearChannelAfterSTARTTLSPolicyFailure()
                 throw SMTPError.tlsFailed("STARTTLS upgrade failed: \(error.localizedDescription)")
             }
         }
@@ -386,6 +389,31 @@ public actor SMTPServer {
         capabilities: [String]
     ) -> Bool {
         transportMode == .startTLSRequired && !capabilities.contains("STARTTLS")
+    }
+
+    var hasChannelForTesting: Bool {
+        channel != nil
+    }
+
+    func replaceChannelForTesting(_ channel: Channel?) {
+        self.channel = channel
+    }
+
+    func closeAndClearChannelAfterSTARTTLSPolicyFailure() async {
+        let channel = self.channel
+        self.channel = nil
+        self.isTLSEnabled = false
+        self.capabilities = []
+
+        guard let channel else {
+            return
+        }
+
+        do {
+            try await channel.close().get()
+        } catch {
+            logger.debug("Channel close after STARTTLS policy failure reported: \(error)")
+        }
     }
 
     /**

--- a/Sources/SwiftMail/SMTP/SMTPServer.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer.swift
@@ -216,7 +216,8 @@ public actor SMTPServer {
                         )
                         
                         let sslContext = try NIOSSLContext(configuration: tlsConfig)
-                        let sslHandler = try NIOSSLClientHandler(context: sslContext, serverHostname: host)
+                        let serverHostname = MailTLSConfiguration.serverHostnameForTLSHandler(host: host)
+                        let sslHandler = try NIOSSLClientHandler(context: sslContext, serverHostname: serverHostname)
                         
                         // Add SSL handler first, then SMTP handlers using syncOperations
                         try! channel.pipeline.syncOperations.addHandler(sslHandler)
@@ -829,7 +830,8 @@ public actor SMTPServer {
         // Add SSL handler to the pipeline using EventLoop submission to ensure correct thread
         try await channel.eventLoop.submit {
             let sslContext = try NIOSSLContext(configuration: finalTlsConfig)
-            let sslHandler = try NIOSSLClientHandler(context: sslContext, serverHostname: host)
+            let serverHostname = MailTLSConfiguration.serverHostnameForTLSHandler(host: host)
+            let sslHandler = try NIOSSLClientHandler(context: sslContext, serverHostname: serverHostname)
             try channel.pipeline.syncOperations.addHandler(sslHandler, position: .first)
         }.get()
         

--- a/Sources/SwiftMail/SMTP/SMTPServer.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer.swift
@@ -250,6 +250,19 @@ public actor SMTPServer {
         // Fetch capabilities using our new method
         let capabilities = try await fetchCapabilities()
         
+        try await applyPostEHLOTLSPolicy(
+            transportMode: transportMode,
+            capabilities: capabilities
+        )
+        
+        logger.info("Connected to SMTP server \(self.host):\(self.port)")
+    }
+    
+    func applyPostEHLOTLSPolicy(
+        transportMode: SMTPTransportMode,
+        capabilities: [String],
+        startTLSOverrideForTesting: (@Sendable () async throws -> Void)? = nil
+    ) async throws {
         if Self.requiresMissingSTARTTLSError(
             transportMode: transportMode,
             capabilities: capabilities
@@ -264,15 +277,17 @@ public actor SMTPServer {
             capabilities: capabilities
         ) {
             do {
-                try await startTLS()
+                if let startTLSOverrideForTesting {
+                    try await startTLSOverrideForTesting()
+                } else {
+                    try await startTLS()
+                }
             } catch {
                 logger.error("STARTTLS failed for \(host):\(port): \(error.localizedDescription). Cannot continue without encryption.")
                 await closeAndClearChannelAfterSTARTTLSPolicyFailure()
                 throw SMTPError.tlsFailed("STARTTLS upgrade failed: \(error.localizedDescription)")
             }
         }
-        
-        logger.info("Connected to SMTP server \(self.host):\(self.port)")
     }
     
     /**

--- a/Sources/SwiftMail/SMTP/SMTPServer.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer.swift
@@ -254,10 +254,10 @@ public actor SMTPServer {
             transportMode: transportMode,
             capabilities: capabilities
         )
-        
+
         logger.info("Connected to SMTP server \(self.host):\(self.port)")
     }
-    
+
     func applyPostEHLOTLSPolicy(
         transportMode: SMTPTransportMode,
         capabilities: [String],

--- a/Tests/SwiftIMAPTests/IMAPConnectionTLSModeTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPConnectionTLSModeTests.swift
@@ -23,14 +23,14 @@ struct IMAPConnectionTLSModeTests {
     func requiresExplicitTLSChoiceOnNonStandardPorts() {
         do {
             _ = try IMAPConnection.resolveTLSTransportMode(port: 1143, useTLS: nil)
-            Issue.record("Expected non-standard ports to require explicit useTLS")
+            Issue.record("Expected non-standard ports to require explicit transportSecurity")
         } catch let error as IMAPError {
             guard case .invalidArgument(let message) = error else {
                 Issue.record("Expected invalidArgument, got \(error)")
                 return
             }
 
-            #expect(message.contains("requires explicit useTLS"))
+            #expect(message.contains("requires explicit transportSecurity"))
         } catch {
             Issue.record("Expected IMAPError.invalidArgument, got \(error)")
         }

--- a/Tests/SwiftIMAPTests/IMAPTransportSecurityTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPTransportSecurityTests.swift
@@ -76,34 +76,45 @@ struct IMAPTransportSecurityTests {
     @Test
     func advertisedSTARTTLSFailureClearsChannel() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer {
-            Task {
-                try? await group.shutdownGracefully()
-            }
-        }
-
-        let connection = IMAPConnection(
-            host: "localhost",
-            port: 143,
-            transportSecurity: .startTLS,
-            group: group,
-            loggerLabel: "test.imap",
-            outboundLabel: "test.imap.out",
-            inboundLabel: "test.imap.in",
-            connectionID: "test-starttls-failure",
-            connectionRole: "test"
-        )
-        let channel = EmbeddedChannel()
-        connection.replaceChannelForTesting(channel)
-
         do {
-            try await connection.applyPostGreetingTLSPolicy(
-                tlsTransportMode: .startTLSRequired,
-                capabilities: [.startTLS]
+            let connection = IMAPConnection(
+                host: "localhost",
+                port: 143,
+                transportSecurity: .startTLS,
+                group: group,
+                loggerLabel: "test.imap",
+                outboundLabel: "test.imap.out",
+                inboundLabel: "test.imap.in",
+                connectionID: "test-starttls-failure",
+                connectionRole: "test"
             )
-            Issue.record("Expected STARTTLS upgrade failure")
+            let channel = EmbeddedChannel()
+            let address = try SocketAddress(ipAddress: "127.0.0.1", port: 143)
+            try await channel.connect(to: address).get()
+
+            connection.replaceChannelForTesting(channel)
+            connection.replaceCapabilitiesForTesting([.idle, .startTLS])
+            #expect(connection.isConnected)
+            connection.replaceStartTLSUpgradeForTesting {
+                throw IMAPError.connectionFailed("Injected STARTTLS failure")
+            }
+
+            do {
+                try await connection.applyPostGreetingTLSPolicy(
+                    tlsTransportMode: .startTLSRequired,
+                    capabilities: [.startTLS]
+                )
+                Issue.record("Expected STARTTLS upgrade failure")
+            } catch {
+                #expect(!connection.isConnected)
+            }
+
+            #expect(connection.capabilitiesSnapshot.isEmpty)
         } catch {
-            #expect(!connection.isConnected)
+            try? await group.shutdownGracefully()
+            throw error
         }
+
+        try await group.shutdownGracefully()
     }
 }

--- a/Tests/SwiftIMAPTests/IMAPTransportSecurityTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPTransportSecurityTests.swift
@@ -1,11 +1,37 @@
 import NIOIMAPCore
 import NIO
 import NIOEmbedded
+import NIOSSL
 import Testing
 @testable import SwiftMail
 
 @Suite(.serialized, .timeLimit(.minutes(1)))
 struct IMAPTransportSecurityTests {
+    @Test
+    func certificateVerificationPolicyMapsToNIOSSLConfiguration() {
+        let fullVerification = MailTLSConfiguration.makeClientConfiguration(
+            certificateVerificationPolicy: .fullVerification
+        )
+        #expect(fullVerification.certificateVerification == .fullVerification)
+
+        let noVerification = MailTLSConfiguration.makeClientConfiguration(
+            certificateVerificationPolicy: .noVerification
+        )
+        #expect(noVerification.certificateVerification == .none)
+    }
+
+    @Test
+    func imapServerPropagatesCertificateVerificationPolicyToPrimaryConnection() async {
+        let server = IMAPServer(
+            host: "127.0.0.1",
+            port: 1143,
+            transportSecurity: .startTLS,
+            certificateVerificationPolicy: .noVerification
+        )
+
+        #expect(await server.primaryConnectionCertificateVerificationPolicyForTesting == .noVerification)
+    }
+
     @Test
     func explicitStartTLSRequiresUpgradeOnArbitraryPorts() throws {
         let mode = try IMAPConnection.resolveTLSTransportMode(port: 1143, transportSecurity: .startTLS)

--- a/Tests/SwiftIMAPTests/IMAPTransportSecurityTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPTransportSecurityTests.swift
@@ -1,0 +1,56 @@
+import NIOIMAPCore
+import Testing
+@testable import SwiftMail
+
+@Suite(.serialized, .timeLimit(.minutes(1)))
+struct IMAPTransportSecurityTests {
+    @Test
+    func explicitStartTLSRequiresUpgradeOnArbitraryPorts() throws {
+        let mode = IMAPConnection.resolveTLSTransportMode(port: 1143, transportSecurity: .startTLS)
+
+        #expect(mode == .startTLSRequired)
+    }
+
+    @Test
+    func startTLSRequiredUpgradesWhenCapabilityIsAdvertised() {
+        #expect(
+            IMAPConnection.requiresSTARTTLSUpgrade(
+                tlsTransportMode: .startTLSRequired,
+                capabilities: [.startTLS]
+            )
+        )
+    }
+
+    @Test
+    func startTLSRequiredFailsClosedWhenCapabilityIsMissing() {
+        #expect(
+            IMAPConnection.requiresMissingSTARTTLSError(
+                tlsTransportMode: .startTLSRequired,
+                capabilities: [.idle]
+            )
+        )
+    }
+
+    @Test
+    func explicitImplicitTLSOnArbitraryPortsSkipsStartTLS() {
+        let mode = IMAPConnection.resolveTLSTransportMode(port: 1143, transportSecurity: .implicitTLS)
+
+        #expect(mode == .implicitTLS)
+        #expect(
+            !IMAPConnection.requiresSTARTTLSUpgrade(
+                tlsTransportMode: mode,
+                capabilities: [.startTLS]
+            )
+        )
+    }
+
+    @Test
+    func automaticPreservesStandardIMAPPortBehavior() {
+        #expect(
+            IMAPConnection.resolveTLSTransportMode(port: 993, transportSecurity: .automatic) == .implicitTLS
+        )
+        #expect(
+            IMAPConnection.resolveTLSTransportMode(port: 143, transportSecurity: .automatic) == .startTLSIfAvailable
+        )
+    }
+}

--- a/Tests/SwiftIMAPTests/IMAPTransportSecurityTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPTransportSecurityTests.swift
@@ -64,7 +64,7 @@ struct IMAPTransportSecurityTests {
             _ = try IMAPConnection.resolveTLSTransportMode(port: 1143, transportSecurity: .automatic)
         } catch let error as IMAPError {
             if case .invalidArgument(let message) = error {
-                didThrowInvalidArgument = message.contains("requires explicit useTLS")
+                didThrowInvalidArgument = message.contains("requires explicit transportSecurity")
             }
         } catch {
             didThrowInvalidArgument = false

--- a/Tests/SwiftIMAPTests/IMAPTransportSecurityTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPTransportSecurityTests.swift
@@ -6,7 +6,7 @@ import Testing
 struct IMAPTransportSecurityTests {
     @Test
     func explicitStartTLSRequiresUpgradeOnArbitraryPorts() throws {
-        let mode = IMAPConnection.resolveTLSTransportMode(port: 1143, transportSecurity: .startTLS)
+        let mode = try IMAPConnection.resolveTLSTransportMode(port: 1143, transportSecurity: .startTLS)
 
         #expect(mode == .startTLSRequired)
     }
@@ -32,8 +32,8 @@ struct IMAPTransportSecurityTests {
     }
 
     @Test
-    func explicitImplicitTLSOnArbitraryPortsSkipsStartTLS() {
-        let mode = IMAPConnection.resolveTLSTransportMode(port: 1143, transportSecurity: .implicitTLS)
+    func explicitImplicitTLSOnArbitraryPortsSkipsStartTLS() throws {
+        let mode = try IMAPConnection.resolveTLSTransportMode(port: 1143, transportSecurity: .implicitTLS)
 
         #expect(mode == .implicitTLS)
         #expect(
@@ -45,12 +45,29 @@ struct IMAPTransportSecurityTests {
     }
 
     @Test
-    func automaticPreservesStandardIMAPPortBehavior() {
+    func automaticPreservesStandardIMAPPortBehavior() throws {
         #expect(
-            IMAPConnection.resolveTLSTransportMode(port: 993, transportSecurity: .automatic) == .implicitTLS
+            try IMAPConnection.resolveTLSTransportMode(port: 993, transportSecurity: .automatic) == .implicitTLS
         )
         #expect(
-            IMAPConnection.resolveTLSTransportMode(port: 143, transportSecurity: .automatic) == .startTLSIfAvailable
+            try IMAPConnection.resolveTLSTransportMode(port: 143, transportSecurity: .automatic) == .startTLSIfAvailable
         )
+    }
+
+    @Test
+    func automaticRejectsAmbiguousCustomPorts() {
+        var didThrowInvalidArgument = false
+
+        do {
+            _ = try IMAPConnection.resolveTLSTransportMode(port: 1143, transportSecurity: .automatic)
+        } catch let error as IMAPError {
+            if case .invalidArgument(let message) = error {
+                didThrowInvalidArgument = message.contains("requires explicit useTLS")
+            }
+        } catch {
+            didThrowInvalidArgument = false
+        }
+
+        #expect(didThrowInvalidArgument)
     }
 }

--- a/Tests/SwiftIMAPTests/IMAPTransportSecurityTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPTransportSecurityTests.swift
@@ -21,6 +21,15 @@ struct IMAPTransportSecurityTests {
     }
 
     @Test
+    func tlsServerHostnameOmitsIPLiteralSNI() {
+        #expect(MailTLSConfiguration.serverHostnameForTLSHandler(host: "127.0.0.1") == nil)
+        #expect(MailTLSConfiguration.serverHostnameForTLSHandler(host: "::1") == nil)
+        #expect(MailTLSConfiguration.serverHostnameForTLSHandler(host: "[::1]") == nil)
+        #expect(MailTLSConfiguration.serverHostnameForTLSHandler(host: "localhost") == "localhost")
+        #expect(MailTLSConfiguration.serverHostnameForTLSHandler(host: "mail.example.com") == "mail.example.com")
+    }
+
+    @Test
     func imapServerPropagatesCertificateVerificationPolicyToPrimaryConnection() async {
         let server = IMAPServer(
             host: "127.0.0.1",

--- a/Tests/SwiftIMAPTests/IMAPTransportSecurityTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPTransportSecurityTests.swift
@@ -1,4 +1,6 @@
 import NIOIMAPCore
+import NIO
+import NIOEmbedded
 import Testing
 @testable import SwiftMail
 
@@ -69,5 +71,39 @@ struct IMAPTransportSecurityTests {
         }
 
         #expect(didThrowInvalidArgument)
+    }
+
+    @Test
+    func advertisedSTARTTLSFailureClearsChannel() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer {
+            Task {
+                try? await group.shutdownGracefully()
+            }
+        }
+
+        let connection = IMAPConnection(
+            host: "localhost",
+            port: 143,
+            transportSecurity: .startTLS,
+            group: group,
+            loggerLabel: "test.imap",
+            outboundLabel: "test.imap.out",
+            inboundLabel: "test.imap.in",
+            connectionID: "test-starttls-failure",
+            connectionRole: "test"
+        )
+        let channel = EmbeddedChannel()
+        connection.replaceChannelForTesting(channel)
+
+        do {
+            try await connection.applyPostGreetingTLSPolicy(
+                tlsTransportMode: .startTLSRequired,
+                capabilities: [.startTLS]
+            )
+            Issue.record("Expected STARTTLS upgrade failure")
+        } catch {
+            #expect(!connection.isConnected)
+        }
     }
 }

--- a/Tests/SwiftSMTPTests/SMTPTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPTests.swift
@@ -61,7 +61,7 @@ struct SMTPTests {
     func testRequiresSTARTTLSUpgradePolicy() {
         #expect(
             SMTPServer.requiresSTARTTLSUpgrade(
-                transportSecurity: SMTPServer.resolveTransportSecurity(
+                transportMode: SMTPServer.resolveTransportMode(
                     port: 587,
                     transportSecurity: .automatic
                 ),
@@ -71,7 +71,7 @@ struct SMTPTests {
 
         #expect(
             !SMTPServer.requiresSTARTTLSUpgrade(
-                transportSecurity: SMTPServer.resolveTransportSecurity(
+                transportMode: SMTPServer.resolveTransportMode(
                     port: 587,
                     transportSecurity: .automatic
                 ),
@@ -81,7 +81,7 @@ struct SMTPTests {
 
         #expect(
             !SMTPServer.requiresSTARTTLSUpgrade(
-                transportSecurity: SMTPServer.resolveTransportSecurity(
+                transportMode: SMTPServer.resolveTransportMode(
                     port: 465,
                     transportSecurity: .automatic
                 ),
@@ -91,10 +91,20 @@ struct SMTPTests {
     }
 
     @Test
-    func testMissingSTARTTLSIsFatalForResolvedSTARTTLSPolicy() {
+    func testMissingSTARTTLSIsFatalForExplicitSTARTTLSPolicy() {
         #expect(
             SMTPServer.requiresMissingSTARTTLSError(
-                transportSecurity: SMTPServer.resolveTransportSecurity(
+                transportMode: SMTPServer.resolveTransportMode(
+                    port: 587,
+                    transportSecurity: .startTLS
+                ),
+                capabilities: ["SIZE", "AUTH PLAIN"]
+            )
+        )
+
+        #expect(
+            !SMTPServer.requiresMissingSTARTTLSError(
+                transportMode: SMTPServer.resolveTransportMode(
                     port: 587,
                     transportSecurity: .automatic
                 ),
@@ -104,7 +114,7 @@ struct SMTPTests {
 
         #expect(
             !SMTPServer.requiresMissingSTARTTLSError(
-                transportSecurity: SMTPServer.resolveTransportSecurity(
+                transportMode: SMTPServer.resolveTransportMode(
                     port: 465,
                     transportSecurity: .automatic
                 ),
@@ -114,7 +124,7 @@ struct SMTPTests {
 
         #expect(
             !SMTPServer.requiresMissingSTARTTLSError(
-                transportSecurity: SMTPServer.resolveTransportSecurity(
+                transportMode: SMTPServer.resolveTransportMode(
                     port: 25,
                     transportSecurity: .automatic
                 ),

--- a/Tests/SwiftSMTPTests/SMTPTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPTests.swift
@@ -61,36 +61,66 @@ struct SMTPTests {
     func testRequiresSTARTTLSUpgradePolicy() {
         #expect(
             SMTPServer.requiresSTARTTLSUpgrade(
-                port: 587,
-                useSSL: false,
+                transportSecurity: SMTPServer.resolveTransportSecurity(
+                    port: 587,
+                    transportSecurity: .automatic
+                ),
                 capabilities: ["SIZE", "STARTTLS", "AUTH PLAIN"]
             )
         )
 
         #expect(
             !SMTPServer.requiresSTARTTLSUpgrade(
-                port: 587,
-                useSSL: false,
+                transportSecurity: SMTPServer.resolveTransportSecurity(
+                    port: 587,
+                    transportSecurity: .automatic
+                ),
                 capabilities: ["SIZE", "AUTH PLAIN"]
             )
         )
 
         #expect(
             !SMTPServer.requiresSTARTTLSUpgrade(
-                port: 465,
-                useSSL: true,
+                transportSecurity: SMTPServer.resolveTransportSecurity(
+                    port: 465,
+                    transportSecurity: .automatic
+                ),
                 capabilities: ["STARTTLS"]
             )
         )
     }
 
     @Test
-    func testSTARTTLSFailureIsFatalForPort587RegardlessOfHost() {
-        #expect(SMTPServer.shouldFailClosedOnSTARTTLSFailure(port: 587, host: "smtp.gmail.com"))
-        #expect(SMTPServer.shouldFailClosedOnSTARTTLSFailure(port: 587, host: "smtp.example.com"))
+    func testMissingSTARTTLSIsFatalForResolvedSTARTTLSPolicy() {
+        #expect(
+            SMTPServer.requiresMissingSTARTTLSError(
+                transportSecurity: SMTPServer.resolveTransportSecurity(
+                    port: 587,
+                    transportSecurity: .automatic
+                ),
+                capabilities: ["SIZE", "AUTH PLAIN"]
+            )
+        )
 
-        #expect(!SMTPServer.shouldFailClosedOnSTARTTLSFailure(port: 465, host: "smtp.gmail.com"))
-        #expect(!SMTPServer.shouldFailClosedOnSTARTTLSFailure(port: 25, host: "smtp.example.com"))
+        #expect(
+            !SMTPServer.requiresMissingSTARTTLSError(
+                transportSecurity: SMTPServer.resolveTransportSecurity(
+                    port: 465,
+                    transportSecurity: .automatic
+                ),
+                capabilities: ["SIZE", "AUTH PLAIN"]
+            )
+        )
+
+        #expect(
+            !SMTPServer.requiresMissingSTARTTLSError(
+                transportSecurity: SMTPServer.resolveTransportSecurity(
+                    port: 25,
+                    transportSecurity: .automatic
+                ),
+                capabilities: ["SIZE", "AUTH PLAIN"]
+            )
+        )
     }
 
     @Test

--- a/Tests/SwiftSMTPTests/SMTPTransportSecurityTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPTransportSecurityTests.swift
@@ -1,3 +1,4 @@
+import NIO
 import NIOEmbedded
 import Testing
 @testable import SwiftMail
@@ -73,12 +74,57 @@ struct SMTPTransportSecurityTests {
     }
 
     @Test
-    func startTLSPolicyFailureClearsChannel() async throws {
+    func explicitSTARTTLSMissingCapabilityClearsChannelThroughPolicy() async throws {
         let server = SMTPServer(host: "localhost", port: 587, transportSecurity: .startTLS)
         let channel = EmbeddedChannel()
+        let address = try SocketAddress(ipAddress: "127.0.0.1", port: 587)
+        try await channel.connect(to: address).get()
+
         await server.replaceChannelForTesting(channel)
 
-        await server.closeAndClearChannelAfterSTARTTLSPolicyFailure()
+        do {
+            try await server.applyPostEHLOTLSPolicy(
+                transportMode: .startTLSRequired,
+                capabilities: ["SIZE", "AUTH PLAIN"]
+            )
+            Issue.record("Expected missing STARTTLS capability failure")
+        } catch let error as SMTPError {
+            if case .tlsFailed(let message) = error {
+                #expect(message.contains("STARTTLS required but not advertised"))
+            } else {
+                Issue.record("Expected tlsFailed error, got \(error)")
+            }
+        }
+
+        #expect(await !server.hasChannelForTesting)
+        #expect(!channel.isActive)
+    }
+
+    @Test
+    func advertisedSTARTTLSUpgradeFailureClearsChannelThroughPolicy() async throws {
+        let server = SMTPServer(host: "localhost", port: 587, transportSecurity: .startTLS)
+        let channel = EmbeddedChannel()
+        let address = try SocketAddress(ipAddress: "127.0.0.1", port: 587)
+        try await channel.connect(to: address).get()
+
+        await server.replaceChannelForTesting(channel)
+
+        do {
+            try await server.applyPostEHLOTLSPolicy(
+                transportMode: .startTLSRequired,
+                capabilities: ["SIZE", "STARTTLS", "AUTH PLAIN"],
+                startTLSOverrideForTesting: {
+                    throw SMTPError.tlsFailed("Injected STARTTLS failure")
+                }
+            )
+            Issue.record("Expected STARTTLS upgrade failure")
+        } catch let error as SMTPError {
+            if case .tlsFailed(let message) = error {
+                #expect(message.contains("STARTTLS upgrade failed"))
+            } else {
+                Issue.record("Expected tlsFailed error, got \(error)")
+            }
+        }
 
         #expect(await !server.hasChannelForTesting)
         #expect(!channel.isActive)

--- a/Tests/SwiftSMTPTests/SMTPTransportSecurityTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPTransportSecurityTests.swift
@@ -7,7 +7,7 @@ struct SMTPTransportSecurityTests {
     func explicitSTARTTLSRequiresAdvertisedUpgrade() {
         #expect(
             SMTPServer.requiresSTARTTLSUpgrade(
-                transportSecurity: .startTLS,
+                transportMode: .startTLSRequired,
                 capabilities: ["SIZE", "STARTTLS", "AUTH PLAIN"]
             )
         )
@@ -17,7 +17,7 @@ struct SMTPTransportSecurityTests {
     func explicitSTARTTLSRequiresMissingSTARTTLSErrorWhenNotAdvertised() {
         #expect(
             SMTPServer.requiresMissingSTARTTLSError(
-                transportSecurity: .startTLS,
+                transportMode: .startTLSRequired,
                 capabilities: ["SIZE", "AUTH PLAIN"]
             )
         )
@@ -27,14 +27,14 @@ struct SMTPTransportSecurityTests {
     func implicitTLSSkipsSTARTTLSPolicyHelpers() {
         #expect(
             !SMTPServer.requiresSTARTTLSUpgrade(
-                transportSecurity: .implicitTLS,
+                transportMode: .implicitTLS,
                 capabilities: ["SIZE", "STARTTLS", "AUTH PLAIN"]
             )
         )
 
         #expect(
             !SMTPServer.requiresMissingSTARTTLSError(
-                transportSecurity: .implicitTLS,
+                transportMode: .implicitTLS,
                 capabilities: ["SIZE", "AUTH PLAIN"]
             )
         )
@@ -42,8 +42,32 @@ struct SMTPTransportSecurityTests {
 
     @Test
     func automaticTransportSecurityPreservesPortInferredBehavior() {
-        #expect(SMTPServer.resolveTransportSecurity(port: 465, transportSecurity: .automatic) == .implicitTLS)
-        #expect(SMTPServer.resolveTransportSecurity(port: 587, transportSecurity: .automatic) == .startTLS)
-        #expect(SMTPServer.resolveTransportSecurity(port: 1025, transportSecurity: .automatic) == .plainText)
+        #expect(SMTPServer.resolveTransportMode(port: 465, transportSecurity: .automatic) == .implicitTLS)
+        #expect(SMTPServer.resolveTransportMode(port: 587, transportSecurity: .automatic) == .startTLSIfAvailable)
+        #expect(SMTPServer.resolveTransportMode(port: 1025, transportSecurity: .automatic) == .plainText)
+    }
+
+    @Test
+    func automatic587DoesNotRequireSTARTTLSWhenCapabilityIsMissing() {
+        let transportMode = SMTPServer.resolveTransportMode(port: 587, transportSecurity: .automatic)
+
+        #expect(
+            !SMTPServer.requiresMissingSTARTTLSError(
+                transportMode: transportMode,
+                capabilities: ["SIZE", "AUTH PLAIN"]
+            )
+        )
+    }
+
+    @Test
+    func automatic587RequestsSTARTTLSWhenCapabilityIsAdvertised() {
+        let transportMode = SMTPServer.resolveTransportMode(port: 587, transportSecurity: .automatic)
+
+        #expect(
+            SMTPServer.requiresSTARTTLSUpgrade(
+                transportMode: transportMode,
+                capabilities: ["SIZE", "STARTTLS", "AUTH PLAIN"]
+            )
+        )
     }
 }

--- a/Tests/SwiftSMTPTests/SMTPTransportSecurityTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPTransportSecurityTests.swift
@@ -1,0 +1,49 @@
+import Testing
+@testable import SwiftMail
+
+@Suite(.serialized, .timeLimit(.minutes(1)))
+struct SMTPTransportSecurityTests {
+    @Test
+    func explicitSTARTTLSRequiresAdvertisedUpgrade() {
+        #expect(
+            SMTPServer.requiresSTARTTLSUpgrade(
+                transportSecurity: .startTLS,
+                capabilities: ["SIZE", "STARTTLS", "AUTH PLAIN"]
+            )
+        )
+    }
+
+    @Test
+    func explicitSTARTTLSRequiresMissingSTARTTLSErrorWhenNotAdvertised() {
+        #expect(
+            SMTPServer.requiresMissingSTARTTLSError(
+                transportSecurity: .startTLS,
+                capabilities: ["SIZE", "AUTH PLAIN"]
+            )
+        )
+    }
+
+    @Test
+    func implicitTLSSkipsSTARTTLSPolicyHelpers() {
+        #expect(
+            !SMTPServer.requiresSTARTTLSUpgrade(
+                transportSecurity: .implicitTLS,
+                capabilities: ["SIZE", "STARTTLS", "AUTH PLAIN"]
+            )
+        )
+
+        #expect(
+            !SMTPServer.requiresMissingSTARTTLSError(
+                transportSecurity: .implicitTLS,
+                capabilities: ["SIZE", "AUTH PLAIN"]
+            )
+        )
+    }
+
+    @Test
+    func automaticTransportSecurityPreservesPortInferredBehavior() {
+        #expect(SMTPServer.resolveTransportSecurity(port: 465, transportSecurity: .automatic) == .implicitTLS)
+        #expect(SMTPServer.resolveTransportSecurity(port: 587, transportSecurity: .automatic) == .startTLS)
+        #expect(SMTPServer.resolveTransportSecurity(port: 1025, transportSecurity: .automatic) == .plainText)
+    }
+}

--- a/Tests/SwiftSMTPTests/SMTPTransportSecurityTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPTransportSecurityTests.swift
@@ -1,3 +1,4 @@
+import NIOEmbedded
 import Testing
 @testable import SwiftMail
 
@@ -69,5 +70,17 @@ struct SMTPTransportSecurityTests {
                 capabilities: ["SIZE", "STARTTLS", "AUTH PLAIN"]
             )
         )
+    }
+
+    @Test
+    func startTLSPolicyFailureClearsChannel() async throws {
+        let server = SMTPServer(host: "localhost", port: 587, transportSecurity: .startTLS)
+        let channel = EmbeddedChannel()
+        await server.replaceChannelForTesting(channel)
+
+        await server.closeAndClearChannelAfterSTARTTLSPolicyFailure()
+
+        #expect(await !server.hasChannelForTesting)
+        #expect(!channel.isActive)
     }
 }

--- a/Tests/SwiftSMTPTests/SMTPTransportSecurityTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPTransportSecurityTests.swift
@@ -1,10 +1,30 @@
 import NIO
 import NIOEmbedded
+import NIOSSL
 import Testing
 @testable import SwiftMail
 
 @Suite(.serialized, .timeLimit(.minutes(1)))
 struct SMTPTransportSecurityTests {
+    @Test
+    func smtpServerDefaultsToFullCertificateVerification() async {
+        let server = SMTPServer(host: "smtp.example.com", port: 587)
+
+        #expect(await server.certificateVerificationPolicyForTesting == .fullVerification)
+    }
+
+    @Test
+    func smtpServerStoresExplicitNoCertificateVerificationPolicy() async {
+        let server = SMTPServer(
+            host: "127.0.0.1",
+            port: 1025,
+            transportSecurity: .startTLS,
+            certificateVerificationPolicy: .noVerification
+        )
+
+        #expect(await server.certificateVerificationPolicyForTesting == .noVerification)
+    }
+
     @Test
     func explicitSTARTTLSRequiresAdvertisedUpgrade() {
         #expect(


### PR DESCRIPTION
## Motivation
This was motivated by adding compatibility for Proton Mail Bridge, which exposes local IMAP/SMTP endpoints on non-standard ports that require STARTTLS.

## Summary
- Add `MailTransportSecurity` so IMAP and SMTP callers can choose automatic, implicit TLS, required STARTTLS, or plaintext transport explicitly.
- Thread explicit transport policy through IMAP and SMTP setup, including required STARTTLS on non-standard local bridge ports.
- Preserve legacy automatic behavior while failing closed and clearing retained transport state when required STARTTLS is missing or fails.

## Validation
- `swift test --filter SMTPTransportSecurityTests`
- `swift test --filter IMAPTransportSecurityTests`
- `swift test --filter SMTPTests/testRequiresSTARTTLSUpgradePolicy`
- `swift test --filter SMTPTests/testMissingSTARTTLSIsFatalForExplicitSTARTTLSPolicy`
- `swift build`
- `git diff --check upstream/main...HEAD`