### PR TITLE
Fix pipelined FETCH dispatcher dropping later parts when a server batches responses

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 .DS_Store
 /.build
+/build
 /Packages
 xcuserdata/
 DerivedData/

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/PipelinedCommandDispatcher.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/PipelinedCommandDispatcher.swift
@@ -4,7 +4,11 @@
 // IMAP RFC 3501 §5.5 allows clients to send multiple commands without waiting for responses.
 // The server processes commands in order and sends tagged responses (A001 OK, A002 OK, etc.)
 // so responses can be matched to commands by tag. Untagged responses (e.g., * FETCH data)
-// always belong to the oldest pending command (server processes commands serially).
+// carry no tag; they arrive in command order and are routed to the oldest command whose
+// untagged response has not yet finished, advancing on each response's `.finish`. A server
+// may stream data for several pipelined commands before sending any tagged OK (RFC 3501
+// §5.5), so advancing only on the tagged OK would misdeliver a later command's data to an
+// already-finished earlier handler and silently drop it.
 //
 // This handler sits in the NIO pipeline during a pipelined batch. It maintains an ordered
 // registry of (tag → PipelinedHandler) and routes responses accordingly.
@@ -22,16 +26,25 @@ final class PipelinedCommandDispatcher: ChannelInboundHandler, RemovableChannelH
 
     private let lock = NIOLock()
 
-    /// Ordered list of (tag, handler) — insertion order matches send order.
-    /// Untagged FETCH responses route to the first (oldest) entry per RFC 3501.
-    private var entries: [(tag: String, handler: any PipelinedHandler)] = []
+    /// A registered pipelined command awaiting its responses. `finishedUntagged` flips
+    /// once this command's untagged FETCH response has fully arrived (its `.finish`), so
+    /// subsequent untagged data routes to the next command even before any tagged OK.
+    private struct PendingCommand {
+        let tag: String
+        let handler: any PipelinedHandler
+        var finishedUntagged: Bool
+    }
+
+    /// Ordered registry — insertion order matches send order. Untagged FETCH responses
+    /// route to the oldest entry whose untagged response has not finished.
+    private var entries: [PendingCommand] = []
 
     private let logger = Logger(label: "com.cocoanetics.SwiftMail.PipelinedDispatcher")
 
     /// Register a handler for a command tag. Must be called in send order.
     func register(tag: String, handler: any PipelinedHandler) {
         lock.withLock {
-            entries.append((tag: tag, handler: handler))
+            entries.append(PendingCommand(tag: tag, handler: handler, finishedUntagged: false))
         }
     }
 
@@ -51,28 +64,16 @@ final class PipelinedCommandDispatcher: ChannelInboundHandler, RemovableChannelH
                     }
 
                 case .fetch(let fetchResponse):
-                    // RFC 3501: untagged FETCH responses belong to the oldest pending command
-                    // (server processes commands in order, sends untagged data before tagged OK)
-                    if let first = entries.first {
-                        first.handler.processFetchResponse(fetchResponse)
-                    }
+                    routeUntaggedFetch(fetchResponse)
 
                 case .untagged(let payload):
                     // BYE — server is terminating. Fail all pending handlers.
                     if case .conditionalState(let status) = payload, case .bye(let text) = status {
-                        let error = IMAPError.connectionFailed("Server terminated connection: \(text.text)")
-                        for entry in entries {
-                            entry.handler.fail(error)
-                        }
-                        entries.removeAll()
+                        failAllPending(IMAPError.connectionFailed("Server terminated connection: \(text.text)"))
                     }
 
                 case .fatal(let text):
-                    let error = IMAPError.connectionFailed("Server fatal error: \(text.text)")
-                    for entry in entries {
-                        entry.handler.fail(error)
-                    }
-                    entries.removeAll()
+                    failAllPending(IMAPError.connectionFailed("Server fatal error: \(text.text)"))
 
                 default:
                     break
@@ -83,23 +84,40 @@ final class PipelinedCommandDispatcher: ChannelInboundHandler, RemovableChannelH
         context.fireChannelRead(data)
     }
 
+    /// Route an untagged FETCH response to the oldest command whose untagged response has
+    /// not yet finished, marking it finished when its `.finish` arrives so the next response
+    /// routes to the next command. A server may emit untagged data for several pipelined
+    /// commands before any tagged OK (RFC 3501 §5.5); routing on the first entry and advancing
+    /// only on the tagged OK would misdeliver a later part's bytes to an already-finished
+    /// earlier handler — which drops them — leaving the later part (e.g. a multipart message's
+    /// text/html body) empty. Caller holds `lock`.
+    private func routeUntaggedFetch(_ fetchResponse: FetchResponse) {
+        guard let idx = entries.firstIndex(where: { !$0.finishedUntagged }) else { return }
+        entries[idx].handler.processFetchResponse(fetchResponse)
+        if case .finish = fetchResponse {
+            entries[idx].finishedUntagged = true
+        }
+    }
+
+    /// Fail every pending handler and clear the registry. Caller holds `lock`.
+    private func failAllPending(_ error: Error) {
+        for entry in entries {
+            entry.handler.fail(error)
+        }
+        entries.removeAll()
+    }
+
     func channelInactive(context: ChannelHandlerContext) {
         let error = IMAPError.connectionFailed("Connection closed during pipelined fetch")
         lock.withLock {
-            for entry in entries {
-                entry.handler.fail(error)
-            }
-            entries.removeAll()
+            failAllPending(error)
         }
         context.fireChannelInactive()
     }
 
     func errorCaught(context: ChannelHandlerContext, error: Error) {
         lock.withLock {
-            for entry in entries {
-                entry.handler.fail(error)
-            }
-            entries.removeAll()
+            failAllPending(error)
         }
         context.fireErrorCaught(error)
     }

