### PR TITLE
Update dependencies to latest

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -18,6 +18,14 @@ jobs:
     timeout-minutes: 10
     steps:
       - uses: actions/checkout@v6
+      # swift-testing 6.3.2 (shared by the test targets) has a swift-tools-version
+      # 6.2 manifest, which the runner's default Xcode (Swift 6.1.2) cannot
+      # resolve. Xcode 26.0 ships Swift 6.2 — same version already used by the
+      # iOS job, so it is known to be available on the runner.
+      - name: Select Xcode 26.0
+        uses: maxim-lobanov/setup-xcode@v1
+        with:
+          xcode-version: "26.0"
       - name: Verify Swift version
         run: swift --version
       - name: Build (macOS)
@@ -92,11 +100,11 @@ jobs:
   build-android:
     # Cross-build the SwiftMail library for Android via skiptools/swift-android-action.
     #
-    # Build-only (no test run): swift-testing 0.12.0 — an exact pin shared by
-    # every test target — does not compile against Bionic, so we validate that
-    # the library cross-compiles rather than the test suites. The earlier
-    # "invalid redeclaration of 'badOS'" blocker is fixed by depending on
-    # swift-nio-imap 0.3.1-pre, which adds Android/Bionic to its libc guards.
+    # Build-only (no test run): the test targets depend on swift-testing, whose
+    # Android compatibility is not validated here, so we check that the library
+    # cross-compiles rather than the test suites. The earlier "invalid
+    # redeclaration of 'badOS'" blocker is fixed upstream by apple/swift-nio-imap
+    # #826 (commit bcf8756), which adds Android/Bionic to NIOIMAPCore's libc guards.
     #
     # Package.swift also drops the ArgumentParser-based CLI demos on Android
     # (keyed on the TARGET_OS_ANDROID env the action sets) to avoid a spurious
@@ -113,7 +121,7 @@ jobs:
           swift-version: "6.3.2"
           # SDK + NDK overrun the runner's ~14 GiB free space.
           free-disk-space: true
-          # Skip building/running the test targets (swift-testing 0.12.0 is not
-          # Android-compatible); build the library + its dependencies only.
+          # Skip building/running the test targets (swift-testing's Android
+          # compatibility is unverified); build the library + its deps only.
           build-tests: false
           run-tests: false

