### PR TITLE
Add RFC 2047 encoded-word encoding for outgoing message headers

### DIFF
--- a/Sources/SwiftMail/Extensions/Email+Content.swift
+++ b/Sources/SwiftMail/Extensions/Email+Content.swift
@@ -69,14 +69,14 @@ extension Email {
     /// `Message-Id`, `MIME-Version`) plus any caller-supplied additional
     /// headers, suppressing a duplicate `Message-Id` when one is already set.
     private func writeHeaders(into content: inout String) {
-        content += "From: \(self.sender)\r\n"
+        content += "From: \(self.sender.headerString())\r\n"
         if !self.recipients.isEmpty {
-            content += "To: \(self.recipients.map { $0.description }.joined(separator: ", "))\r\n"
+            content += "To: \(self.recipients.map { $0.headerString() }.joined(separator: ", "))\r\n"
         }
         if !self.ccRecipients.isEmpty {
-            content += "Cc: \(self.ccRecipients.map { $0.description }.joined(separator: ", "))\r\n"
+            content += "Cc: \(self.ccRecipients.map { $0.headerString() }.joined(separator: ", "))\r\n"
         }
-        content += "Subject: \(self.subject)\r\n"
+        content += "Subject: \(self.subject.rfc2047EncodedHeader())\r\n"
         content += "Date: \(Self.rfc2822Date())\r\n"
 
         let resolvedHeaderID = resolvedMessageIDHeader()

--- a/Sources/SwiftMail/Extensions/EmailAddress+StringConversion.swift
+++ b/Sources/SwiftMail/Extensions/EmailAddress+StringConversion.swift
@@ -70,4 +70,25 @@ extension EmailAddress: LosslessStringConvertible {
             return address
         }
     }
+
+    /**
+     RFC 5322 address string for use in a header field (`From`/`To`/`Cc`/…).
+
+     Identical to ``description`` for ASCII display names, but a non-ASCII name
+     is RFC 2047-encoded. Encoded-words must not appear inside a quoted-string,
+     so an encoded name is emitted bare (never quoted). Use this — not
+     ``description`` — when writing an address into a header so that non-ASCII
+     names survive transport instead of being mojibake'd.
+     */
+    func headerString() -> String {
+        guard let name = name, !name.isEmpty else { return address }
+        if name.contains(where: { !$0.isASCII }) {
+            return "\(name.rfc2047EncodedHeader()) <\(address)>"
+        }
+        // Use quotes if the (ASCII) name contains special characters
+        if name.contains(where: { !$0.isLetter && !$0.isNumber && !$0.isWhitespace }) {
+            return "\"\(name)\" <\(address)>"
+        }
+        return "\(name) <\(address)>"
+    }
 }

--- a/Sources/SwiftMail/Extensions/String+RFC2047Encode.swift
+++ b/Sources/SwiftMail/Extensions/String+RFC2047Encode.swift
@@ -1,0 +1,55 @@
+// String+RFC2047Encode.swift
+// RFC 2047 "encoded-word" ENCODING for non-ASCII header values (the inverse of
+// `decodeMIMEHeader()` in String+QuotedPrintable+MIMEHeader.swift).
+//
+// RFC 5322 requires header field bodies to be 7-bit ASCII. Any non-ASCII text
+// (e.g. a Korean Subject or display name) MUST be wrapped in an RFC 2047
+// encoded-word; emitting raw 8-bit bytes in a header invites downstream agents
+// to apply their own charset guesses and produce mojibake. (Message *bodies*
+// are unaffected because they carry an explicit charset + transfer-encoding;
+// header fields have no such mechanism other than RFC 2047.)
+
+import Foundation
+
+extension String {
+    /// Max UTF-8 bytes encoded per encoded-word. `=?UTF-8?B?` (10) + `?=` (2)
+    /// is 12 octets of overhead and Base64 of N bytes is `4*ceil(N/3)`; 45 bytes
+    /// → 60 Base64 chars → a 72-octet word, safely under RFC 2047 §2's 75-octet
+    /// per-encoded-word ceiling.
+    private static let rfc2047MaxBytesPerWord = 45
+
+    /// Encode the receiver as one or more RFC 2047 Base64 encoded-words when it
+    /// contains any non-ASCII character. Pure-ASCII input is returned unchanged
+    /// (it is already a valid header value).
+    ///
+    /// Multiple encoded-words are folded with `CRLF SPACE` so each stays within
+    /// the 75-octet limit; a character's UTF-8 bytes are never split across two
+    /// encoded-words, so every word decodes independently (required by clients
+    /// that decode each word in isolation). Round-trips through
+    /// ``decodeMIMEHeader()``.
+    public func rfc2047EncodedHeader() -> String {
+        guard self.contains(where: { !$0.isASCII }) else { return self }
+
+        var words: [String] = []
+        var chunk: [UInt8] = []
+
+        func flush() {
+            guard !chunk.isEmpty else { return }
+            words.append("=?UTF-8?B?\(Data(chunk).base64EncodedString())?=")
+            chunk.removeAll(keepingCapacity: true)
+        }
+
+        for character in self {
+            let bytes = Array(String(character).utf8)
+            if !chunk.isEmpty, chunk.count + bytes.count > Self.rfc2047MaxBytesPerWord {
+                flush()
+            }
+            chunk.append(contentsOf: bytes)
+        }
+        flush()
+
+        // CRLF+SPACE between adjacent encoded-words: the linear whitespace is
+        // dropped on decode (RFC 2047 §2), reassembling the original text.
+        return words.joined(separator: "\r\n ")
+    }
+}