--- a/Tests/SwiftIMAPTests/PipelinedFetchTests.swift
+++ b/Tests/SwiftIMAPTests/PipelinedFetchTests.swift
@@ -1,6 +1,7 @@
 import Foundation
 import Testing
 import NIO
+import NIOEmbedded
 import NIOConcurrencyHelpers
 @preconcurrency import NIOIMAP
 import NIOIMAPCore
@@ -177,5 +178,115 @@ struct PipelinedCommandDispatcherTests {
     func initEmpty() {
         let dispatcher = PipelinedCommandDispatcher()
         #expect(dispatcher.pendingCount == 0)
+    }
+
+    // MARK: - Response routing through channelRead
+
+    /// Build a `* FETCH (BODY[...] {n})` streaming-bytes response.
+    private func bytes(_ text: String) -> Response {
+        var buf = ByteBufferAllocator().buffer(capacity: text.utf8.count)
+        buf.writeString(text)
+        return .fetch(.streamingBytes(buf))
+    }
+
+    /// Build a tagged `<tag> OK completed` response.
+    private func taggedOK(_ tag: String) -> Response {
+        .tagged(TaggedResponse(tag: tag, state: .ok(ResponseText(text: "completed"))))
+    }
+
+    /// Drive the dispatcher through an `EmbeddedChannel` (single-threaded, synchronous)
+    /// with a scripted server response stream. One command is registered per tag (in
+    /// order); returns each pipelined part's resolved bytes as UTF-8, aligned to `tags`.
+    /// A `nil` result means that part's promise never resolved.
+    private func resolveParts(tags: [String], stream: [Response]) throws -> [String?] {
+        let loop = EmbeddedEventLoop()
+        let channel = EmbeddedChannel(loop: loop)
+        let dispatcher = PipelinedCommandDispatcher()
+        try channel.pipeline.syncOperations.addHandler(dispatcher)
+
+        // EmbeddedEventLoop fires future callbacks inline when run — capture results
+        // synchronously into a box so the test stays single-threaded (no cross-loop
+        // promise + async await, which trips EmbeddedEventLoop's thread-safety check).
+        final class Box: @unchecked Sendable { var results: [Data?] = [] }
+        let box = Box(); box.results = Array(repeating: nil, count: tags.count)
+        for (index, tag) in tags.enumerated() {
+            let promise = loop.makePromise(of: Data.self)
+            promise.futureResult.whenSuccess { box.results[index] = $0 }
+            dispatcher.register(tag: tag, handler: PipelinedFetchPartHandler(promise: promise))
+        }
+
+        for response in stream {
+            try channel.writeInbound(response)
+        }
+        loop.run()
+        _ = try? channel.finish()
+
+        return box.results.map { $0.flatMap { String(bytes: $0, encoding: .utf8) } }
+    }
+
+    /// Control: a server that strictly interleaves `data → OK → data → OK` routes
+    /// each pipelined part to its own handler. This path works today and must keep
+    /// working after the fix.
+    @Test("Interleaved untagged FETCH (data, OK, data, OK) routes each part correctly")
+    func interleavedRoutesToCorrectHandler() throws {
+        let stream: [Response] = [
+            .fetch(.start(.init(1))), bytes("PLAINTEXT"), .fetch(.finish), taggedOK("A001"),
+            .fetch(.start(.init(1))), bytes("<html>HI</html>"), .fetch(.finish), taggedOK("A002")
+        ]
+        let parts = try resolveParts(tags: ["A001", "A002"], stream: stream)
+        #expect(parts == ["PLAINTEXT", "<html>HI</html>"])
+    }
+
+    /// Regression reproduction for the "HTML email rendered as plaintext" bug.
+    ///
+    /// A server is allowed (RFC 3501 §5.5) to emit untagged FETCH data for MULTIPLE
+    /// pipelined commands before sending their tagged OKs — common when responses are
+    /// small and back-to-back (e.g. two sections of one short multipart/alternative).
+    /// Wire order here: BODY[1] data, BODY[2] data, A001 OK, A002 OK.
+    ///
+    /// Pre-fix the dispatcher routed untagged FETCH to `entries.first` and only advanced
+    /// on a tagged OK, so BODY[2]'s bytes were delivered to A001 (which had already
+    /// finished part 1 and silently dropped them), leaving A002 — the text/html part —
+    /// resolved EMPTY. Empty html ⇒ BodyRenderer falls back to plainTextToHTML ⇒ the
+    /// HTML email is cached as escaped plaintext until pull-to-refresh.
+    @Test("Batched untagged FETCH (both parts' data before either tagged OK) must not drop the second part")
+    func batchedUntaggedRoutesToCorrectHandler() throws {
+        let stream: [Response] = [
+            .fetch(.start(.init(1))), bytes("PLAINTEXT"), .fetch(.finish),
+            .fetch(.start(.init(1))), bytes("<html>HI</html>"), .fetch(.finish),
+            taggedOK("A001"), taggedOK("A002")
+        ]
+        let parts = try resolveParts(tags: ["A001", "A002"], stream: stream)
+        #expect(parts == ["PLAINTEXT", "<html>HI</html>"])
+    }
+
+    /// Three pipelined parts, fully batched (all data, then all OKs). Locks in that the
+    /// routing cursor advances across MULTIPLE `.finish` boundaries — pre-fix, parts 2
+    /// AND 3 were both dropped (all untagged data routed to the first, finished handler).
+    @Test("Three batched untagged FETCH responses each route to their own handler")
+    func threeBatchedPartsRouteCorrectly() throws {
+        let stream: [Response] = [
+            .fetch(.start(.init(1))), bytes("ONE"), .fetch(.finish),
+            .fetch(.start(.init(1))), bytes("TWO"), .fetch(.finish),
+            .fetch(.start(.init(1))), bytes("THREE"), .fetch(.finish),
+            taggedOK("A001"), taggedOK("A002"), taggedOK("A003")
+        ]
+        let parts = try resolveParts(tags: ["A001", "A002", "A003"], stream: stream)
+        #expect(parts == ["ONE", "TWO", "THREE"])
+    }
+
+    /// Mixed ordering: part 1 completes interleaved (data, OK), then parts 2 and 3 are
+    /// batched (data, data, OK, OK) — after part 1's entry is removed by its tagged OK.
+    /// Confirms the "oldest not-yet-finished" routing survives front removal.
+    @Test("Mixed interleaved-then-batched ordering routes each part correctly")
+    func mixedOrderingRoutesCorrectly() throws {
+        let stream: [Response] = [
+            .fetch(.start(.init(1))), bytes("ONE"), .fetch(.finish), taggedOK("A001"),
+            .fetch(.start(.init(1))), bytes("TWO"), .fetch(.finish),
+            .fetch(.start(.init(1))), bytes("THREE"), .fetch(.finish),
+            taggedOK("A002"), taggedOK("A003")
+        ]
+        let parts = try resolveParts(tags: ["A001", "A002", "A003"], stream: stream)
+        #expect(parts == ["ONE", "TWO", "THREE"])
     }
 }


