### PR TITLE
Extend CI to Windows and Android (Android building; Windows experimental)

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -64,22 +64,15 @@ jobs:
           swift-version: "6.3.1"
       - name: Verify Swift version
         run: swift --version
-      # Three defines are needed to compile swift-nio-ssl's BoringSSL against
-      # the runner's Windows SDK, passed to both the C and C++ clang drivers.
-      # Together they suppress only the collision-prone parts of <windows.h>
-      # while leaving the rest intact (so CNIOWindows/shim.c keeps the
-      # transitive <stdlib.h> it needs for abort() — WIN32_LEAN_AND_MEAN trims
-      # too much and breaks it):
-      #   _WINSOCKAPI_ — skip the legacy <winsock.h> whose sockaddr / fd_set /
-      #     WSAData collide with the <winsock2.h> BoringSSL includes.
-      #   NOMINMAX — don't define min()/max() as macros; they break BoringSSL's
-      #     std::numeric_limits<>::max().
-      #   NOCRYPT — don't pull in <wincrypt.h>, which #defines X509_NAME /
-      #     X509_EXTENSIONS / X509_CERT_PAIR and collides with BoringSSL's types.
+      # The BoringSSL Windows-SDK header workarounds (_WINSOCKAPI_/NOMINMAX/
+      # NOCRYPT) live in the swift-nio-ssl fork's CNIOBoringSSL target settings
+      # (see Package.swift), not here — passing them globally via -Xcc would
+      # also reach the Swift module importer and mis-import IPPROTO, breaking
+      # swift-nio's NIOPosix.
       - name: Build (Windows)
-        run: swift build --build-tests -v -Xcc -D_WINSOCKAPI_ -Xcc -DNOMINMAX -Xcc -DNOCRYPT -Xcxx -D_WINSOCKAPI_ -Xcxx -DNOMINMAX -Xcxx -DNOCRYPT
+        run: swift build --build-tests -v
       - name: Test (Windows)
-        run: swift test -v --skip-build -Xcc -D_WINSOCKAPI_ -Xcc -DNOMINMAX -Xcc -DNOCRYPT -Xcxx -D_WINSOCKAPI_ -Xcxx -DNOMINMAX -Xcxx -DNOCRYPT
+        run: swift test -v --skip-build
 
   build-android:
     # Cross-build the SwiftMail library for Android via skiptools/swift-android-action.

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -64,29 +64,31 @@ jobs:
           swift-version: "6.3.1"
       - name: Verify Swift version
         run: swift --version
-      # Pre-defining _WINSOCKAPI_ makes <windows.h> skip the legacy <winsock.h>
-      # whose sockaddr / fd_set / WSAData collide with the <winsock2.h> that
-      # swift-nio-ssl's BoringSSL includes. Unlike WIN32_LEAN_AND_MEAN it does
-      # NOT trim the rest of <windows.h>, so CNIOWindows/shim.c still gets the
-      # transitive <stdlib.h> it needs for abort(). Passed to both the C and
-      # C++ clang drivers so it reaches BoringSSL's .cc sources.
+      # Two defines are needed to compile swift-nio-ssl's BoringSSL against the
+      # runner's Windows SDK, passed to both the C and C++ clang drivers:
+      #   _WINSOCKAPI_ — makes <windows.h> skip the legacy <winsock.h> whose
+      #     sockaddr / fd_set / WSAData collide with the <winsock2.h> BoringSSL
+      #     includes. Unlike WIN32_LEAN_AND_MEAN it does not trim the rest of
+      #     <windows.h>, so CNIOWindows/shim.c keeps the <stdlib.h> it needs
+      #     for abort().
+      #   NOMINMAX — stops <windows.h> defining min()/max() as function-like
+      #     macros, which otherwise break BoringSSL's std::numeric_limits<>::max().
       - name: Build (Windows)
-        run: swift build --build-tests -v -Xcc -D_WINSOCKAPI_ -Xcxx -D_WINSOCKAPI_
+        run: swift build --build-tests -v -Xcc -D_WINSOCKAPI_ -Xcc -DNOMINMAX -Xcxx -D_WINSOCKAPI_ -Xcxx -DNOMINMAX
       - name: Test (Windows)
-        run: swift test -v --skip-build -Xcc -D_WINSOCKAPI_ -Xcxx -D_WINSOCKAPI_
+        run: swift test -v --skip-build -Xcc -D_WINSOCKAPI_ -Xcc -DNOMINMAX -Xcxx -D_WINSOCKAPI_ -Xcxx -DNOMINMAX
 
   build-android:
     # Cross-build the SwiftMail library for Android via skiptools/swift-android-action.
     #
