### PR TITLE
Fix attachment base64 to use CRLF line endings (#168)

### DIFF
--- a/Sources/SwiftMail/Extensions/Email+Content.swift
+++ b/Sources/SwiftMail/Extensions/Email+Content.swift
@@ -205,7 +205,14 @@ extension Email {
     }
 
     private func encodedAttachmentBody(_ data: Data) -> String {
-        data.base64EncodedString(options: [.lineLength76Characters, .endLineWithCarriageReturn])
+        // MIME (RFC 2045) requires CRLF line endings between wrapped base64
+        // lines. `.endLineWithCarriageReturn` alone emits a bare CR, which some
+        // clients fail to de-wrap, saving the raw base64 text as the attachment.
+        data.base64EncodedString(options: [
+            .lineLength76Characters,
+            .endLineWithCarriageReturn,
+            .endLineWithLineFeed
+        ])
     }
 
     /// Formats the current date in RFC 2822 format for the Date header.

--- a/Tests/SwiftSMTPTests/SMTPTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPTests.swift
@@ -258,6 +258,50 @@ struct SMTPTests {
         #expect(relatedCloseRange.upperBound < pdfPartRange.lowerBound)
     }
 
+    // Regression test for #168: base64-wrapped attachment bodies must use CRLF
+    // line endings, not bare CR, or some clients save the raw base64 as the file.
+    @Test
+    func testRegularAttachmentBase64UsesCRLFLineEndings() {
+        // 512 bytes encodes to enough base64 to wrap across multiple 76-char lines.
+        let regularAttachment = Attachment(
+            filename: "attachment.bin",
+            mimeType: "application/octet-stream",
+            data: Data(repeating: 0xAB, count: 512)
+        )
+        let email = Email(
+            sender: EmailAddress(name: "Sender", address: "sender@example.com"),
+            recipients: [EmailAddress(address: "recipient@example.com")],
+            subject: "Attachment test",
+            textBody: "Testing attachment encoding.",
+            attachments: [regularAttachment]
+        )
+
+        let rawData = Data(email.constructContent().utf8)
+        #expect(bareCarriageReturnOffsets(in: rawData).isEmpty, "Found bare CR in MIME message")
+    }
+
+    @Test
+    func testInlineAttachmentBase64UsesCRLFLineEndings() {
+        let inlineAttachment = Attachment(
+            filename: "inline.png",
+            mimeType: "image/png",
+            data: Data(repeating: 0x42, count: 512),
+            contentID: "inline-img",
+            isInline: true
+        )
+        let email = Email(
+            sender: EmailAddress(name: "Sender", address: "sender@example.com"),
+            recipients: [EmailAddress(address: "recipient@example.com")],
+            subject: "Inline attachment test",
+            textBody: "Testing inline attachment encoding.",
+            htmlBody: "<p>Hello<img src=\"cid:inline-img\"></p>",
+            attachments: [inlineAttachment]
+        )
+
+        let rawData = Data(email.constructContent().utf8)
+        #expect(bareCarriageReturnOffsets(in: rawData).isEmpty, "Found bare CR in MIME message")
+    }
+
     @Test
     func testPrepareEmailForSendOmitsMailFromSizeWhenServerDoesNotAdvertiseSIZE() throws {
         let email = Email(
@@ -668,6 +712,20 @@ struct SMTPTests {
         else { return nil }
         let valueStart = content.index(prefixStart.upperBound, offsetBy: -prefix.count)
         return String(content[valueStart..<closingQuote.lowerBound])
+    }
+
+    /// Byte offsets of any carriage return (0x0D) not immediately followed by a
+    /// line feed (0x0A). MIME bodies must only ever contain CRLF, never bare CR.
+    private func bareCarriageReturnOffsets(in data: Data) -> [Int] {
+        let bytes = Array(data)
+        var offsets: [Int] = []
+        for index in bytes.indices where bytes[index] == 0x0D {
+            let next = index + 1
+            if next >= bytes.count || bytes[next] != 0x0A {
+                offsets.append(index)
+            }
+        }
+        return offsets
     }
 }
 // swiftlint:enable file_length type_body_length


### PR DESCRIPTION
## Summary

Fixes #168. Wrapped base64 attachment bodies were separated by a **bare CR** instead of **CRLF**, because Foundation's `.endLineWithCarriageReturn` and `.endLineWithLineFeed` are independent flags and only the first was set:

```swift
// before
data.base64EncodedString(options: [.lineLength76Characters, .endLineWithCarriageReturn])
```

MIME (RFC 2045) requires CRLF line endings. With bare CRs, some clients fail to de-wrap the base64 and save the raw text (e.g. `/9j/...`) as the attachment instead of the decoded binary — exactly the symptom reported.

The bug affected **both regular and inline attachments**, since they share `encodedAttachmentBody(_:)`.

## Fix

Add `.endLineWithLineFeed` so wrapped lines end in CRLF.

## Tests

Two regression tests in `SMTPTests` (covering the regular and inline code paths) assert that `constructContent()` output contains no bare CR. Verified they **fail** on the old code (bare CRs found every 77 bytes) and **pass** with the fix. Full `SMTPTests` suite (53 tests) passes; SwiftLint clean.

Thanks to @andrewgioia for the detailed report, root-cause analysis, and minimal reproduction. 🙏