--- a/Package.resolved
+++ b/Package.resolved
@@ -102,8 +102,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/swiftlang/swift-syntax.git",
       "state" : {
-        "revision" : "0687f71944021d616d34d922343dcef086855920",
-        "version" : "600.0.1"
+        "revision" : "9de99a78f099e59caf2b2beec65a4c45d54b2081",
+        "version" : "603.0.1"
       }
     },
     {
@@ -120,8 +120,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-testing",
       "state" : {
-        "revision" : "c55848b2aa4b29a4df542b235dfdd792a6fbe341",
-        "version" : "0.12.0"
+        "revision" : "70eff261d7f462cad1fff51e05bcc74aa0b0f420",
+        "version" : "6.3.2"
       }
     },
     {

--- a/Package.resolved
+++ b/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-argument-parser",
       "state" : {
-        "revision" : "c5d11a805e765f52ba34ec7284bd4fcd6ba68615",
-        "version" : "1.7.0"
+        "revision" : "ca37474853a4b5f59a22c74bfdd449b1f6bc4cc2",
+        "version" : "1.8.1"
       }
     },
     {
@@ -23,8 +23,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-collections.git",
       "state" : {
-        "revision" : "8d9834a6189db730f6264db7556a7ffb751e99ee",
-        "version" : "1.4.0"
+        "revision" : "fea17c02d767f46b23070fdfdacc28a03a39232a",
+        "version" : "1.5.1"
       }
     },
     {
@@ -32,8 +32,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-docc-plugin",
       "state" : {
-        "revision" : "e977f65879f82b375a044c8837597f690c067da6",
-        "version" : "1.4.6"
+        "revision" : "647c708be89f834fa6a6d4945442793a77ddf5b6",
+        "version" : "1.5.0"
       }
     },
     {
@@ -59,8 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log.git",
       "state" : {
-        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
-        "version" : "1.10.1"
+        "revision" : "2aed77ae5ec9a86d8fe42c12275e4c2653a286ee",
+        "version" : "1.13.1"
       }
     },
     {
@@ -85,7 +85,7 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-ssl",
       "state" : {
-        "revision" : "ae6b517f53289d72b7b0d4495b4609d25065deed"
+        "revision" : "407d82d5b6cc00e1c3fb83a81b1539b70c788c5e"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -57,13 +57,14 @@ let package = Package(
             url: "https://github.com/apple/swift-nio-imap",
             revision: "bcf875610ca56dfd7bae869fa19ca3149c075908"
         ),
-        // Pinned to the upstream commit that merged the Windows-SDK BoringSSL
-        // header workarounds (_WINSOCKAPI_/NOMINMAX/NOCRYPT scoped to the
-        // CNIOBoringSSL target, apple/swift-nio-ssl#585). Switch to a normal
-        // `from:` once a release ships with that fix.
+        // Pinned to the latest upstream main, which carries the Windows-SDK
+        // BoringSSL header workarounds (_WINSOCKAPI_/NOMINMAX/NOCRYPT scoped to
+        // the CNIOBoringSSL target, apple/swift-nio-ssl#585). No release contains
+        // that fix yet (latest tag is 2.37.0) — switch to a normal `from:` once
+        // one ships.
         .package(
             url: "https://github.com/apple/swift-nio-ssl",
-            revision: "ae6b517f53289d72b7b0d4495b4609d25065deed"
+            revision: "407d82d5b6cc00e1c3fb83a81b1539b70c788c5e"
         ),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-testing", exact: "0.12.0"),

--- a/Package.swift
+++ b/Package.swift
@@ -67,7 +67,11 @@ let package = Package(
             revision: "407d82d5b6cc00e1c3fb83a81b1539b70c788c5e"
         ),
         .package(url: "https://github.com/apple/swift-collections.git", from: "1.0.0"),
-        .package(url: "https://github.com/apple/swift-testing", exact: "0.12.0"),
+        // swift-testing releases track toolchain versions: 6.3.2's manifest is
+        // swift-tools-version 6.2, so every platform that compiles the test
+        // targets needs Swift 6.2+. The macOS CI job selects Xcode 26 for that
+        // reason (Linux/Android/Windows runners are already on Swift 6.3.x).
+        .package(url: "https://github.com/apple/swift-testing", exact: "6.3.2"),
         .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0")
     ],


### PR DESCRIPTION
Refreshes every dependency to its latest: `swift package update` for the version-range deps, a revision re-pin for swift-nio-ssl, and a swift-testing major bump (with the macOS CI toolchain raised to match).

## Version bumps
| Dependency | From | To |
|---|---|---|
| swift-argument-parser | 1.7.0 | 1.8.1 |
| swift-collections | 1.4.0 | 1.5.1 |
| swift-docc-plugin | 1.4.6 | 1.5.0 |
| swift-log | 1.10.1 | 1.13.1 |
| swift-nio-ssl | `ae6b517` | `407d82d` |
| swift-testing | 0.12.0 | 6.3.2 |
| swift-syntax (transitive) | 600.0.1 | 603.0.1 |

- **swift-nio-ssl** → latest upstream `main`, which still carries the [#585](https://github.com/apple/swift-nio-ssl/pull/585) Windows BoringSSL header workarounds (verified the `_WINSOCKAPI_`/`NOMINMAX`/`NOCRYPT` defines are still present). No release contains that fix yet (latest tag 2.37.0), so it stays a revision pin.
- **swift-testing** → 6.3.2. Its standalone releases now track toolchain versions: 6.3.2's manifest is `swift-tools-version: 6.2` and it requires swift-syntax 603.x. The macOS CI's default Xcode (Swift 6.1.2) can't resolve that, so **build-macos now selects Xcode 26.0 (Swift 6.2)** — the same Xcode the iOS job already uses, so it's known-available. Linux (6.3.1) / Android (6.3.2) / Windows (6.3.1) runners already clear the floor.

## Already at latest (unchanged)
swift-nio (2.100.0), SwiftCross (1.2.0), swift-nio-imap (`bcf8756`, latest `main` — [#829](https://github.com/apple/swift-nio-imap/pull/829) still open so it stays Bionic), plus transitive deps (atomics, system, docc-symbolkit, se0270-range-set, dotenv).

## Also
Refreshed stale `swift-testing 0.12.0` / `swift-nio-imap 0.3.1-pre` references in the Android job comments.

## Verification
`swift build --build-tests` clean, `swift test` — **285 tests pass** locally (Swift 6.3). First commit (range deps + nio-ssl) already went green on CI across macOS/iOS/Linux/Android.

🤖 Generated with [Claude Code](https://claude.com/claude-code)