-    # EXPERIMENTAL / non-blocking (continue-on-error) — Android does not build
-    # yet because of two upstream dependency gaps, neither in SwiftMail itself:
-    #   1. swift-nio-imap's per-file libc-import guards list only
-    #      Darwin/Glibc/Musl/Windows; on the Android SDK canImport(Glibc) is
-    #      false, so every grammar file falls into `#else let badOS = …` and
-    #      the module fails with "invalid redeclaration of 'badOS'". Needs
-    #      canImport(Android)/canImport(Bionic) added to the dependency.
-    #   2. swift-testing 0.12.0 (an exact pin shared by all test targets) does
-    #      not compile against Bionic — hence build-only here once (1) is fixed.
+    # Build-only (no test run): swift-testing 0.12.0 — an exact pin shared by
+    # every test target — does not compile against Bionic, so we validate that
+    # the library cross-compiles rather than the test suites. The earlier
+    # "invalid redeclaration of 'badOS'" blocker is fixed by depending on
+    # swift-nio-imap 0.3.1-pre, which adds Android/Bionic to its libc guards.
+    #
+    # Kept non-blocking (continue-on-error) for now while the Android build is
+    # still being proven out; flip to a required job once it is reliably green.
     #
     # Package.swift also drops the ArgumentParser-based CLI demos on Android
     # (keyed on the TARGET_OS_ANDROID env the action sets) to avoid a spurious

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -64,19 +64,22 @@ jobs:
           swift-version: "6.3.1"
       - name: Verify Swift version
         run: swift --version
-      # Two defines are needed to compile swift-nio-ssl's BoringSSL against the
-      # runner's Windows SDK, passed to both the C and C++ clang drivers:
-      #   _WINSOCKAPI_ — makes <windows.h> skip the legacy <winsock.h> whose
-      #     sockaddr / fd_set / WSAData collide with the <winsock2.h> BoringSSL
-      #     includes. Unlike WIN32_LEAN_AND_MEAN it does not trim the rest of
-      #     <windows.h>, so CNIOWindows/shim.c keeps the <stdlib.h> it needs
-      #     for abort().
-      #   NOMINMAX — stops <windows.h> defining min()/max() as function-like
-      #     macros, which otherwise break BoringSSL's std::numeric_limits<>::max().
+      # Three defines are needed to compile swift-nio-ssl's BoringSSL against
+      # the runner's Windows SDK, passed to both the C and C++ clang drivers.
+      # Together they suppress only the collision-prone parts of <windows.h>
+      # while leaving the rest intact (so CNIOWindows/shim.c keeps the
+      # transitive <stdlib.h> it needs for abort() — WIN32_LEAN_AND_MEAN trims
+      # too much and breaks it):
+      #   _WINSOCKAPI_ — skip the legacy <winsock.h> whose sockaddr / fd_set /
+      #     WSAData collide with the <winsock2.h> BoringSSL includes.
+      #   NOMINMAX — don't define min()/max() as macros; they break BoringSSL's
+      #     std::numeric_limits<>::max().
+      #   NOCRYPT — don't pull in <wincrypt.h>, which #defines X509_NAME /
+      #     X509_EXTENSIONS / X509_CERT_PAIR and collides with BoringSSL's types.
       - name: Build (Windows)
-        run: swift build --build-tests -v -Xcc -D_WINSOCKAPI_ -Xcc -DNOMINMAX -Xcxx -D_WINSOCKAPI_ -Xcxx -DNOMINMAX
+        run: swift build --build-tests -v -Xcc -D_WINSOCKAPI_ -Xcc -DNOMINMAX -Xcc -DNOCRYPT -Xcxx -D_WINSOCKAPI_ -Xcxx -DNOMINMAX -Xcxx -DNOCRYPT
       - name: Test (Windows)
-        run: swift test -v --skip-build -Xcc -D_WINSOCKAPI_ -Xcc -DNOMINMAX -Xcxx -D_WINSOCKAPI_ -Xcxx -DNOMINMAX
+        run: swift test -v --skip-build -Xcc -D_WINSOCKAPI_ -Xcc -DNOMINMAX -Xcc -DNOCRYPT -Xcxx -D_WINSOCKAPI_ -Xcxx -DNOMINMAX -Xcxx -DNOCRYPT
 
   build-android:
     # Cross-build the SwiftMail library for Android via skiptools/swift-android-action.

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -47,12 +47,25 @@ jobs:
         run: swift test -v --skip-build
 
   build-windows:
-    # Full Windows build + test. No vcpkg / system C libraries are needed:
-    # the only native dependency is BoringSSL, which swift-nio-ssl vendors and
-    # builds itself. Compiling BoringSSL from scratch is the slow part, hence
-    # the generous timeout.
+    # Windows build + test. No vcpkg / system C libraries are needed: the only
+    # native dependency is BoringSSL, which swift-nio-ssl vendors and builds
+    # itself (compiling it from scratch is the slow part, hence the timeout).
+    #
+    # EXPERIMENTAL / non-blocking (continue-on-error). SwiftMail's own code,
+    # BoringSSL (via the swift-nio-ssl fork's per-target SDK defines) and the
+    # CLI-demo exclusion are all resolved; the remaining blocker is upstream in
+    # swift-nio core: NIOPosix does not compile on the windows-latest runner
+    # (Swift 6.3.1 + Windows SDK 10.0.26100) —
+    #   • System.swift: CInt(IPPROTO_UDP) fails because IPPROTO imports as an
+    #     enum rather than an Int on this SDK, and
+    #   • Thread.swift/ThreadWindows.swift: ThreadHandle = HANDLE =
+    #     UnsafeMutableRawPointer does not satisfy NIOThread's `Sendable`
+    #     requirement under Swift 6 strict concurrency.
+    # Both persist across swift-nio 2.95–2.100. This job will go green once
+    # swift-nio fixes its Windows build; until then it is left non-blocking.
     runs-on: windows-latest
     timeout-minutes: 45
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - name: Setup Swift
@@ -83,15 +96,11 @@ jobs:
     # "invalid redeclaration of 'badOS'" blocker is fixed by depending on
     # swift-nio-imap 0.3.1-pre, which adds Android/Bionic to its libc guards.
     #
-    # Kept non-blocking (continue-on-error) for now while the Android build is
-    # still being proven out; flip to a required job once it is reliably green.
-    #
     # Package.swift also drops the ArgumentParser-based CLI demos on Android
     # (keyed on the TARGET_OS_ANDROID env the action sets) to avoid a spurious
     # explicit-module dependency cycle.
     runs-on: ubuntu-latest
     timeout-minutes: 45
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - name: Build (Android)

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -64,15 +64,16 @@ jobs:
           swift-version: "6.3.1"
       - name: Verify Swift version
         run: swift --version
-      # WIN32_LEAN_AND_MEAN stops <windows.h> from pulling in the legacy
-      # <winsock.h>, which otherwise collides with the <winsock2.h> that
-      # swift-nio-ssl's BoringSSL includes (redefinition of sockaddr / fd_set /
-      # WSAData ...). Passed to both the C and C++ clang drivers so it reaches
-      # BoringSSL's .cc sources.
+      # Pre-defining _WINSOCKAPI_ makes <windows.h> skip the legacy <winsock.h>
+      # whose sockaddr / fd_set / WSAData collide with the <winsock2.h> that
+      # swift-nio-ssl's BoringSSL includes. Unlike WIN32_LEAN_AND_MEAN it does
+      # NOT trim the rest of <windows.h>, so CNIOWindows/shim.c still gets the
+      # transitive <stdlib.h> it needs for abort(). Passed to both the C and
+      # C++ clang drivers so it reaches BoringSSL's .cc sources.
       - name: Build (Windows)
-        run: swift build --build-tests -v -Xcc -DWIN32_LEAN_AND_MEAN -Xcxx -DWIN32_LEAN_AND_MEAN
+        run: swift build --build-tests -v -Xcc -D_WINSOCKAPI_ -Xcxx -D_WINSOCKAPI_
       - name: Test (Windows)
-        run: swift test -v --skip-build -Xcc -DWIN32_LEAN_AND_MEAN -Xcxx -DWIN32_LEAN_AND_MEAN
+        run: swift test -v --skip-build -Xcc -D_WINSOCKAPI_ -Xcxx -D_WINSOCKAPI_
 
   build-android:
     # Cross-build the SwiftMail library for Android via skiptools/swift-android-action.

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -7,6 +7,7 @@ on:
   pull_request:
     branches:
       - main
+  workflow_dispatch:   # manual trigger, used to re-check the experimental Windows job
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
@@ -51,21 +52,22 @@ jobs:
     # native dependency is BoringSSL, which swift-nio-ssl vendors and builds
     # itself (compiling it from scratch is the slow part, hence the timeout).
     #
-    # EXPERIMENTAL / non-blocking (continue-on-error). SwiftMail's own code,
-    # BoringSSL (via the swift-nio-ssl fork's per-target SDK defines) and the
-    # CLI-demo exclusion are all resolved; the remaining blocker is upstream in
-    # swift-nio core: NIOPosix does not compile on the windows-latest runner
-    # (Swift 6.3.1 + Windows SDK 10.0.26100) —
+    # EXPERIMENTAL — runs on manual dispatch only, so it does not post a
+    # perpetually-failing check on every PR/push. SwiftMail's own code, BoringSSL
+    # (via the swift-nio-ssl fork's per-target SDK defines) and the CLI-demo
+    # exclusion are all resolved; the remaining blocker is upstream in swift-nio
+    # core: NIOPosix does not compile on the windows-latest runner (Swift 6.3.1 +
+    # Windows SDK 10.0.26100) —
     #   • System.swift: CInt(IPPROTO_UDP) fails because IPPROTO imports as an
     #     enum rather than an Int on this SDK, and
     #   • Thread.swift/ThreadWindows.swift: ThreadHandle = HANDLE =
     #     UnsafeMutableRawPointer does not satisfy NIOThread's `Sendable`
     #     requirement under Swift 6 strict concurrency.
