### PR TITLE
Drop the swift-docc-plugin dependency

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -28,24 +28,6 @@
       }
     },
     {
-      "identity" : "swift-docc-plugin",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/apple/swift-docc-plugin",
-      "state" : {
-        "revision" : "647c708be89f834fa6a6d4945442793a77ddf5b6",
-        "version" : "1.5.0"
-      }
-    },
-    {
-      "identity" : "swift-docc-symbolkit",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/swiftlang/swift-docc-symbolkit",
-      "state" : {
-        "revision" : "b45d1f2ed151d057b54504d653e0da5552844e34",
-        "version" : "1.0.0"
-      }
-    },
-    {
       "identity" : "swift-dotenv",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/thebarndog/swift-dotenv",

--- a/Package.swift
+++ b/Package.swift
@@ -72,7 +72,9 @@ let package = Package(
         // targets needs Swift 6.2+. The macOS CI job selects Xcode 26 for that
         // reason (Linux/Android/Windows runners are already on Swift 6.3.x).
         .package(url: "https://github.com/apple/swift-testing", exact: "6.3.2"),
-        .package(url: "https://github.com/apple/swift-docc-plugin", from: "1.0.0"),
+        // No DocC plugin dependency: Swift Package Index injects it when building
+        // the hosted docs (.spi.yml), and Xcode's Build Documentation has DocC
+        // built in — declaring it would only tax consumers with extra clones.
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.3.0")
     ],
     targets: [


### PR DESCRIPTION
## Summary
- Remove the `swift-docc-plugin` package dependency from `Package.swift`; it was never referenced by any target, CI step, or local tooling.
- Prune the now-unused `swift-docc-plugin` and `swift-docc-symbolkit` pins from `Package.resolved`.

## Why it's safe
- **Swift Package Index docs keep building.** SPI injects the DocC plugin itself when generating the hosted documentation: *"Your package manifest does not need to include the DocC plugin in order for us to host your DocC documentation. We will automatically inject it when building your documentation if we don't detect the plugin in your manifest."* The `.spi.yml` and the `SwiftMail.docc` catalog (tutorials, articles) are untouched.
- **Xcode doc builds keep working.** Product → Build Documentation has DocC built in and never used the plugin.
- The plugin is a command plugin, so it was never linked into any product — the only effect of declaring it was two extra repo clones during dependency resolution for this package and every consumer of SwiftMail.

The only capability lost is running `swift package generate-documentation` / `preview-documentation` from the command line, which nothing in the repo automates.

## Verification
- `swift package resolve` succeeds; both DocC pins drop out of `Package.resolved`.
- `swift build` completes cleanly (full package incl. CLI demos).

🤖 Generated with [Claude Code](https://claude.com/claude-code)