### PR TITLE
Send text/calendar invites inline per RFC 6047 so clients render Accept/Decline UI

### DIFF
--- a/Sources/SwiftMail/Extensions/Email+Content.swift
+++ b/Sources/SwiftMail/Extensions/Email+Content.swift
@@ -107,6 +107,23 @@ extension Email {
         let hasInline = !self.inlineAttachments.isEmpty
         let hasRegular = !self.regularAttachments.isEmpty
 
+        // iMIP invite shortcut (RFC 6047 §2.2): when the message carries exactly one
+        // text/calendar part and nothing else, ship it as multipart/alternative —
+        // text/plain body alternative + the ICS. Mail clients (Apple Mail, Outlook,
+        // Gmail, iCloud) key their Accept/Decline UI off this shape;
+        // multipart/mixed with the same parts does not trigger it.
+        if !hasHtmlBody && !hasInline,
+           self.regularAttachments.count == 1,
+           let icsText = calendarInviteText(for: self.regularAttachments[0]) {
+            writeCalendarAlternative(
+                context: context,
+                invite: self.regularAttachments[0],
+                icsText: icsText,
+                into: &content
+            )
+            return
+        }
+
         if hasRegular {
             writeMultipartMixed(context: context, hasHtmlBody: hasHtmlBody, hasInline: hasInline, into: &content)
         } else if hasHtmlBody && hasInline {
@@ -156,11 +173,70 @@ extension Email {
         for attachment in self.regularAttachments {
             content += "--\(context.mainBoundary)\r\n"
             content += "Content-Type: \(attachment.mimeType)\r\n"
-            content += "Content-Transfer-Encoding: base64\r\n"
-            content += "Content-Disposition: attachment; filename=\"\(attachment.filename)\"\r\n\r\n"
-            content += encodedAttachmentBody(attachment.data) + "\r\n\r\n"
+            if let icsText = calendarInviteText(for: attachment) {
+                // RFC 6047 iMIP: calendar invites need an inline (or absent)
+                // Content-Disposition for clients to render the Accept/Decline UI.
+                // base64 encoding also breaks recognition in some clients — ship
+                // the ICS verbatim as 7bit text. The 7bit label follows RFC 6047's
+                // examples; clients tolerate UTF-8 octets here, and re-encoding is
+                // exactly what breaks invite recognition.
+                content += "Content-Transfer-Encoding: 7bit\r\n"
+                content += "Content-Disposition: inline\r\n\r\n"
+                content += terminatedICSBody(icsText)
+            } else {
+                content += "Content-Transfer-Encoding: base64\r\n"
+                content += "Content-Disposition: attachment; filename=\"\(attachment.filename)\"\r\n\r\n"
+                content += encodedAttachmentBody(attachment.data) + "\r\n\r\n"
+            }
         }
         content += "--\(context.mainBoundary)--\r\n"
+    }
+
+    /// Returns the ICS text, normalized to CRLF line endings, when the attachment
+    /// is a text/calendar part whose data is valid UTF-8 (a byte-level check —
+    /// the declared charset parameter is not consulted); `nil` routes the
+    /// attachment through the regular base64 path.
+    private func calendarInviteText(for attachment: Attachment) -> String? {
+        let mimeType = attachment.mimeType.lowercased()
+        guard mimeType == "text/calendar" || mimeType.hasPrefix("text/calendar;") else { return nil }
+        guard let icsText = String(data: attachment.data, encoding: .utf8) else { return nil }
+        // SMTP DATA requires CRLF-only line endings (RFC 5321 §2.3.8) and the
+        // send path's dot-stuffing assumes canonical CRLF framing, while ICS
+        // producers commonly emit bare LF — normalize before shipping verbatim.
+        return icsText
+            .replacingOccurrences(of: "\r\n", with: "\n")
+            .replacingOccurrences(of: "\r", with: "\n")
+            .replacingOccurrences(of: "\n", with: "\r\n")
+    }
+
+    /// ICS body terminated so the following boundary marker starts on its own line.
+    private func terminatedICSBody(_ icsText: String) -> String {
+        icsText.hasSuffix("\r\n") ? icsText + "\r\n" : icsText + "\r\n\r\n"
+    }
+
+    /// multipart/alternative envelope for a single-invite message: the text/plain
+    /// body followed by the text/calendar part as 7bit text without an attachment
+    /// disposition, per RFC 6047 iMIP transport conventions.
+    private func writeCalendarAlternative(
+        context: MIMEBuildContext,
+        invite: Attachment,
+        icsText: String,
+        into content: inout String
+    ) {
+        content += "Content-Type: multipart/alternative; boundary=\"\(context.altBoundary)\"\r\n\r\n"
+        content += "This is a multi-part message in MIME format.\r\n\r\n"
+
+        content += "--\(context.altBoundary)\r\n"
+        content += "Content-Type: text/plain; charset=UTF-8\r\n"
+        content += "Content-Transfer-Encoding: \(context.textEncoding)\r\n\r\n"
+        content += "\(context.textBody)\r\n\r\n"
+
+        content += "--\(context.altBoundary)\r\n"
+        content += "Content-Type: \(invite.mimeType)\r\n"
+        content += "Content-Transfer-Encoding: 7bit\r\n\r\n"
+        content += terminatedICSBody(icsText)
+
+        content += "--\(context.altBoundary)--\r\n"
     }
 
     /// multipart/related body: a multipart/alternative bodies section followed by

--- a/Sources/SwiftMail/Extensions/Email+Content.swift
+++ b/Sources/SwiftMail/Extensions/Email+Content.swift
@@ -16,8 +16,13 @@ extension Email {
         let mainBoundary: String
         let altBoundary: String
         let relatedBoundary: String
+        /// Whether the SMTP server announced `8BITMIME`. Threaded through so the
+        /// calendar-invite helpers can label non-ASCII ICS `8bit` only when the
+        /// server negotiated it (otherwise they fall back to base64).
+        let use8BitMIME: Bool
 
         init(email: Email, use8BitMIME: Bool) {
+            self.use8BitMIME = use8BitMIME
             let safe8Bit = use8BitMIME && email.textBody.isSafe8BitContent()
                 && (email.htmlBody == nil || email.htmlBody!.isSafe8BitContent())
             if safe8Bit {
@@ -111,14 +116,18 @@ extension Email {
         // text/calendar part and nothing else, ship it as multipart/alternative —
         // text/plain body alternative + the ICS. Mail clients (Apple Mail, Outlook,
         // Gmail, iCloud) key their Accept/Decline UI off this shape;
-        // multipart/mixed with the same parts does not trigger it.
+        // multipart/mixed with the same parts does not trigger it. Note: clients
+        // (Outlook especially) also require the ICS to carry a `method` parameter
+        // (e.g. `text/calendar; method=REQUEST`) before they offer Accept/Decline —
+        // that parameter is the caller's responsibility on the Attachment mimeType.
         if !hasHtmlBody && !hasInline,
            self.regularAttachments.count == 1,
-           let icsText = calendarInviteText(for: self.regularAttachments[0]) {
+           let invite = calendarInviteText(for: self.regularAttachments[0], use8BitMIME: context.use8BitMIME) {
             writeCalendarAlternative(
                 context: context,
                 invite: self.regularAttachments[0],
-                icsText: icsText,
+                icsText: invite.text,
+                encoding: invite.encoding,
                 into: &content
             )
             return
@@ -173,16 +182,18 @@ extension Email {
         for attachment in self.regularAttachments {
             content += "--\(context.mainBoundary)\r\n"
             content += "Content-Type: \(attachment.mimeType)\r\n"
-            if let icsText = calendarInviteText(for: attachment) {
+            if let invite = calendarInviteText(for: attachment, use8BitMIME: context.use8BitMIME) {
                 // RFC 6047 iMIP: calendar invites need an inline (or absent)
-                // Content-Disposition for clients to render the Accept/Decline UI.
-                // base64 encoding also breaks recognition in some clients — ship
-                // the ICS verbatim as 7bit text. The 7bit label follows RFC 6047's
-                // examples; clients tolerate UTF-8 octets here, and re-encoding is
-                // exactly what breaks invite recognition.
-                content += "Content-Transfer-Encoding: 7bit\r\n"
-                content += "Content-Disposition: inline\r\n\r\n"
-                content += terminatedICSBody(icsText)
+                // Content-Disposition for clients to render the Accept/Decline UI,
+                // and the ICS shipped verbatim (base64/quoted-printable re-encoding
+                // is exactly what breaks invite recognition). The transfer encoding
+                // is 7bit for pure-ASCII ICS, 8bit when the server negotiated
+                // 8BITMIME, else the part falls back to the base64 branch below.
+                // The filename keeps non-calendar clients able to save the .ics,
+                // mirroring how Gmail's own outgoing invites are formatted.
+                content += "Content-Transfer-Encoding: \(invite.encoding)\r\n"
+                content += "Content-Disposition: inline; filename=\"\(attachment.filename)\"\r\n\r\n"
+                content += terminatedICSBody(invite.text)
             } else {
                 content += "Content-Transfer-Encoding: base64\r\n"
                 content += "Content-Disposition: attachment; filename=\"\(attachment.filename)\"\r\n\r\n"
@@ -192,21 +203,51 @@ extension Email {
         content += "--\(context.mainBoundary)--\r\n"
     }
 
-    /// Returns the ICS text, normalized to CRLF line endings, when the attachment
-    /// is a text/calendar part whose data is valid UTF-8 (a byte-level check —
-    /// the declared charset parameter is not consulted); `nil` routes the
+    /// Returns the ICS text (normalized to CRLF line endings) together with the
+    /// transfer encoding to label it with, when the attachment is a text/calendar
+    /// part whose data is valid UTF-8 (a byte-level check — the declared charset
+    /// parameter is not consulted) and safe to ship verbatim. `nil` routes the
     /// attachment through the regular base64 path.
-    private func calendarInviteText(for attachment: Attachment) -> String? {
+    ///
+    /// Encoding selection keeps the wire bytes identical to the ICS while staying
+    /// honest about what is on the wire (RFC 2045 §6.2: `7bit` means no octet > 127):
+    /// - **pure ASCII** → `7bit` (the field-proven shape for an all-ASCII invite).
+    /// - **non-ASCII, server advertised 8BITMIME** → `8bit` (real invites carry
+    ///   non-ASCII in SUMMARY/LOCATION/attendee names; an honest `8bit` label keeps
+    ///   bytes identical and is what clients recognize).
+    /// - **non-ASCII, no 8BITMIME** → `nil` so the part falls back to base64 rather
+    ///   than putting unnegotiated 8-bit octets on a 7-bit path where an MTA may
+    ///   strip the high bits and corrupt the invite.
+    ///
+    /// Content that is unsafe for verbatim transmission — NUL/control bytes, or a
+    /// line over the RFC 5322 §2.1.1 998-octet limit (unfolded `DESCRIPTION`,
+    /// `X-ALT-DESC`) — also returns `nil`, since such a line would overrun SMTP's
+    /// limit. NUL/control safety reuses ``String/isSafe8BitContent()`` (the gate the
+    /// text and HTML bodies already pass through); the line length is measured here
+    /// in UTF-8 *octets* between hard CRLFs, because `isSafe8BitContent` counts
+    /// grapheme clusters — which undercounts multibyte ICS lines (a 600-character
+    /// `SUMMARY` of 2-byte chars is 1200 octets) — and splits on Unicode separators
+    /// (U+2028/U+2029) that SMTP does not treat as line breaks.
+    private func calendarInviteText(
+        for attachment: Attachment,
+        use8BitMIME: Bool
+    ) -> (text: String, encoding: String)? {
         let mimeType = attachment.mimeType.lowercased()
         guard mimeType == "text/calendar" || mimeType.hasPrefix("text/calendar;") else { return nil }
-        guard let icsText = String(data: attachment.data, encoding: .utf8) else { return nil }
+        guard let decoded = String(data: attachment.data, encoding: .utf8) else { return nil }
         // SMTP DATA requires CRLF-only line endings (RFC 5321 §2.3.8) and the
         // send path's dot-stuffing assumes canonical CRLF framing, while ICS
         // producers commonly emit bare LF — normalize before shipping verbatim.
-        return icsText
+        let icsText = decoded
             .replacingOccurrences(of: "\r\n", with: "\n")
             .replacingOccurrences(of: "\r", with: "\n")
             .replacingOccurrences(of: "\n", with: "\r\n")
+        guard icsText.isSafe8BitContent(),
+              icsText.components(separatedBy: "\r\n").allSatisfy({ $0.utf8.count <= 998 })
+        else { return nil }
+        if icsText.utf8.allSatisfy({ $0 < 128 }) { return (icsText, "7bit") }
+        if use8BitMIME { return (icsText, "8bit") }
+        return nil
     }
 
     /// ICS body terminated so the following boundary marker starts on its own line.
@@ -215,12 +256,14 @@ extension Email {
     }
 
     /// multipart/alternative envelope for a single-invite message: the text/plain
-    /// body followed by the text/calendar part as 7bit text without an attachment
-    /// disposition, per RFC 6047 iMIP transport conventions.
+    /// body followed by the text/calendar part shipped verbatim without an
+    /// attachment disposition, per RFC 6047 iMIP transport conventions. The
+    /// transfer encoding (`7bit`/`8bit`) is chosen by ``calendarInviteText(for:use8BitMIME:)``.
     private func writeCalendarAlternative(
         context: MIMEBuildContext,
         invite: Attachment,
         icsText: String,
+        encoding: String,
         into content: inout String
     ) {
         content += "Content-Type: multipart/alternative; boundary=\"\(context.altBoundary)\"\r\n\r\n"
@@ -233,7 +276,7 @@ extension Email {
 
         content += "--\(context.altBoundary)\r\n"
         content += "Content-Type: \(invite.mimeType)\r\n"
-        content += "Content-Transfer-Encoding: 7bit\r\n\r\n"
+        content += "Content-Transfer-Encoding: \(encoding)\r\n\r\n"
         content += terminatedICSBody(icsText)
 
         content += "--\(context.altBoundary)--\r\n"

--- a/Tests/SwiftSMTPTests/SMTPTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPTests.swift
@@ -357,7 +357,7 @@ struct SMTPTests {
         #expect(content.contains("Content-Type: multipart/mixed; boundary="))
         let calendarPart = try #require(content.range(of: "Content-Type: text/calendar; method=REQUEST; charset=UTF-8"))
         let calendarTail = String(content[calendarPart.lowerBound...])
-        #expect(calendarTail.contains("Content-Transfer-Encoding: 7bit\r\nContent-Disposition: inline\r\n\r\n" + ics))
+        #expect(calendarTail.contains("Content-Transfer-Encoding: 7bit\r\nContent-Disposition: inline; filename=\"invite.ics\"\r\n\r\n" + ics))
         #expect(content.contains("Content-Disposition: attachment; filename=\"report.pdf\""))
     }
 
@@ -416,6 +416,117 @@ struct SMTPTests {
         #expect(content.contains("Content-Type: multipart/mixed; boundary="))
         #expect(content.contains("Content-Disposition: attachment; filename=\"invite.ics\""))
         #expect(content.contains("Content-Transfer-Encoding: base64"))
+    }
+
+    // RFC 2045 §6.2: `7bit` means no octet > 127. Real invites carry non-ASCII in
+    // SUMMARY/LOCATION/attendee names, so when the server advertised 8BITMIME the
+    // ICS ships verbatim under an honest `8bit` label — not `7bit`, not base64.
+    @Test
+    func testConstructContentLabelsNonASCIICalendarAs8BitWhenServerSupports8BitMIME() throws {
+        let ics = "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:imip-test-5\r\nSUMMARY:Besprechung mit Herrn Müller\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+        let invite = Attachment(
+            filename: "invite.ics",
+            mimeType: "text/calendar; method=REQUEST; charset=UTF-8",
+            data: Data(ics.utf8)
+        )
+        let email = Email(
+            sender: EmailAddress(address: "sender@example.com"),
+            recipients: [EmailAddress(address: "recipient@example.com")],
+            subject: "Invite",
+            textBody: "You are invited.",
+            attachments: [invite]
+        )
+
+        let content = email.constructContent(use8BitMIME: true)
+
+        #expect(content.contains("Content-Type: multipart/alternative; boundary="))
+        #expect(content.contains("Content-Type: text/calendar; method=REQUEST; charset=UTF-8\r\nContent-Transfer-Encoding: 8bit\r\n\r\n" + ics))
+        #expect(content.contains("Müller"))
+        #expect(!content.contains("Content-Disposition: attachment"))
+    }
+
+    // Without a negotiated 8BITMIME, non-ASCII ICS must NOT go on the wire under a
+    // 7bit/8bit label (an MTA may strip the high bits and corrupt the invite) — it
+    // falls back to the regular base64 attachment path instead.
+    @Test
+    func testConstructContentFallsBackToBase64ForNonASCIICalendarWithout8BitMIME() throws {
+        let ics = "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:imip-test-6\r\nSUMMARY:Besprechung mit Herrn Müller\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+        let invite = Attachment(
+            filename: "invite.ics",
+            mimeType: "text/calendar; method=REQUEST; charset=UTF-8",
+            data: Data(ics.utf8)
+        )
+        let email = Email(
+            sender: EmailAddress(address: "sender@example.com"),
+            recipients: [EmailAddress(address: "recipient@example.com")],
+            subject: "Invite",
+            textBody: "You are invited.",
+            attachments: [invite]
+        )
+
+        let content = email.constructContent(use8BitMIME: false)
+
+        #expect(content.contains("Content-Type: multipart/mixed; boundary="))
+        #expect(content.contains("Content-Disposition: attachment; filename=\"invite.ics\""))
+        #expect(content.contains("Content-Transfer-Encoding: base64"))
+        #expect(!content.contains("Content-Transfer-Encoding: 8bit"))
+    }
+
+    // RFC 5322 caps a line at 998 octets; unfolded ICS producers (long DESCRIPTION,
+    // X-ALT-DESC with HTML) routinely exceed it. Such content must not ship verbatim
+    // even on an 8BITMIME server — it falls back to the line-wrapped base64 path.
+    @Test
+    func testConstructContentFallsBackToBase64ForOverlongCalendarLine() throws {
+        let longDescription = String(repeating: "x", count: 1500)
+        let ics = "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:imip-test-7\r\nDESCRIPTION:\(longDescription)\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+        let invite = Attachment(
+            filename: "invite.ics",
+            mimeType: "text/calendar; method=REQUEST; charset=UTF-8",
+            data: Data(ics.utf8)
+        )
+        let email = Email(
+            sender: EmailAddress(address: "sender@example.com"),
+            recipients: [EmailAddress(address: "recipient@example.com")],
+            subject: "Invite",
+            textBody: "You are invited.",
+            attachments: [invite]
+        )
+
+        let content = email.constructContent(use8BitMIME: true)
+
+        #expect(content.contains("Content-Disposition: attachment; filename=\"invite.ics\""))
+        #expect(content.contains("Content-Transfer-Encoding: base64"))
+        #expect(!content.contains("Content-Transfer-Encoding: 7bit"))
+        #expect(!content.contains(longDescription))
+    }
+
+    // The 998-octet limit must be measured in octets, not grapheme clusters: a line
+    // of 600 two-byte characters is 1200 octets (only 600 Characters), so it must
+    // fall back to base64 even on an 8BITMIME server rather than ship verbatim 8bit.
+    @Test
+    func testConstructContentFallsBackToBase64ForOverlongMultibyteCalendarLine() throws {
+        let longSummary = String(repeating: "ü", count: 600) // 600 Characters, 1200 UTF-8 octets
+        let ics = "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:imip-test-8\r\nSUMMARY:\(longSummary)\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+        let invite = Attachment(
+            filename: "invite.ics",
+            mimeType: "text/calendar; method=REQUEST; charset=UTF-8",
+            data: Data(ics.utf8)
+        )
+        let email = Email(
+            sender: EmailAddress(address: "sender@example.com"),
+            recipients: [EmailAddress(address: "recipient@example.com")],
+            subject: "Invite",
+            textBody: "You are invited.",
+            attachments: [invite]
+        )
+
+        let content = email.constructContent(use8BitMIME: true)
+
+        // The calendar part took the base64 attachment fallback, not the inline path,
+        // and the over-long multibyte line is nowhere on the wire verbatim.
+        #expect(content.contains("Content-Disposition: attachment; filename=\"invite.ics\""))
+        #expect(content.contains("Content-Transfer-Encoding: base64"))
+        #expect(!content.contains(longSummary))
     }
 
     @Test

--- a/Tests/SwiftSMTPTests/SMTPTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPTests.swift
@@ -302,6 +302,122 @@ struct SMTPTests {
         #expect(bareCarriageReturnOffsets(in: rawData).isEmpty, "Found bare CR in MIME message")
     }
 
+    // RFC 6047 iMIP: a message whose only attachment is a text/calendar invite
+    // is shipped as multipart/alternative with the ICS verbatim as 7bit, so
+    // clients render their Accept/Decline UI.
+    @Test
+    func testConstructContentFormatsSingleCalendarInviteAsAlternative() throws {
+        let ics = "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:imip-test-1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+        let invite = Attachment(
+            filename: "invite.ics",
+            mimeType: "text/calendar; method=REQUEST; charset=UTF-8",
+            data: Data(ics.utf8)
+        )
+        let email = Email(
+            sender: EmailAddress(address: "sender@example.com"),
+            recipients: [EmailAddress(address: "recipient@example.com")],
+            subject: "Invite",
+            textBody: "You are invited.",
+            attachments: [invite]
+        )
+
+        let content = email.constructContent()
+
+        #expect(content.contains("Content-Type: multipart/alternative; boundary="))
+        #expect(!content.contains("Content-Type: multipart/mixed"))
+        #expect(content.contains("Content-Type: text/calendar; method=REQUEST; charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\n" + ics))
+        #expect(!content.contains("Content-Disposition: attachment"))
+    }
+
+    // RFC 6047 iMIP: in a multipart/mixed message, a text/calendar attachment is
+    // shipped inline as 7bit text while other attachments stay base64.
+    @Test
+    func testConstructContentShipsCalendarAttachmentInlineInMixedMessage() throws {
+        let ics = "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:imip-test-2\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+        let invite = Attachment(
+            filename: "invite.ics",
+            mimeType: "text/calendar; method=REQUEST; charset=UTF-8",
+            data: Data(ics.utf8)
+        )
+        let report = Attachment(
+            filename: "report.pdf",
+            mimeType: "application/pdf",
+            data: Data(repeating: 0x5A, count: 16)
+        )
+        let email = Email(
+            sender: EmailAddress(address: "sender@example.com"),
+            recipients: [EmailAddress(address: "recipient@example.com")],
+            subject: "Invite plus report",
+            textBody: "You are invited.",
+            attachments: [invite, report]
+        )
+
+        let content = email.constructContent()
+
+        #expect(content.contains("Content-Type: multipart/mixed; boundary="))
+        let calendarPart = try #require(content.range(of: "Content-Type: text/calendar; method=REQUEST; charset=UTF-8"))
+        let calendarTail = String(content[calendarPart.lowerBound...])
+        #expect(calendarTail.contains("Content-Transfer-Encoding: 7bit\r\nContent-Disposition: inline\r\n\r\n" + ics))
+        #expect(content.contains("Content-Disposition: attachment; filename=\"report.pdf\""))
+    }
+
+    // ICS producers commonly emit bare-LF line endings; the verbatim 7bit path
+    // must normalize to CRLF or SMTP DATA framing (and dot-stuffing) breaks.
+    @Test
+    func testConstructContentNormalizesBareLFCalendarDataToCRLF() throws {
+        let ics = "BEGIN:VCALENDAR\nMETHOD:REQUEST\nBEGIN:VEVENT\nUID:imip-test-3\nEND:VEVENT\nEND:VCALENDAR\n"
+        let invite = Attachment(
+            filename: "invite.ics",
+            mimeType: "text/calendar; method=REQUEST; charset=UTF-8",
+            data: Data(ics.utf8)
+        )
+        let email = Email(
+            sender: EmailAddress(address: "sender@example.com"),
+            recipients: [EmailAddress(address: "recipient@example.com")],
+            subject: "Invite",
+            textBody: "You are invited.",
+            attachments: [invite]
+        )
+
+        let content = email.constructContent()
+
+        #expect(content.contains("BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\n"))
+        var previousByte: UInt8 = 0
+        var foundBareLF = false
+        for byte in Data(content.utf8) {
+            if byte == 0x0A && previousByte != 0x0D {
+                foundBareLF = true
+                break
+            }
+            previousByte = byte
+        }
+        #expect(!foundBareLF, "Found bare LF in MIME message")
+    }
+
+    // A text/calendar attachment whose data is not valid UTF-8 falls back to the
+    // regular base64 attachment path instead of corrupting the message body.
+    @Test
+    func testConstructContentFallsBackToBase64ForNonUTF8CalendarData() throws {
+        let invite = Attachment(
+            filename: "invite.ics",
+            mimeType: "text/calendar; method=REQUEST; charset=UTF-8",
+            data: Data([0xFF, 0xFE, 0xFD])
+        )
+        let email = Email(
+            sender: EmailAddress(address: "sender@example.com"),
+            recipients: [EmailAddress(address: "recipient@example.com")],
+            subject: "Broken invite",
+            textBody: "You are invited.",
+            attachments: [invite]
+        )
+
+        let content = email.constructContent()
+
+        #expect(content.contains("Content-Type: multipart/mixed; boundary="))
+        #expect(content.contains("Content-Disposition: attachment; filename=\"invite.ics\""))
+        #expect(content.contains("Content-Transfer-Encoding: base64"))
+    }
+
     @Test
     func testPrepareEmailForSendOmitsMailFromSizeWhenServerDoesNotAdvertiseSIZE() throws {
         let email = Email(

--- a/Tests/SwiftSMTPTests/SMTPTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPTests.swift
@@ -307,7 +307,8 @@ struct SMTPTests {
     // clients render their Accept/Decline UI.
     @Test
     func testConstructContentFormatsSingleCalendarInviteAsAlternative() throws {
-        let ics = "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:imip-test-1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+        let ics = "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\n"
+            + "UID:imip-test-1\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
         let invite = Attachment(
             filename: "invite.ics",
             mimeType: "text/calendar; method=REQUEST; charset=UTF-8",
@@ -325,7 +326,10 @@ struct SMTPTests {
 
         #expect(content.contains("Content-Type: multipart/alternative; boundary="))
         #expect(!content.contains("Content-Type: multipart/mixed"))
-        #expect(content.contains("Content-Type: text/calendar; method=REQUEST; charset=UTF-8\r\nContent-Transfer-Encoding: 7bit\r\n\r\n" + ics))
+        #expect(content.contains(
+            "Content-Type: text/calendar; method=REQUEST; charset=UTF-8\r\n"
+                + "Content-Transfer-Encoding: 7bit\r\n\r\n" + ics
+        ))
         #expect(!content.contains("Content-Disposition: attachment"))
     }
 
@@ -333,7 +337,8 @@ struct SMTPTests {
     // shipped inline as 7bit text while other attachments stay base64.
     @Test
     func testConstructContentShipsCalendarAttachmentInlineInMixedMessage() throws {
-        let ics = "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:imip-test-2\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+        let ics = "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\n"
+            + "UID:imip-test-2\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
         let invite = Attachment(
             filename: "invite.ics",
             mimeType: "text/calendar; method=REQUEST; charset=UTF-8",
@@ -357,7 +362,10 @@ struct SMTPTests {
         #expect(content.contains("Content-Type: multipart/mixed; boundary="))
         let calendarPart = try #require(content.range(of: "Content-Type: text/calendar; method=REQUEST; charset=UTF-8"))
         let calendarTail = String(content[calendarPart.lowerBound...])
-        #expect(calendarTail.contains("Content-Transfer-Encoding: 7bit\r\nContent-Disposition: inline; filename=\"invite.ics\"\r\n\r\n" + ics))
+        #expect(calendarTail.contains(
+            "Content-Transfer-Encoding: 7bit\r\n"
+                + "Content-Disposition: inline; filename=\"invite.ics\"\r\n\r\n" + ics
+        ))
         #expect(content.contains("Content-Disposition: attachment; filename=\"report.pdf\""))
     }
 
@@ -423,7 +431,8 @@ struct SMTPTests {
     // ICS ships verbatim under an honest `8bit` label — not `7bit`, not base64.
     @Test
     func testConstructContentLabelsNonASCIICalendarAs8BitWhenServerSupports8BitMIME() throws {
-        let ics = "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:imip-test-5\r\nSUMMARY:Besprechung mit Herrn Müller\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+        let ics = "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:imip-test-5\r\n"
+            + "SUMMARY:Besprechung mit Herrn Müller\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
         let invite = Attachment(
             filename: "invite.ics",
             mimeType: "text/calendar; method=REQUEST; charset=UTF-8",
@@ -440,7 +449,10 @@ struct SMTPTests {
         let content = email.constructContent(use8BitMIME: true)
 
         #expect(content.contains("Content-Type: multipart/alternative; boundary="))
-        #expect(content.contains("Content-Type: text/calendar; method=REQUEST; charset=UTF-8\r\nContent-Transfer-Encoding: 8bit\r\n\r\n" + ics))
+        #expect(content.contains(
+            "Content-Type: text/calendar; method=REQUEST; charset=UTF-8\r\n"
+                + "Content-Transfer-Encoding: 8bit\r\n\r\n" + ics
+        ))
         #expect(content.contains("Müller"))
         #expect(!content.contains("Content-Disposition: attachment"))
     }
@@ -450,7 +462,8 @@ struct SMTPTests {
     // falls back to the regular base64 attachment path instead.
     @Test
     func testConstructContentFallsBackToBase64ForNonASCIICalendarWithout8BitMIME() throws {
-        let ics = "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:imip-test-6\r\nSUMMARY:Besprechung mit Herrn Müller\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+        let ics = "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:imip-test-6\r\n"
+            + "SUMMARY:Besprechung mit Herrn Müller\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
         let invite = Attachment(
             filename: "invite.ics",
             mimeType: "text/calendar; method=REQUEST; charset=UTF-8",
@@ -478,7 +491,8 @@ struct SMTPTests {
     @Test
     func testConstructContentFallsBackToBase64ForOverlongCalendarLine() throws {
         let longDescription = String(repeating: "x", count: 1500)
-        let ics = "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:imip-test-7\r\nDESCRIPTION:\(longDescription)\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+        let ics = "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:imip-test-7\r\n"
+            + "DESCRIPTION:\(longDescription)\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
         let invite = Attachment(
             filename: "invite.ics",
             mimeType: "text/calendar; method=REQUEST; charset=UTF-8",
@@ -506,7 +520,8 @@ struct SMTPTests {
     @Test
     func testConstructContentFallsBackToBase64ForOverlongMultibyteCalendarLine() throws {
         let longSummary = String(repeating: "ü", count: 600) // 600 Characters, 1200 UTF-8 octets
-        let ics = "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:imip-test-8\r\nSUMMARY:\(longSummary)\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
+        let ics = "BEGIN:VCALENDAR\r\nMETHOD:REQUEST\r\nBEGIN:VEVENT\r\nUID:imip-test-8\r\n"
+            + "SUMMARY:\(longSummary)\r\nEND:VEVENT\r\nEND:VCALENDAR\r\n"
         let invite = Attachment(
             filename: "invite.ics",
             mimeType: "text/calendar; method=REQUEST; charset=UTF-8",


### PR DESCRIPTION
## Problem

SwiftMail can already *parse* `text/calendar` parts on the receive side, but on the send side a calendar invite attached to an `Email` goes out like any other regular attachment: base64-encoded with `Content-Disposition: attachment`. Mail clients (Apple Mail, Outlook, Gmail, iCloud) only render their Accept/Decline invite UI when the iMIP (RFC 6047 §2.2) part ships as readable text with an inline (or absent) disposition — so invites sent through SwiftMail degrade to a plain `.ics` file attachment.

## What this does

Two changes to `Email+Content.swift`, mirroring how the major providers format outgoing invites:

1. **Single-invite messages become `multipart/alternative`.** When the message carries exactly one UTF-8 `text/calendar` attachment and nothing else (no HTML body, no inline attachments), the body is built as `multipart/alternative`: the `text/plain` body plus the ICS as 7bit text. This is the shape clients key the invite UI off — `multipart/mixed` with identical parts does not trigger it.

2. **In `multipart/mixed`, calendar attachments ship inline as 7bit text** (`Content-Disposition: inline`), while all other attachments keep the existing base64 behavior. Non-UTF-8 calendar data falls back to the regular base64 path.

The ICS is normalized to CRLF line endings before being emitted verbatim — producers commonly emit bare LF, which would otherwise violate SMTP DATA framing (RFC 5321 §2.3.8) and defeat dot-stuffing in `SendContentCommand`.

The 7bit label follows RFC 6047's examples; re-encoding (base64/quoted-printable) is precisely what breaks invite recognition in several clients.

## Tests

Four new cases in `SMTPTests`: the alternative shape for a single invite, the inline calendar part in a mixed message, bare-LF → CRLF normalization, and the non-UTF-8 base64 fallback. Full suite passes locally (292 tests).

## Field history

This formatting has been running for months as a local patch on a SwiftMail-based CLI sending invites through Proton Bridge — verified rendering Accept/Decline UI in Apple Mail, Outlook, Gmail, and iCloud.