### PR TITLE
Make the IMAP response parser buffer limit configurable

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAPConnection+Connection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+Connection.swift
@@ -28,7 +28,7 @@ extension IMAPConnection {
         self.isSessionAuthenticated = false
         self.namespaces = nil
 
-        logger.info("\(connectionContext) Connected to IMAP server with 1MB buffer limit for large responses")
+        logger.info("\(connectionContext) Connected; response buffer limit \(responseBufferLimit) bytes")
 
         let greetingCapabilities = try await waitForGreeting(
             channel: channel,
@@ -47,6 +47,7 @@ extension IMAPConnection {
         let certificateVerificationPolicy = self.certificateVerificationPolicy
         let duplexLogger = self.duplexLogger
         let responseBuffer = self.responseBuffer
+        let responseBufferLimit = self.responseBufferLimit
 
         return ClientBootstrap(group: group)
             .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
@@ -54,7 +55,7 @@ extension IMAPConnection {
             .channelInitializer { channel in
                 do {
                     let parserOptions = ResponseParser.Options(
-                        bufferLimit: 1024 * 1024,
+                        bufferLimit: responseBufferLimit,
                         messageAttributeLimit: .max,
                         bodySizeLimit: .max,
                         literalSizeLimit: IMAPDefaults.literalSizeLimit

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -18,6 +18,7 @@ final class IMAPConnection {
     let port: Int
     let transportSecurity: MailTransportSecurity
     let certificateVerificationPolicy: MailCertificateVerificationPolicy
+    let responseBufferLimit: Int
     let group: EventLoopGroup
     let connectionID: String
     let connectionRole: String
@@ -46,12 +47,14 @@ final class IMAPConnection {
         outboundLabel: String,
         inboundLabel: String,
         connectionID: String,
-        connectionRole: String
+        connectionRole: String,
+        responseBufferLimit: Int = IMAPServer.defaultResponseBufferLimit
     ) {
         self.host = host
         self.port = port
         self.transportSecurity = transportSecurity
         self.certificateVerificationPolicy = certificateVerificationPolicy
+        self.responseBufferLimit = responseBufferLimit
         self.group = group
         self.connectionID = connectionID
         self.connectionRole = connectionRole
@@ -91,7 +94,8 @@ final class IMAPConnection {
         outboundLabel: String,
         inboundLabel: String,
         connectionID: String,
-        connectionRole: String
+        connectionRole: String,
+        responseBufferLimit: Int = IMAPServer.defaultResponseBufferLimit
     ) {
         self.init(
             host: host,
@@ -103,7 +107,8 @@ final class IMAPConnection {
             outboundLabel: outboundLabel,
             inboundLabel: inboundLabel,
             connectionID: connectionID,
-            connectionRole: connectionRole
+            connectionRole: connectionRole,
+            responseBufferLimit: responseBufferLimit
         )
     }
 
@@ -177,6 +182,12 @@ final class IMAPConnection {
     var certificateVerificationPolicyForTesting: MailCertificateVerificationPolicy {
         certificateVerificationPolicy
     }
+
+    #if DEBUG
+    var responseBufferLimitForTesting: Int {
+        responseBufferLimit
+    }
+    #endif
 
     var namespacesSnapshot: NamespaceResponse? {
         namespaces

--- a/Sources/SwiftMail/IMAP/IMAPServer+Connection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Connection.swift
@@ -224,7 +224,8 @@ extension IMAPServer {
             outboundLabel: outboundLabel,
             inboundLabel: inboundLabel,
             connectionID: shortID,
-            connectionRole: "idle:\(sanitizedMailbox)"
+            connectionRole: "idle:\(sanitizedMailbox)",
+            responseBufferLimit: responseBufferLimit
         )
     }
 
@@ -247,7 +248,8 @@ extension IMAPServer {
             outboundLabel: outboundLabel,
             inboundLabel: inboundLabel,
             connectionID: "named-\(shortID)",
-            connectionRole: "named:\(sanitizedName)"
+            connectionRole: "named:\(sanitizedName)",
+            responseBufferLimit: responseBufferLimit
         )
     }
 

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -42,6 +42,11 @@ public actor IMAPServer {
     /// Certificate verification preference used by all TLS transports for this server.
     let certificateVerificationPolicy: MailCertificateVerificationPolicy
 
+    /// Maximum number of bytes the IMAP response parser may buffer before failing.
+    /// Large SEARCH/FETCH responses from dense mailboxes can exceed a small buffer
+    /// and surface as `PayloadTooLargeError`; raise this for very large mailboxes.
+    let responseBufferLimit: Int
+
     /** The event loop group for handling asynchronous operations */
     let group: EventLoopGroup
 
@@ -119,6 +124,13 @@ public actor IMAPServer {
 
     // MARK: - Initialization
 
+    /// The default IMAP response parser buffer limit (1 MB).
+    ///
+    /// Large SEARCH responses can contain thousands of message IDs; 1 MB keeps
+    /// typical mailboxes working without an unbounded buffer. Callers indexing
+    /// very large or dense mailboxes can pass a larger value to the initializer.
+    public static let defaultResponseBufferLimit = 1024 * 1024
+
     /**
      Initialize a new IMAP server connection
 
@@ -129,22 +141,29 @@ public actor IMAPServer {
      ports; explicit values override that inference.
      - certificateVerificationPolicy: The certificate verification policy to use for TLS connections.
      - numberOfThreads: The number of threads to use for the event loop group
+     - responseBufferLimit: Maximum bytes the IMAP response parser may buffer
+     before failing with `PayloadTooLargeError`. Defaults to
+     ``IMAPServer/defaultResponseBufferLimit`` (1 MB), which handles large SEARCH
+     responses containing thousands of message IDs. Raise it for very dense
+     mailboxes whose SEARCH/FETCH responses exceed 1 MB. Must be greater than 0.
 
-     - Note: The connection is configured with a 1MB buffer limit to handle large SEARCH responses
-     that may contain thousands of message IDs. This prevents PayloadTooLargeError when
-     searching large mailboxes.
+     - Precondition: `responseBufferLimit > 0` — a non-positive limit would make
+     every response exceed the buffer and fail with `PayloadTooLargeError`.
      */
     public init(
         host: String,
         port: Int,
         transportSecurity: MailTransportSecurity = .automatic,
         certificateVerificationPolicy: MailCertificateVerificationPolicy = .fullVerification,
-        numberOfThreads: Int = 1
+        numberOfThreads: Int = 1,
+        responseBufferLimit: Int = IMAPServer.defaultResponseBufferLimit
     ) {
+        precondition(responseBufferLimit > 0, "responseBufferLimit must be greater than 0 bytes")
         self.host = host
         self.port = port
         self.transportSecurity = transportSecurity
         self.certificateVerificationPolicy = certificateVerificationPolicy
+        self.responseBufferLimit = responseBufferLimit
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: numberOfThreads)
 
         // Initialize loggers
@@ -163,17 +182,25 @@ public actor IMAPServer {
             outboundLabel: outboundLabel,
             inboundLabel: inboundLabel,
             connectionID: "primary",
-            connectionRole: "primary"
+            connectionRole: "primary",
+            responseBufferLimit: responseBufferLimit
         )
     }
 
-    public init(host: String, port: Int, useTLS: Bool?, numberOfThreads: Int = 1) {
+    public init(
+        host: String,
+        port: Int,
+        useTLS: Bool?,
+        numberOfThreads: Int = 1,
+        responseBufferLimit: Int = IMAPServer.defaultResponseBufferLimit
+    ) {
         self.init(
             host: host,
             port: port,
             transportSecurity: Self.resolveLegacyTransportSecurity(port: port, useTLS: useTLS),
             certificateVerificationPolicy: .fullVerification,
-            numberOfThreads: numberOfThreads
+            numberOfThreads: numberOfThreads,
+            responseBufferLimit: responseBufferLimit
         )
     }
 
@@ -188,6 +215,13 @@ public actor IMAPServer {
 
         return .plainText
     }
+
+    #if DEBUG
+    /// Test-only access to the response buffer limit configured on the primary connection.
+    var primaryResponseBufferLimitForTesting: Int {
+        primaryConnection.responseBufferLimit
+    }
+    #endif
 
     deinit {
         // Schedule shutdown on a background thread to avoid EventLoop issues

--- a/Tests/SwiftIMAPTests/IMAPResponseBufferLimitTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPResponseBufferLimitTests.swift
@@ -1,0 +1,100 @@
+import Foundation
+import NIO
+import Testing
+@testable import SwiftMail
+
+@Suite(.serialized, .timeLimit(.minutes(1)))
+struct IMAPResponseBufferLimitTests {
+    /// Deterministically shuts `group` down via `syncShutdownGracefully()`, but runs
+    /// that blocking call OFF the Swift Concurrency cooperative pool. Calling
+    /// `syncShutdownGracefully()` directly from a swift-testing test blocks a
+    /// cooperative-pool thread; on a core-constrained CI runner that violates the
+    /// pool's forward-progress guarantee and deadlocks the whole run (a 7-minute
+    /// hang to the job timeout was observed). Dispatching to a non-cooperative GCD
+    /// global queue and awaiting the continuation keeps the shutdown deterministic
+    /// without ever blocking the pool.
+    private func shutDownGracefully(_ group: MultiThreadedEventLoopGroup) async {
+        await withCheckedContinuation { continuation in
+            DispatchQueue.global().async {
+                try? group.syncShutdownGracefully()
+                continuation.resume()
+            }
+        }
+    }
+
+    @Test("Default response buffer limit is 1 MB")
+    func defaultIsOneMegabyte() async {
+        let server = IMAPServer(host: "imap.example.com", port: 993)
+        let limit = await server.primaryResponseBufferLimitForTesting
+        #expect(IMAPServer.defaultResponseBufferLimit == 1024 * 1024)
+        #expect(limit == IMAPServer.defaultResponseBufferLimit)
+    }
+
+    @Test("Custom limit propagates to the primary connection")
+    func customLimitPropagatesToPrimary() async {
+        let custom = 4 * 1024 * 1024
+        let server = IMAPServer(
+            host: "imap.example.com",
+            port: 993,
+            responseBufferLimit: custom
+        )
+        let limit = await server.primaryResponseBufferLimitForTesting
+        #expect(limit == custom)
+    }
+
+    @Test("Legacy useTLS initializer honors a custom limit")
+    func legacyInitHonorsCustomLimit() async {
+        let custom = 2 * 1024 * 1024
+        let server = IMAPServer(
+            host: "imap.example.com",
+            port: 993,
+            useTLS: true,
+            numberOfThreads: 1,
+            responseBufferLimit: custom
+        )
+        let limit = await server.primaryResponseBufferLimitForTesting
+        #expect(limit == custom)
+    }
+
+    // Spawned idle/named connections forward the same `responseBufferLimit`
+    // value the server was configured with; verifying the connection-level
+    // plumbing here (without crossing the actor boundary with a non-Sendable
+    // IMAPConnection) covers what those one-line forwarders rely on.
+    @Test("Directly constructed connection defaults to 1 MB")
+    func directConnectionDefault() async {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let connection = IMAPConnection(
+            host: "localhost",
+            port: 993,
+            useTLS: true,
+            group: group,
+            loggerLabel: "test.imap",
+            outboundLabel: "test.imap.out",
+            inboundLabel: "test.imap.in",
+            connectionID: "test-default-buffer",
+            connectionRole: "test"
+        )
+        #expect(connection.responseBufferLimitForTesting == IMAPServer.defaultResponseBufferLimit)
+        await shutDownGracefully(group)
+    }
+
+    @Test("Directly constructed connection honors a custom limit")
+    func directConnectionCustom() async {
+        let custom = 3 * 1024 * 1024
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let connection = IMAPConnection(
+            host: "localhost",
+            port: 993,
+            useTLS: true,
+            group: group,
+            loggerLabel: "test.imap",
+            outboundLabel: "test.imap.out",
+            inboundLabel: "test.imap.in",
+            connectionID: "test-custom-buffer",
+            connectionRole: "test",
+            responseBufferLimit: custom
+        )
+        #expect(connection.responseBufferLimitForTesting == custom)
+        await shutDownGracefully(group)
+    }
+}


### PR DESCRIPTION
## What

The IMAP response parser's `bufferLimit` is hardcoded to 1 MB in `IMAPConnection`'s connection bootstrap. This makes it configurable via a new `responseBufferLimit` parameter on `IMAPServer`, defaulting to 1 MB so existing callers are unaffected.

## Why

Dense mailboxes can return `SEARCH`/`FETCH` responses larger than 1 MB — e.g. a `UID SEARCH` matching tens of thousands of messages. These overflow the parser's buffer and surface as `PayloadTooLargeError`, which drops the connection. Today the only recourse is to live with the failures or fork the constant. Exposing it lets clients that index large mailboxes raise the limit when they need to.

## What changed

- Add `IMAPServer.defaultResponseBufferLimit` (1 MB) and a `responseBufferLimit:` parameter on both public `IMAPServer` initializers, defaulting to it — **no behavior change** for existing callers.
- Thread the value to the primary connection and to spawned **idle** and **named** connections (where large IDLE / parallel-FETCH responses actually arrive), then apply it to `ResponseParser.Options`.
- The connect log line now reports the actual configured limit instead of a hardcoded "1MB".

## Tests

Adds `IMAPResponseBufferLimitTests`:
- default resolves to `defaultResponseBufferLimit` (1 MB),
- a custom value propagates through both initializers to the primary connection,
- the `IMAPConnection`-level plumbing honors default and custom limits.

Full suite green locally (310 tests, Xcode 26 / Swift 6.3.2).
