### PR TITLE
Update SwiftCross to 1.2.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -129,7 +129,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/Cocoanetics/SwiftCross",
       "state" : {
-        "revision" : "63fd355925644600540d9e3b29cd0de64dd2e1c3"
+        "revision" : "cc164b31ede7d2ee72af713b59c5d1f9be1556e0",
+        "version" : "1.2.0"
       }
     }
   ],

--- a/Package.swift
+++ b/Package.swift
@@ -46,13 +46,8 @@ let package = Package(
         .package(url: "https://github.com/thebarndog/swift-dotenv", from: "2.1.0"),
 		.package(url: "https://github.com/apple/swift-log.git", from: "1.0.0"),
         // Cross-platform Foundation compatibility shims (UTType, charset/IANA
-        // encoding, ProcessInfo.localIPAddress). No release tag yet — pinned to
-        // the commit that gives UTType its comprehensive extension/MIME table
-        // (merged in Cocoanetics/SwiftCross#2); switch to `from:` once SwiftCross ships a release.
-        .package(
-            url: "https://github.com/Cocoanetics/SwiftCross",
-            revision: "63fd355925644600540d9e3b29cd0de64dd2e1c3"
-        ),
+        // encoding, ProcessInfo.localIPAddress).
+        .package(url: "https://github.com/Cocoanetics/SwiftCross", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.0.0"),
         // Upstream now carries the Android/Bionic libc-guard fix for NIOIMAPCore
         // (apple/swift-nio-imap#826), so depend on it directly instead of a fork.


### PR DESCRIPTION
SwiftCross shipped a **1.2.0** release (which includes the comprehensive UTType extension↔MIME table), so SwiftMail can drop the interim main-revision pin and depend on the tagged release.

- `revision: "63fd3559…"` → `from: "1.2.0"`
- Same deployment floors (iOS 15 / tvOS 15 / watchOS 8) and tools-version 6.1 — no other changes.

macOS build + 285 tests pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)