--- a/Sources/SwiftMail/MIME/EMLSerializer.swift
+++ b/Sources/SwiftMail/MIME/EMLSerializer.swift
@@ -47,7 +47,10 @@ public struct EMLSerializer {
         appendListHeader("To", header.to, into: &output)
         appendListHeader("Cc", header.cc, into: &output)
         appendListHeader("Bcc", header.bcc, into: &output)
-        appendHeaderIfPresent("Subject", header.subject, into: &output)
+        // Subject is free text — RFC 2047-encode it if non-ASCII. (From/To/Cc here
+        // are already-formatted address strings, so they are left as-is; per-name
+        // encoding of those would require re-parsing each address.)
+        appendHeaderIfPresent("Subject", header.subject?.rfc2047EncodedHeader(), into: &output)
         if let date = header.date {
             output += "Date: \(formatRFC2822Date(date))\r\n"
         }

--- a/Tests/SwiftSMTPTests/RFC2047EncodeTests.swift
+++ b/Tests/SwiftSMTPTests/RFC2047EncodeTests.swift
@@ -1,0 +1,123 @@
+// RFC2047EncodeTests.swift
+// Verifies RFC 2047 encoded-word ENCODING of non-ASCII header values and that
+// the output round-trips through `decodeMIMEHeader()`.
+
+import Foundation
+import Testing
+@testable import SwiftMail
+
+@Suite("RFC 2047 header encoding")
+struct RFC2047EncodeTests {
+
+    // MARK: - String.rfc2047EncodedHeader()
+
+    @Test("Pure-ASCII subject is returned unchanged")
+    func asciiPassthrough() {
+        #expect("Hello, world!".rfc2047EncodedHeader() == "Hello, world!")
+        #expect("Re: Q3 report".rfc2047EncodedHeader() == "Re: Q3 report")
+        #expect("".rfc2047EncodedHeader() == "")
+    }
+
+    @Test("Korean subject encodes to pure ASCII and round-trips")
+    func koreanRoundTrip() {
+        let subject = "가입정보 변경 안내"
+        let encoded = subject.rfc2047EncodedHeader()
+
+        // Header bytes must be 7-bit clean.
+        #expect(encoded.allSatisfy { $0.isASCII })
+        #expect(encoded.hasPrefix("=?UTF-8?B?"))
+        // The raw Korean must NOT appear literally in the header.
+        #expect(!encoded.contains("가"))
+        // And it decodes back to exactly the original.
+        #expect(encoded.decodeMIMEHeader() == subject)
+    }
+
+    @Test("Mixed ASCII + non-ASCII round-trips")
+    func mixedRoundTrip() {
+        let subject = "Re: 회의 일정 (Q3) 안내 — 確認"
+        let encoded = subject.rfc2047EncodedHeader()
+        #expect(encoded.allSatisfy { $0.isASCII })
+        #expect(encoded.decodeMIMEHeader() == subject)
+    }
+
+    @Test("Long non-ASCII subject folds into multiple ≤75-octet encoded-words and round-trips")
+    func longSubjectFolds() {
+        // ~40 Korean syllables → must exceed one 45-byte encoded-word.
+        let subject = String(repeating: "한국어제목", count: 8)
+        let encoded = subject.rfc2047EncodedHeader()
+
+        #expect(encoded.allSatisfy { $0.isASCII })
+        #expect(encoded.decodeMIMEHeader() == subject)
+
+        // Every individual encoded-word stays within RFC 2047 §2's 75-octet limit.
+        let words = encoded
+            .components(separatedBy: "\r\n ")
+            .flatMap { $0.split(separator: " ").map(String.init) }
+        #expect(words.count > 1, "expected the subject to fold into multiple words")
+        for word in words {
+            #expect(word.utf8.count <= 75, "encoded-word exceeds 75 octets: \(word)")
+            #expect(word.hasPrefix("=?UTF-8?B?") && word.hasSuffix("?="))
+        }
+    }
+
+    @Test("Each folded word decodes independently (no multibyte char split across words)")
+    func wordsDecodeIndependently() {
+        let subject = String(repeating: "테스트", count: 10)
+        let encoded = subject.rfc2047EncodedHeader()
+        let words = encoded.components(separatedBy: "\r\n ")
+        // Decoding each word in isolation must yield valid UTF-8, and the
+        // concatenation must reproduce the original — proving no character's
+        // bytes were split across the word boundary.
+        let rejoined = words.map { $0.decodeMIMEHeader() }.joined()
+        #expect(rejoined == subject)
+    }
+
+    // MARK: - EmailAddress.headerString()
+
+    @Test("ASCII display name behaves like description")
+    func asciiDisplayName() {
+        let addr = EmailAddress(name: "Alice Smith", address: "alice@example.com")
+        #expect(addr.headerString() == "Alice Smith <alice@example.com>")
+        let comma = EmailAddress(name: "Smith, Alice", address: "alice@example.com")
+        #expect(comma.headerString() == "\"Smith, Alice\" <alice@example.com>")
+    }
+
+    @Test("Non-ASCII display name is RFC 2047-encoded, address kept literal")
+    func nonAsciiDisplayName() {
+        let addr = EmailAddress(name: "홍길동", address: "hong@example.com")
+        let header = addr.headerString()
+        #expect(header.allSatisfy { $0.isASCII })
+        #expect(header.hasSuffix(" <hong@example.com>"))
+        // Name portion (before the address) decodes back to the original.
+        let namePart = String(header.dropLast(" <hong@example.com>".count))
+        #expect(namePart.decodeMIMEHeader() == "홍길동")
+    }
+
+    // MARK: - constructContent integration
+
+    @Test("constructContent emits an encoded Subject, not raw 8-bit")
+    func constructContentEncodesSubject() {
+        let email = Email(
+            sender: EmailAddress(address: "me@example.com"),
+            recipients: [EmailAddress(address: "you@example.com")],
+            subject: "테스트 제목",
+            textBody: "본문",
+            htmlBody: nil
+        )
+        let content = email.constructContent()
+
+        // The Subject header line carries an encoded-word, not the raw Korean.
+        #expect(content.contains("Subject: =?UTF-8?B?"))
+        #expect(!content.contains("Subject: 테스트"))
+
+        // Extract the Subject line and confirm it decodes to the original.
+        let subjectLine = content
+            .components(separatedBy: "\r\n")
+            .first { $0.hasPrefix("Subject: ") }
+        #expect(subjectLine != nil)
+        if let subjectLine {
+            let value = String(subjectLine.dropFirst("Subject: ".count))
+            #expect(value.decodeMIMEHeader() == "테스트 제목")
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Outgoing message headers (`Subject`, and `From`/`To`/`Cc` display names) are written verbatim in `Email`/`EMLSerializer`. A non-ASCII value (CJK, accented names, emoji, …) therefore goes onto the wire as raw 8-bit bytes, which is not valid per RFC 5322 (header field bodies must be 7-bit ASCII) and leads receivers to mis-decode them (mojibake). Message *bodies* are already safe because they carry a `charset` + `Content-Transfer-Encoding`; header fields have no such mechanism other than RFC 2047 encoded-words. The library could already **decode** them (`decodeMIMEHeader()`) but never **encode** them.

## Changes

- **`String.rfc2047EncodedHeader()`** — the inverse of `decodeMIMEHeader()`. Returns the receiver unchanged when it is pure ASCII; otherwise emits one or more Base64 encoded-words (`=?UTF-8?B?…?=`), each ≤ 75 octets (RFC 2047 §2), split on character boundaries so every word decodes independently, folded with `CRLF SPACE`.
- **`EmailAddress.headerString()`** — like `description`, but RFC 2047-encodes a non-ASCII display name (encoded-words are never placed inside a quoted-string). `description` and the `LosslessStringConvertible` round-trip are intentionally left unchanged.
- Apply at the emission sites: `Email+Content` (`Subject` + `From`/`To`/`Cc`) and `EMLSerializer` (`Subject`).
- Add `RFC2047EncodeTests`: ASCII passthrough, CJK round-trip through `decodeMIMEHeader()`, folding of long subjects (each word ≤ 75 octets, no multibyte split), and `headerString()`.

## Notes

- Output round-trips through the existing `decodeMIMEHeader()` (verified in the tests).
- `EMLSerializer` encodes the `Subject` only; its `From`/`To`/`Cc` are already-formatted address strings, so per-name encoding there would require re-parsing each address — left as-is.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