### PR DESCRIPTION
## Problem

`PipelinedCommandDispatcher` routes every untagged `* FETCH` chunk to the oldest registered handler (`entries.first`) and only advances when that command's **tagged** `OK` arrives. RFC 3501 §5.5 permits a server to stream untagged data for several pipelined commands *before* sending any tagged `OK` — i.e. wire order `*FETCH(BODY[1]) *FETCH(BODY[2]) A001 OK A002 OK` rather than `*FETCH(BODY[1]) A001 OK *FETCH(BODY[2]) A002 OK`. Servers commonly coalesce responses this way when they're small and back-to-back.

In that ordering:

1. `BODY[1]` → routed to A001. ✔
2. `BODY[2]` → still routed to A001 (its tagged `OK` hasn't arrived), but A001's handler has already seen `.finish`, so `guard !didFinishPart` drops the bytes.
3. `A001 OK` removes A001; `A002 OK` then resolves A002's promise with **empty data** — it never received its part.

So the second (and any later) pipelined part comes back empty. For body-part fetches this silently drops, e.g., the `text/html` alternative of a multipart message. It's intermittent (depends on whether the server batches a given pair of responses) and — counter-intuitively — more likely for *small* messages, since the server is more apt to coalesce small back-to-back responses. The sequential `fetchAllMessageParts` path is immune because only one command is ever in flight.

The dispatcher tests previously covered only the registry / `fail` paths, never response routing — so this was uncovered.

## Fix

Route untagged FETCH responses to the oldest command whose untagged response has **not yet finished**, flipping a per-entry `finishedUntagged` flag on each `.finish` so the next response routes to the next command — independent of when tagged `OK`s arrive. Correct for both interleaved (`data, OK, data, OK`) and batched (`data, data, OK, OK`) orderings; tagged-removal and failure semantics are unchanged.

## Tests

Adds dispatcher routing tests that drive the handler through an `EmbeddedChannel` with scripted response streams:

- interleaved control (passes before and after),
- 2- and 3-part **batched** (reproduce the empty-later-part bug — red before, green after),
- mixed interleaved-then-batched (confirms routing survives front removal on a tagged `OK`).

## Note

A second small commit adds `/build` to `.gitignore`: building the package target with Xcode dumps a `build/` directory of products/intermediates at the repo root, alongside the already-ignored `/.build`. Happy to drop it if you'd prefer the fix on its own.