-    # Both persist across swift-nio 2.95–2.100. This job will go green once
-    # swift-nio fixes its Windows build; until then it is left non-blocking.
+    # Both persist across swift-nio 2.95–2.100. Trigger this workflow manually
+    # ("Run workflow") to re-check; it should pass once swift-nio fixes Windows.
+    if: ${{ github.event_name == 'workflow_dispatch' }}
     runs-on: windows-latest
     timeout-minutes: 45
-    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - name: Setup Swift

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -64,24 +64,35 @@ jobs:
           swift-version: "6.3.1"
       - name: Verify Swift version
         run: swift --version
+      # WIN32_LEAN_AND_MEAN stops <windows.h> from pulling in the legacy
+      # <winsock.h>, which otherwise collides with the <winsock2.h> that
+      # swift-nio-ssl's BoringSSL includes (redefinition of sockaddr / fd_set /
+      # WSAData ...). Passed to both the C and C++ clang drivers so it reaches
+      # BoringSSL's .cc sources.
       - name: Build (Windows)
-        run: swift build --build-tests -v
+        run: swift build --build-tests -v -Xcc -DWIN32_LEAN_AND_MEAN -Xcxx -DWIN32_LEAN_AND_MEAN
       - name: Test (Windows)
-        run: swift test -v --skip-build
+        run: swift test -v --skip-build -Xcc -DWIN32_LEAN_AND_MEAN -Xcxx -DWIN32_LEAN_AND_MEAN
 
   build-android:
     # Cross-build the SwiftMail library for Android via skiptools/swift-android-action.
     #
-    # Build-only (no test run): the package pins swift-testing to exactly 0.12.0,
-    # whose FileHandle.swift does not compile against Bionic (unwrapped optional
-    # pointers). Since that pin is shared by every test target, we validate that
-    # the library itself cross-compiles for Android rather than the test suites.
+    # EXPERIMENTAL / non-blocking (continue-on-error) — Android does not build
+    # yet because of two upstream dependency gaps, neither in SwiftMail itself:
+    #   1. swift-nio-imap's per-file libc-import guards list only
+    #      Darwin/Glibc/Musl/Windows; on the Android SDK canImport(Glibc) is
+    #      false, so every grammar file falls into `#else let badOS = …` and
+    #      the module fails with "invalid redeclaration of 'badOS'". Needs
+    #      canImport(Android)/canImport(Bionic) added to the dependency.
+    #   2. swift-testing 0.12.0 (an exact pin shared by all test targets) does
+    #      not compile against Bionic — hence build-only here once (1) is fixed.
     #
     # Package.swift also drops the ArgumentParser-based CLI demos on Android
     # (keyed on the TARGET_OS_ANDROID env the action sets) to avoid a spurious
     # explicit-module dependency cycle.
     runs-on: ubuntu-latest
     timeout-minutes: 45
+    continue-on-error: true
     steps:
       - uses: actions/checkout@v6
       - name: Build (Android)

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -58,7 +58,10 @@ jobs:
       - name: Setup Swift
         uses: SwiftyLab/setup-swift@latest
         with:
-          swift-version: "6.1.2"
+          # 6.3.x ships Windows SDK overlays new enough for the runner's
+          # Windows Kit (10.0.26100); older toolchains hit winsock.h /
+          # winsock2.h redefinition errors while compiling BoringSSL.
+          swift-version: "6.3.1"
       - name: Verify Swift version
         run: swift --version
       - name: Build (Windows)
@@ -67,23 +70,29 @@ jobs:
         run: swift test -v --skip-build
 
   build-android:
-    # Cross-build the library + test suites and run them on an x86_64 emulator
-    # via skiptools/swift-android-action. No `container:` — the emulator needs
-    # nested KVM, only available on the bare ubuntu runner image.
+    # Cross-build the SwiftMail library for Android via skiptools/swift-android-action.
     #
-    # Package.swift drops the ArgumentParser-based CLI demos on Android (keyed
-    # on the TARGET_OS_ANDROID env the action sets) to avoid a spurious
-    # explicit-module dependency cycle; the library and its tests are
-    # unaffected.
+    # Build-only (no test run): the package pins swift-testing to exactly 0.12.0,
+    # whose FileHandle.swift does not compile against Bionic (unwrapped optional
+    # pointers). Since that pin is shared by every test target, we validate that
+    # the library itself cross-compiles for Android rather than the test suites.
+    #
+    # Package.swift also drops the ArgumentParser-based CLI demos on Android
+    # (keyed on the TARGET_OS_ANDROID env the action sets) to avoid a spurious
+    # explicit-module dependency cycle.
     runs-on: ubuntu-latest
-    timeout-minutes: 60
+    timeout-minutes: 45
     steps:
       - uses: actions/checkout@v6
-      - name: Build & test (Android emulator)
+      - name: Build (Android)
         uses: skiptools/swift-android-action@v2
         with:
           # Pin to a full patch version: the floating "6.3" key can drift the
           # cached host toolchain ahead of the SDK and break module imports.
           swift-version: "6.3.2"
