### PR TITLE
Add mailbox delete/rename and FETCH metadata extensions

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Commands/DeleteMailboxCommand.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/DeleteMailboxCommand.swift
@@ -1,0 +1,26 @@
+import Foundation
+import NIO
+import NIOIMAPCore
+
+/** Command to delete an existing mailbox. */
+struct DeleteMailboxCommand: IMAPTaggedCommand {
+    typealias ResultType = Void
+    typealias HandlerType = DeleteMailboxHandler
+
+    let mailboxName: String
+
+    init(mailboxName: String) {
+        self.mailboxName = mailboxName
+    }
+
+    func validate() throws {
+        guard !mailboxName.isEmpty else {
+            throw IMAPError.invalidArgument("Mailbox name must not be empty")
+        }
+    }
+
+    func toTaggedCommand(tag: String) -> TaggedCommand {
+        let mailbox = MailboxName(ByteBuffer(string: mailboxName))
+        return TaggedCommand(tag: tag, command: .delete(mailbox))
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAP/Commands/RenameMailboxCommand.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/RenameMailboxCommand.swift
@@ -1,0 +1,34 @@
+import Foundation
+import NIO
+import NIOIMAPCore
+import OrderedCollections
+
+/** Command to rename an existing mailbox. */
+struct RenameMailboxCommand: IMAPTaggedCommand {
+    typealias ResultType = Void
+    typealias HandlerType = RenameMailboxHandler
+
+    let from: String
+    let to: String
+
+    init(from: String, to: String) {
+        self.from = from
+        self.to = to
+    }
+
+    func validate() throws {
+        guard !from.isEmpty, !to.isEmpty else {
+            throw IMAPError.invalidArgument("Source and destination mailbox names must not be empty")
+        }
+        guard from != to else {
+            throw IMAPError.invalidArgument("Source and destination mailbox names must differ")
+        }
+    }
+
+    func toTaggedCommand(tag: String) -> TaggedCommand {
+        let source = MailboxName(ByteBuffer(string: from))
+        let destination = MailboxName(ByteBuffer(string: to))
+        let parameters: OrderedDictionary<String, ParameterValue?> = [:]
+        return TaggedCommand(tag: tag, command: .rename(from: source, to: destination, parameters: parameters))
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/DeleteMailboxHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/DeleteMailboxHandler.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Logging
+import NIO
+import NIOIMAPCore
+
+/** Handler for the DELETE command. */
+final class DeleteMailboxHandler: BaseIMAPCommandHandler<Void>, IMAPCommandHandler, @unchecked Sendable {
+    typealias ResultType = Void
+    typealias InboundIn = Response
+    typealias InboundOut = Never
+
+    override func handleTaggedErrorResponse(_ response: TaggedResponse) {
+        failWithError(IMAPError.deleteFailed(String(describing: response.state)))
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/FetchMessageInfoHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/FetchMessageInfoHandler.swift
@@ -189,9 +189,10 @@ final class FetchMessageInfoHandler: BaseIMAPCommandHandler<[MessageInfo]>, IMAP
                 let dateString = String(date)
                 if let parsedDate = Self.parseEnvelopeDate(dateString) {
                     header.date = parsedDate
-                } else {
-                    print("Warning: Failed to parse email date: \(dateString)")
                 }
+                // If parsing fails we silently fall through. Callers can use `internalDate`
+                // (the server's receipt timestamp) as a stable fallback. We don't log here:
+                // a large mailbox with many unparsable dates would flood stderr.
             }
             
             if let messageID = envelope.messageID {
@@ -226,7 +227,10 @@ final class FetchMessageInfoHandler: BaseIMAPCommandHandler<[MessageInfo]>, IMAP
             if case .valid(let structure) = bodyStructure {
                 header.parts = Array<MessagePart>(structure)
             }
-            
+
+        case .rfc822Size(let size):
+            header.size = size
+
         default:
             break
         }
@@ -277,25 +281,34 @@ final class FetchMessageInfoHandler: BaseIMAPCommandHandler<[MessageInfo]>, IMAP
     }
 
     static func shouldCollectThreadingHeaders(for kind: StreamingKind) -> Bool {
-        kind.sectionSpecifier.kind == .header
+        switch kind.sectionSpecifier.kind {
+        case .header, .headerFields:
+            return true
+        default:
+            return false
+        }
     }
 
     /// Parse a date string from an IMAP envelope into a `Date`.
     ///
     /// Accepts the standard RFC 5322 forms and additionally tolerates several common
     /// deviations seen in the wild: lowercase month or weekday abbreviations
-    /// (e.g. `29 apr 2026 02:14:25`) and a missing timezone (interpreted as GMT).
+    /// (e.g. `29 apr 2026 02:14:25`), a missing timezone (interpreted as GMT),
+    /// and the obsolete RFC 5322 §4.3 named US time zones (`PST`, `EST`, `PDT`,
+    /// etc.) which `DateFormatter`'s `Z` token doesn't recognise.
     ///
     /// Out-of-range numeric fields (e.g. `99 Apr`) are still rejected — strict
     /// parsing is used so corrupted dates surface as `nil` rather than silently
     /// rolling over into a different valid timestamp.
     static func parseEnvelopeDate(_ dateString: String) -> Date? {
         // Strip trailing parenthetical comments such as " (UTC)"
-        let cleaned = dateString.replacingOccurrences(
+        var cleaned = dateString.replacingOccurrences(
             of: "\\s*\\([^)]+\\)\\s*$",
             with: "",
             options: .regularExpression
         )
+        // Substitute named US time zones with their numeric offsets so `Z` can parse them.
+        cleaned = normalizeNamedTimeZones(in: cleaned)
 
         let formatter = DateFormatter()
         formatter.locale = Locale(identifier: "en_US_POSIX")
@@ -377,4 +390,25 @@ final class FetchMessageInfoHandler: BaseIMAPCommandHandler<[MessageInfo]>, IMAP
         return results
     }
 
+    // MARK: - RFC 5322 obsolete time zone names
+
+    private static let namedZoneOffsets: [String: String] = [
+        "UT": "+0000", "GMT": "+0000", "UTC": "+0000",
+        "EDT": "-0400", "EST": "-0500",
+        "CDT": "-0500", "CST": "-0600",
+        "MDT": "-0600", "MST": "-0700",
+        "PDT": "-0700", "PST": "-0800",
+        "AKDT": "-0800", "AKST": "-0900",
+        "HDT": "-0900", "HST": "-1000"
+    ]
+
+    /// Replace a trailing alphabetic time zone abbreviation (e.g. ` PST`) with its numeric offset
+    /// so DateFormatter's `Z` token can parse it. Returns the input unchanged if the trailing
+    /// token isn't a recognised abbreviation.
+    static func normalizeNamedTimeZones(in s: String) -> String {
+        guard let lastSpaceIndex = s.lastIndex(of: " ") else { return s }
+        let zone = String(s[s.index(after: lastSpaceIndex)...]).uppercased()
+        guard let offset = namedZoneOffsets[zone] else { return s }
+        return String(s[..<lastSpaceIndex]) + " " + offset
+    }
 }

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/RenameMailboxHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/RenameMailboxHandler.swift
@@ -1,0 +1,15 @@
+import Foundation
+import Logging
+import NIO
+import NIOIMAPCore
+
+/** Handler for the RENAME command. */
+final class RenameMailboxHandler: BaseIMAPCommandHandler<Void>, IMAPCommandHandler, @unchecked Sendable {
+    typealias ResultType = Void
+    typealias InboundIn = Response
+    typealias InboundOut = Never
+
+    override func handleTaggedErrorResponse(_ response: TaggedResponse) {
+        failWithError(IMAPError.renameFailed(String(describing: response.state)))
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAPError.swift
+++ b/Sources/SwiftMail/IMAP/IMAPError.swift
@@ -16,6 +16,8 @@ public enum IMAPError: Error {
     case emptyIdentifierSet
     case commandFailed(String)
     case createFailed(String)
+    case deleteFailed(String)
+    case renameFailed(String)
     case copyFailed(String)
     case storeFailed(String)
     case expungeFailed(String)
@@ -55,6 +57,10 @@ extension IMAPError: CustomStringConvertible {
             return "Command failed: \(reason)"
         case .createFailed(let reason):
             return "Create mailbox failed: \(reason)"
+        case .deleteFailed(let reason):
+            return "Delete mailbox failed: \(reason)"
+        case .renameFailed(let reason):
+            return "Rename mailbox failed: \(reason)"
         case .copyFailed(let reason):
             return "Copy failed: \(reason)"
         case .storeFailed(let reason):
@@ -105,6 +111,10 @@ extension IMAPError: LocalizedError {
             return "The IMAP command failed to execute: \(reason)"
         case .createFailed(let reason):
             return "Failed to create mailbox: \(reason)"
+        case .deleteFailed(let reason):
+            return "Failed to delete mailbox: \(reason)"
+        case .renameFailed(let reason):
+            return "Failed to rename mailbox: \(reason)"
         case .copyFailed(let reason):
             return "Failed to copy messages: \(reason)"
         case .storeFailed(let reason):

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -492,6 +492,40 @@ public actor IMAPServer {
     }
 
     /**
+     Delete an existing mailbox on the server.
+
+     - Parameter mailboxName: The name of the mailbox to delete.
+     - Throws:
+     - `IMAPError.deleteFailed` if the server refuses the request (e.g. the mailbox does not exist
+       or still contains messages — most servers refuse to delete a non-empty mailbox; move or
+       expunge messages first when desired).
+     - `IMAPError.connectionFailed` if not connected.
+     */
+    public func deleteMailbox(_ mailboxName: String) async throws {
+        let command = DeleteMailboxCommand(mailboxName: resolveMailboxPath(mailboxName))
+        try await executeCommand(command)
+    }
+
+    /**
+     Rename an existing mailbox on the server.
+
+     - Parameters:
+        - source: The current name of the mailbox.
+        - destination: The new name of the mailbox.
+     - Throws:
+     - `IMAPError.renameFailed` if the server refuses the request (e.g. the destination already
+       exists or the source does not).
+     - `IMAPError.connectionFailed` if not connected.
+     */
+    public func renameMailbox(from source: String, to destination: String) async throws {
+        let command = RenameMailboxCommand(
+            from: resolveMailboxPath(source),
+            to: resolveMailboxPath(destination)
+        )
+        try await executeCommand(command)
+    }
+
+    /**
      Select a mailbox
 
      This method selects a mailbox and makes it the current mailbox for subsequent

--- a/Sources/SwiftMail/IMAP/Models/MessageInfo.swift
+++ b/Sources/SwiftMail/IMAP/Models/MessageInfo.swift
@@ -50,6 +50,10 @@ public struct MessageInfo: Codable, Sendable {
     /// Additional header fields
     public var additionalFields: [String: String]?
 
+    /// The total size of the message in bytes, from `RFC822.SIZE`. Only populated when the fetch
+    /// request asks for it.
+    public var size: Int?
+
     private enum CodingKeys: String, CodingKey {
         case sequenceNumber
         case uid
@@ -66,6 +70,7 @@ public struct MessageInfo: Codable, Sendable {
         case flags
         case parts
         case additionalFields
+        case size
     }
     
     /// Initialize a new email header
@@ -82,6 +87,7 @@ public struct MessageInfo: Codable, Sendable {
     ///   - flags: The flags of the message
     ///   - parts: The message parts
     ///   - additionalFields: Additional header fields
+    ///   - size: The total size of the message in bytes (RFC822.SIZE)
     public init(
         sequenceNumber: SequenceNumber,
         uid: SwiftMail.UID? = nil,
@@ -97,7 +103,8 @@ public struct MessageInfo: Codable, Sendable {
         references: [MessageID]? = nil,
         flags: [Flag] = [],
         parts: [MessagePart] = [],
-        additionalFields: [String: String]? = nil
+        additionalFields: [String: String]? = nil,
+        size: Int? = nil
     ) {
         self.sequenceNumber = sequenceNumber
         self.uid = uid
@@ -114,6 +121,7 @@ public struct MessageInfo: Codable, Sendable {
         self.flags = flags
         self.parts = parts
         self.additionalFields = additionalFields
+        self.size = size
     }
 }
 
@@ -165,6 +173,7 @@ public extension MessageInfo {
         let flags = try container.decodeIfPresent([Flag].self, forKey: .flags) ?? []
         let parts = try container.decodeIfPresent([MessagePart].self, forKey: .parts) ?? []
         let additionalFields = try container.decodeIfPresent([String: String].self, forKey: .additionalFields)
+        let size = try container.decodeIfPresent(Int.self, forKey: .size)
 
         self.init(
             sequenceNumber: sequenceNumber,
@@ -181,7 +190,8 @@ public extension MessageInfo {
             references: references,
             flags: flags,
             parts: parts,
-            additionalFields: additionalFields
+            additionalFields: additionalFields,
+            size: size
         )
     }
 }

--- a/Tests/SwiftIMAPTests/FetchMessageInfoHandlerTests.swift
+++ b/Tests/SwiftIMAPTests/FetchMessageInfoHandlerTests.swift
@@ -175,6 +175,58 @@ struct FetchMessageInfoHandlerTests {
         #expect(date == nil)
     }
 
+    @Test
+    func testParseEnvelopeDateAcceptsNamedUSTimeZones() {
+        // RFC 5322 §4.3 obsolete named US time zones — common in historical mailboxes.
+        let est = FetchMessageInfoHandler.parseEnvelopeDate("Wed, 31 Jan 2018 15:02:22 EST")
+        let estExpected = Self.makeDate(year: 2018, month: 1, day: 31, hour: 20, minute: 2, second: 22)
+        #expect(est == estExpected)
+
+        let pst = FetchMessageInfoHandler.parseEnvelopeDate("Wed, 31 Jan 2018 15:02:22 PST")
+        let pstExpected = Self.makeDate(year: 2018, month: 1, day: 31, hour: 23, minute: 2, second: 22)
+        #expect(pst == pstExpected)
+
+        let gmt = FetchMessageInfoHandler.parseEnvelopeDate("Wed, 31 Jan 2018 15:02:22 GMT")
+        let gmtExpected = Self.makeDate(year: 2018, month: 1, day: 31, hour: 15, minute: 2, second: 22)
+        #expect(gmt == gmtExpected)
+    }
+
+    @Test
+    func testParseEnvelopeDateLeavesUnknownZoneTokensAlone() {
+        // Unknown trailing tokens shouldn't be rewritten — falls through to format trial and fails.
+        let date = FetchMessageInfoHandler.parseEnvelopeDate("Wed, 31 Jan 2018 15:02:22 ZZT")
+        #expect(date == nil)
+    }
+
+    @Test
+    func testHeaderFieldsStreamingPopulatesAdditionalFieldsAndReferences() async throws {
+        // BODY[HEADER.FIELDS (...)] uses a different streaming kind than BODY[HEADER];
+        // the handler must collect both so HEADER.FIELDS-targeted fetches still parse.
+        let headerBlock = """
+        List-Unsubscribe: <https://example.com/unsubscribe>\r
+        List-ID: <announcements.example.com>\r
+        References: <root@example.com> <child@example.com>\r
+        \r
+        """
+
+        let infos = try await executeFetch(
+            [
+                fetchResponse(
+                    sequenceNumber: 1,
+                    envelope: envelopeAttribute(messageId: "<msg@example.com>"),
+                    headerFields: ["List-Unsubscribe", "List-ID", "References"],
+                    headerBlock: headerBlock
+                ),
+                "A001 OK FETCH completed\r\n",
+            ]
+        )
+
+        #expect(infos.count == 1)
+        #expect(infos[0].additionalFields?["list-unsubscribe"] == "<https://example.com/unsubscribe>")
+        #expect(infos[0].additionalFields?["list-id"] == "<announcements.example.com>")
+        #expect(infos[0].references == [MessageID("<root@example.com>")!, MessageID("<child@example.com>")!])
+    }
+
     private static func makeDate(year: Int, month: Int, day: Int, hour: Int, minute: Int, second: Int) -> Date? {
         var components = DateComponents()
         components.year = year
@@ -211,6 +263,11 @@ struct FetchMessageInfoHandlerTests {
 
     private func fetchResponse(sequenceNumber: Int, envelope: String, headerBlock: String) -> String {
         "* \(sequenceNumber) FETCH (ENVELOPE \(envelope) BODY[HEADER] {\(headerBlock.utf8.count)}\r\n\(headerBlock))\r\n"
+    }
+
+    private func fetchResponse(sequenceNumber: Int, envelope: String, headerFields: [String], headerBlock: String) -> String {
+        let fieldsList = headerFields.joined(separator: " ")
+        return "* \(sequenceNumber) FETCH (ENVELOPE \(envelope) BODY[HEADER.FIELDS (\(fieldsList))] {\(headerBlock.utf8.count)}\r\n\(headerBlock))\r\n"
     }
 
     private func envelopeAttribute(messageId: String, inReplyTo: String? = nil) -> String {


### PR DESCRIPTION
Extracted from #160 — the slim/UID-flags fetch additions are intentionally **not** included; that part is filed as #163 for unification with the existing `fetchMessageInfos` surface (via something like a `FetchProfile`/options type, per the discussion on #160).

## What's in
- **`IMAPServer.deleteMailbox(_:)` and `renameMailbox(from:to:)`** with matching `DeleteMailboxCommand` / `RenameMailboxCommand` + handlers and new `IMAPError.deleteFailed` / `renameFailed` cases (full `description` / `failureReason` coverage).
- **`MessageInfo.size: Int?`** populated from `RFC822.SIZE` via a new `.rfc822Size` arm in `FetchMessageInfoHandler`. Wired through the public init and the custom `init(from:)` decoder so the field actually roundtrips through `Codable` (the original PR was missing the decoder side — Copilot review comment).
- **`BODY[HEADER.FIELDS (…)]` collection** — `shouldCollectThreadingHeaders` now matches both `.header` and `.headerFields` streaming kinds. FETCHes that target specific header fields (e.g. for newsletter / `List-*` triage) now have `additionalFields` and threading headers populated.
- **Obsolete RFC 5322 §4.3 named US time zones** — `parseEnvelopeDate` now rewrites trailing `PST` / `EST` / `PDT` / `GMT` / `UTC` / `AK*T` / `H*T` tokens to numeric offsets before format trial. Strict parsing of numeric fields is preserved, so corrupted dates still surface as `nil`.
- **Stop printing per-message warnings on unparsable envelope dates.** On large mailboxes with many old/broken senders this floods stderr; callers can fall back to `internalDate` (the server receipt timestamp).

## What's out
The `FetchSlimMessageInfoCommand`, `FetchUIDFlagsCommand`, their chunk-size constants, and the four new `IMAPServer` fetch methods from PR #160 are excluded. See #163.

## Tests
- New: `testParseEnvelopeDateAcceptsNamedUSTimeZones`, `testParseEnvelopeDateLeavesUnknownZoneTokensAlone`, `testHeaderFieldsStreamingPopulatesAdditionalFieldsAndReferences`.
- The HEADER.FIELDS test was verified to fail against the unfixed handler (the streaming bytes get skipped, leaving `additionalFields` / `references` nil), then pass with the fix.
- Full test suite (skipping live `IMAPPlaintextIntegrationTests`): **282/282 pass**.

## Test plan
- [x] `swift build` succeeds
- [x] `swift test --skip IMAPPlaintextIntegrationTests` passes
- [ ] Live verification of DELETE/RENAME against a real IMAP server (the original PR reports passing against Fastmail, Namecheap, iCloud — not re-verified here)

🤖 Generated with [Claude Code](https://claude.com/claude-code)