### PR TITLE
Depend on upstream apple/swift-nio-imap; drop the fork

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -75,10 +75,9 @@
     {
       "identity" : "swift-nio-imap",
       "kind" : "remoteSourceControl",
-      "location" : "https://github.com/odrobnik/swift-nio-imap",
+      "location" : "https://github.com/apple/swift-nio-imap",
       "state" : {
-        "revision" : "8fcbcb1ff5f75671d3ec43ca7dc500e23ada1117",
-        "version" : "0.3.2-pre"
+        "revision" : "bcf875610ca56dfd7bae869fa19ca3149c075908"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -54,7 +54,14 @@ let package = Package(
             revision: "63fd355925644600540d9e3b29cd0de64dd2e1c3"
         ),
         .package(url: "https://github.com/apple/swift-nio", from: "2.0.0"),
-        .package(url: "https://github.com/odrobnik/swift-nio-imap", exact: "0.3.2-pre"),
+        // Upstream now carries the Android/Bionic libc-guard fix for NIOIMAPCore
+        // (apple/swift-nio-imap#826), so depend on it directly instead of a fork.
+        // No release contains it yet (latest tag is 0.2.0) — pin the merge
+        // revision; switch to `from:` once a release ships.
+        .package(
+            url: "https://github.com/apple/swift-nio-imap",
+            revision: "bcf875610ca56dfd7bae869fa19ca3149c075908"
+        ),
         // Pinned to the upstream commit that merged the Windows-SDK BoringSSL
         // header workarounds (_WINSOCKAPI_/NOMINMAX/NOCRYPT scoped to the
         // CNIOBoringSSL target, apple/swift-nio-ssl#585). Switch to a normal


### PR DESCRIPTION
swift-nio-imap merged the Android libc-guard fix for `NIOIMAPCore` ([apple/swift-nio-imap#826](https://github.com/apple/swift-nio-imap/pull/826)), so the `odrobnik/swift-nio-imap` fork is no longer needed — SwiftMail now depends on `apple/swift-nio-imap` directly.

- Upstream merged it using `import Bionic` (consistent with swift-nio's own libc-import convention); it compiles on Android the same as `import Android` would.
- No upstream release contains the fix yet (latest tag is 0.2.0), so this pins the merge revision (`bcf8756`); switch to `from:` once a release ships — consistent with how swift-nio-ssl is pinned here.

Removes SwiftMail's dependency on the fork. macOS build + 285 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)