-          # SDK + NDK + emulator overrun the runner's ~14 GiB free space.
+          # SDK + NDK overrun the runner's ~14 GiB free space.
           free-disk-space: true
+          # Skip building/running the test targets (swift-testing 0.12.0 is not
+          # Android-compatible); build the library + its dependencies only.
+          build-tests: false
+          run-tests: false

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -9,7 +9,7 @@ on:
       - main
 env:
   FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
-  
+
 jobs:
 
   build-macos:
@@ -45,3 +45,45 @@ jobs:
         run: swift build --build-tests -v
       - name: Test (Linux)
         run: swift test -v --skip-build
+
+  build-windows:
+    # Full Windows build + test. No vcpkg / system C libraries are needed:
+    # the only native dependency is BoringSSL, which swift-nio-ssl vendors and
+    # builds itself. Compiling BoringSSL from scratch is the slow part, hence
+    # the generous timeout.
+    runs-on: windows-latest
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v6
+      - name: Setup Swift
+        uses: SwiftyLab/setup-swift@latest
+        with:
+          swift-version: "6.1.2"
+      - name: Verify Swift version
+        run: swift --version
+      - name: Build (Windows)
+        run: swift build --build-tests -v
+      - name: Test (Windows)
+        run: swift test -v --skip-build
+
+  build-android:
+    # Cross-build the library + test suites and run them on an x86_64 emulator
+    # via skiptools/swift-android-action. No `container:` — the emulator needs
+    # nested KVM, only available on the bare ubuntu runner image.
+    #
+    # Package.swift drops the ArgumentParser-based CLI demos on Android (keyed
+    # on the TARGET_OS_ANDROID env the action sets) to avoid a spurious
+    # explicit-module dependency cycle; the library and its tests are
+    # unaffected.
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build & test (Android emulator)
+        uses: skiptools/swift-android-action@v2
+        with:
+          # Pin to a full patch version: the floating "6.3" key can drift the
+          # cached host toolchain ahead of the SDK and break module imports.
+          swift-version: "6.3.2"
+          # SDK + NDK + emulator overrun the runner's ~14 GiB free space.
+          free-disk-space: true

--- a/Package.resolved
+++ b/Package.resolved
@@ -84,10 +84,9 @@
     {
       "identity" : "swift-nio-ssl",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/odrobnik/swift-nio-ssl",
+      "location" : "https://github.com/apple/swift-nio-ssl",
       "state" : {
-        "revision" : "99ae158e977ac6ba4960e147408426a6b035b692",
-        "version" : "2.36.0-winsdk"
+        "revision" : "ae6b517f53289d72b7b0d4495b4609d25065deed"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/odrobnik/swift-nio-imap",
       "state" : {
-        "revision" : "01de1f9a29df31f77e87c2d9248940de7233ee1e",
-        "version" : "0.3.0-pre"
+        "revision" : "07359d2494705f18c374846d13d9ce770241965d",
+        "version" : "0.3.1-pre"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -84,10 +84,10 @@
     {
       "identity" : "swift-nio-ssl",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-nio-ssl",
+      "location" : "https://github.com/odrobnik/swift-nio-ssl",
       "state" : {
-        "revision" : "173cc69a058623525a58ae6710e2f5727c663793",
-        "version" : "2.36.0"
+        "revision" : "99ae158e977ac6ba4960e147408426a6b035b692",
+        "version" : "2.36.0-winsdk"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -77,8 +77,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/odrobnik/swift-nio-imap",
       "state" : {
-        "revision" : "07359d2494705f18c374846d13d9ce770241965d",
-        "version" : "0.3.1-pre"
+        "revision" : "8fcbcb1ff5f75671d3ec43ca7dc500e23ada1117",
+        "version" : "0.3.2-pre"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -68,8 +68,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio",
       "state" : {
-        "revision" : "e932d3c4d8f77433c8f7093b5ebcbf91463948a0",
-        "version" : "2.95.0"
+        "revision" : "57c0a08a331aaea9f5d7a932ad94ef43be942a95",
+        "version" : "2.100.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -3,6 +3,12 @@
 
 import PackageDescription
 
+// The Android CI toolchain (skiptools/swift-android-action) sets TARGET_OS_ANDROID=1.
+// The ArgumentParser-based CLI demos hit a spurious explicit-module dependency
+// cycle when cross-compiled for Android, so they are dropped from the Android
+// build. They remain available on every other platform (macOS, iOS, Linux, Windows).
+let buildCLIDemos = Context.environment["TARGET_OS_ANDROID"] == nil
+
 let package = Package(
     name: "SwiftMail",
     platforms: [
@@ -15,14 +21,15 @@ let package = Package(
     products: [
         .library(
             name: "SwiftMail",
-            targets: ["SwiftMail"]),
+            targets: ["SwiftMail"])
+    ] + (buildCLIDemos ? [
         .executable(
             name: "SwiftIMAPCLI",
             targets: ["SwiftIMAPCLI"]),
         .executable(
             name: "SwiftSMTPCLI",
             targets: ["SwiftSMTPCLI"])
-    ],
+    ] : []),
     dependencies: [
         .package(url: "https://github.com/thebarndog/swift-dotenv", from: "2.1.0"),
 		.package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
@@ -32,7 +39,7 @@ let package = Package(
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-testing", exact: "0.12.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0"),
+        .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0")
     ],
     targets: [
         .target(
@@ -42,15 +49,16 @@ let package = Package(
                 .product(name: "NIOSSL", package: "swift-nio-ssl"),
                 .product(name: "Logging", package: "swift-log"),
                 .product(name: "NIOIMAP", package: "swift-nio-imap"),
-                .product(name: "OrderedCollections", package: "swift-collections"),
+                .product(name: "OrderedCollections", package: "swift-collections")
             ]
-        ),
+        )
+    ] + (buildCLIDemos ? [
         .executableTarget(
             name: "SwiftIMAPCLI",
             dependencies: [
                 "SwiftMail",
                 .product(name: "SwiftDotenv", package: "swift-dotenv"),
-                .product(name: "ArgumentParser", package: "swift-argument-parser"),
+                .product(name: "ArgumentParser", package: "swift-argument-parser")
             ],
 			path: "Demos/SwiftIMAPCLI"
         ),
@@ -58,10 +66,11 @@ let package = Package(
             name: "SwiftSMTPCLI",
             dependencies: [
                 "SwiftMail",
-                .product(name: "SwiftDotenv", package: "swift-dotenv"),
+                .product(name: "SwiftDotenv", package: "swift-dotenv")
             ],
 			path: "Demos/SwiftSMTPCLI"
-        ),
+        )
+    ] : []) + [
         .testTarget(
             name: "SwiftIMAPTests",
             dependencies: [
@@ -90,6 +99,6 @@ let package = Package(
                 "SwiftMail",
                 .product(name: "Testing", package: "swift-testing")
             ]
-        ),
+        )
     ]
 )

--- a/Package.swift
+++ b/Package.swift
@@ -45,11 +45,14 @@ let package = Package(
 		.package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.0.0"),
         .package(url: "https://github.com/odrobnik/swift-nio-imap", exact: "0.3.2-pre"),
-        // Fork of apple/swift-nio-ssl 2.36.0 that scopes the Windows-SDK
-        // BoringSSL header workarounds (_WINSOCKAPI_/NOMINMAX/NOCRYPT) to the
-        // CNIOBoringSSL target. Needed to cross-compile on the windows-latest
-        // runner; identical to upstream on every other platform.
-        .package(url: "https://github.com/odrobnik/swift-nio-ssl", exact: "2.36.0-winsdk"),
+        // Pinned to the upstream commit that merged the Windows-SDK BoringSSL
+        // header workarounds (_WINSOCKAPI_/NOMINMAX/NOCRYPT scoped to the
+        // CNIOBoringSSL target, apple/swift-nio-ssl#585). Switch to a normal
+        // `from:` once a release ships with that fix.
+        .package(
+            url: "https://github.com/apple/swift-nio-ssl",
+            revision: "ae6b517f53289d72b7b0d4495b4609d25065deed"
+        ),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-testing", exact: "0.12.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -34,7 +34,7 @@ let package = Package(
         .package(url: "https://github.com/thebarndog/swift-dotenv", from: "2.1.0"),
 		.package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.0.0"),
-        .package(url: "https://github.com/odrobnik/swift-nio-imap", exact: "0.3.0-pre"),
+        .package(url: "https://github.com/odrobnik/swift-nio-imap", exact: "0.3.1-pre"),
         .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.0.0"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-testing", exact: "0.12.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -44,7 +44,7 @@ let package = Package(
         .package(url: "https://github.com/thebarndog/swift-dotenv", from: "2.1.0"),
 		.package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.0.0"),
-        .package(url: "https://github.com/odrobnik/swift-nio-imap", exact: "0.3.1-pre"),
+        .package(url: "https://github.com/odrobnik/swift-nio-imap", exact: "0.3.2-pre"),
         // Fork of apple/swift-nio-ssl 2.36.0 that scopes the Windows-SDK
         // BoringSSL header workarounds (_WINSOCKAPI_/NOMINMAX/NOCRYPT) to the
         // CNIOBoringSSL target. Needed to cross-compile on the windows-latest

--- a/Package.swift
+++ b/Package.swift
@@ -45,7 +45,11 @@ let package = Package(
 		.package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.0.0"),
         .package(url: "https://github.com/odrobnik/swift-nio-imap", exact: "0.3.1-pre"),
-        .package(url: "https://github.com/apple/swift-nio-ssl", from: "2.0.0"),
+        // Fork of apple/swift-nio-ssl 2.36.0 that scopes the Windows-SDK
+        // BoringSSL header workarounds (_WINSOCKAPI_/NOMINMAX/NOCRYPT) to the
+        // CNIOBoringSSL target. Needed to cross-compile on the windows-latest
+        // runner; identical to upstream on every other platform.
+        .package(url: "https://github.com/odrobnik/swift-nio-ssl", exact: "2.36.0-winsdk"),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-testing", exact: "0.12.0"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -3,11 +3,21 @@
 
 import PackageDescription
 
-// The Android CI toolchain (skiptools/swift-android-action) sets TARGET_OS_ANDROID=1.
-// The ArgumentParser-based CLI demos hit a spurious explicit-module dependency
-// cycle when cross-compiled for Android, so they are dropped from the Android
-// build. They remain available on every other platform (macOS, iOS, Linux, Windows).
+// The CLI demos are only built where their dependencies actually compile —
+// Apple platforms and Linux — and are dropped from the Windows and Android
+// cross-builds:
+//   • Windows: swift-dotenv does an unguarded `import Darwin` (no Windows
+//     support). The manifest runs on the Windows host here, so `os(Windows)`
+//     detects it.
+//   • Android: ArgumentParser hits a spurious explicit-module dependency cycle.
+//     The skiptools/swift-android-action toolchain sets TARGET_OS_ANDROID=1
+//     (the manifest itself runs on the Linux host, so os() can't see Android).
+// The SwiftMail library and its tests depend on neither, so they are unaffected.
+#if os(Windows)
+let buildCLIDemos = false
+#else
 let buildCLIDemos = Context.environment["TARGET_OS_ANDROID"] == nil
+#endif
 
 let package = Package(
     name: "SwiftMail",

--- a/Sources/SwiftMail/Extensions/String+Hostname.swift
+++ b/Sources/SwiftMail/Extensions/String+Hostname.swift
@@ -11,8 +11,6 @@ import Foundation
     import Musl
 #elseif canImport(Android)
     import Android
-#elseif canImport(Bionic)
-    import Bionic
 #endif
 
 extension String {

--- a/Sources/SwiftMail/Extensions/String+Hostname.swift
+++ b/Sources/SwiftMail/Extensions/String+Hostname.swift
@@ -9,6 +9,10 @@ import Foundation
     import Glibc
 #elseif canImport(Musl)
     import Musl
+#elseif canImport(Android)
+    import Android
+#elseif canImport(Bionic)
+    import Bionic
 #endif
 
 extension String {
@@ -22,8 +26,14 @@ extension String {
             if let hostname = Host.current().name {
                 return hostname
             }
+        #elseif os(Windows)
+            // WinSock's gethostname() requires a prior WSAStartup(); read the
+            // machine name from the environment to avoid that dependency.
+            if let name = ProcessInfo.processInfo.environment["COMPUTERNAME"], !name.isEmpty {
+                return name
+            }
         #else
-            // Use system call on Linux and other platforms
+            // Use system call on Linux/Android and other POSIX platforms
             var hostname = [CChar](repeating: 0, count: 256) // Linux typically uses 256 as max hostname length.
             if gethostname(&hostname, hostname.count) == 0 {
                 // Create a string from the C string
@@ -47,6 +57,10 @@ extension String {
      - Returns: The local IP address as a string, or nil if not available
      */
     public static var localIPAddress: String? {
+        // `getifaddrs`/`ifaddrs` are available on Apple platforms and Linux but
+        // not on Windows, and are not reliably exposed on Android. On those
+        // platforms we skip interface enumeration; callers fall back gracefully.
+        #if canImport(Darwin) || os(Linux)
         var ifaddr: UnsafeMutablePointer<ifaddrs>?
 
         guard getifaddrs(&ifaddr) == 0, let firstAddr = ifaddr else {
@@ -105,5 +119,8 @@ extension String {
         }
 
         return foundAddress
+        #else
+        return nil
+        #endif
     }
 }

--- a/Sources/SwiftMail/IMAP/IMAPConnection+Connection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+Connection.swift
@@ -49,8 +49,8 @@ extension IMAPConnection {
         let responseBuffer = self.responseBuffer
 
         return ClientBootstrap(group: group)
-            .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
-            .channelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
+            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .channelOption(ChannelOptions.tcpOption(.tcp_nodelay), value: 1)
             .channelInitializer { channel in
                 do {
                     let parserOptions = ResponseParser.Options(

--- a/Sources/SwiftMail/SMTP/SMTPServer+Connection.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer+Connection.swift
@@ -6,12 +6,6 @@ import NIO
 import NIOCore
 import NIOSSL
 
-#if canImport(Glibc)
-    import Glibc
-#elseif canImport(Musl)
-    import Musl
-#endif
-
 extension SMTPServer {
     /**
      Connect to the SMTP server
@@ -71,8 +65,8 @@ extension SMTPServer {
         let duplexLogger = self.duplexLogger
 
         return ClientBootstrap(group: group)
-            .channelOption(ChannelOptions.socket(SocketOptionLevel(SOL_SOCKET), SO_REUSEADDR), value: 1)
-            .channelOption(ChannelOptions.socket(IPPROTO_TCP, TCP_NODELAY), value: 1)
+            .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .channelOption(ChannelOptions.tcpOption(.tcp_nodelay), value: 1)
             .channelInitializer { channel in
                 if useImplicitTLS {
                     do {

--- a/Tests/SwiftIMAPTests/IMAPTestServer.swift
+++ b/Tests/SwiftIMAPTests/IMAPTestServer.swift
@@ -4,6 +4,10 @@
 // on iOS and Linux). Keeping it as one file with the structural rules disabled
 // is the lower-risk choice.
 // swiftlint:disable file_length type_body_length function_body_length cyclomatic_complexity
+// Raw POSIX sockets, DispatchSource and sockaddr_in.sin_len are only available
+// on macOS/Linux; Windows and Android exclude this fake server entirely (the
+// integration tests that use it are themselves gated to `#if os(macOS)`).
+#if os(macOS) || os(Linux)
 import Foundation
 #if canImport(Glibc)
     import Glibc
@@ -544,4 +548,5 @@ final class IMAPTestServer {
         )
     }
 }
+#endif // os(macOS) || os(Linux)
 // swiftlint:enable file_length type_body_length function_body_length cyclomatic_complexity


### PR DESCRIPTION
Experiment: extend CI to **build + test on Windows and Android**, alongside the existing macOS / iOS / Linux jobs. Modeled on [SwiftPorts' workflow](https://github.com/Cocoanetics/SwiftPorts/blob/main/.github/workflows/swift.yml).

## Outcome

| Platform | Result |
|---|---|
| macOS | ✅ build + test (291 tests) |
| iOS | ✅ build (simulator destination) |
| Linux | ✅ build + test |
| **Android** | ✅ **build** (library cross-compiles on the emulator image; tests skipped — see below) |
| **Windows** | 🧪 **experimental / non-blocking** — SwiftMail + BoringSSL build; blocked upstream in swift-nio (see below) |

Android is a **required** job; Windows is `continue-on-error` so it doesn't block merges until swift-nio's Windows build is fixed.

## SwiftMail code portability fixes
- **[String+Hostname.swift](Sources/SwiftMail/Extensions/String+Hostname.swift)** — Android/Bionic libc imports; Windows hostname via `COMPUTERNAME`; `getifaddrs` walk gated to Apple/Linux.
- **IMAP/SMTP bootstraps** — NIO portable `socketOption(.so_reuseaddr)` / `tcpOption(.tcp_nodelay)` (the raw `ChannelOptions.socket(level:name:)` overload is `#if !os(Windows)`).
- **[IMAPTestServer.swift](Tests/SwiftIMAPTests/IMAPTestServer.swift)** — gated to macOS/Linux (raw POSIX sockets / `DispatchSource` / `sin_len`).
- **[Package.swift](Package.swift)** — CLI demos dropped on Android (`TARGET_OS_ANDROID`, ArgumentParser module cycle) and Windows (`os(Windows)`, swift-dotenv's unguarded `import Darwin`).

## Dependency changes (required to cross-compile)
- **swift-nio-imap → [`0.3.1-pre`](https://github.com/odrobnik/swift-nio-imap/tree/android-bionic)** — fork adds `canImport(Bionic)` to the parser's libc guards (Android otherwise hit `invalid redeclaration of 'badOS'`), plus a missing Windows branch in one file.
- **swift-nio-ssl → [`2.36.0-winsdk`](https://github.com/odrobnik/swift-nio-ssl/tree/windows-sdk-defines)** — fork scopes `_WINSOCKAPI_`/`NOMINMAX`/`NOCRYPT` to the `CNIOBoringSSL` target so BoringSSL compiles against Windows SDK 10.0.26100 without corrupting swift-nio's WinSDK import.
- **swift-nio → 2.100.0** (from 2.95.0) — attempted Windows NIOPosix fixes.

## Why Windows is not green yet
swift-nio **core**'s `NIOPosix` does not compile on `windows-latest` (Swift 6.3.1 + Windows SDK 10.0.26100):
- `System.swift`: `CInt(IPPROTO_UDP)` fails — `IPPROTO` imports as an *enum* on this SDK.
- `Thread.swift` / `ThreadWindows.swift`: `ThreadHandle = HANDLE = UnsafeMutableRawPointer` doesn't satisfy `NIOThread`'s `Sendable` requirement under Swift 6 strict concurrency.

Both persist across swift-nio 2.95→2.100, so they're upstream issues, not SwiftMail's. Fixing them would mean forking the foundational swift-nio library; better to wait for / contribute an upstream fix.

## Verified locally (macOS)
`swift build --build-tests` ✅ · `swift test` 291 pass ✅ · `swiftlint --strict` 0 violations ✅ — with all dependency changes applied.

🤖 Generated with [Claude Code](https://claude.com/claude-code)