### PR TITLE
Coalesce concurrent named IMAP connection authentication

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -41,6 +41,15 @@ jobs:
         uses: maxim-lobanov/setup-xcode@v1
         with:
           xcode-version: "26.0"
+      # Xcode 16+ ships platform SDKs as on-demand components, so a freshly
+      # rotated `macos-latest` image can have the selected Xcode without the iOS
+      # platform installed — `-destination 'generic/platform=iOS'` then resolves
+      # to zero destinations ("iOS … is not installed") before anything compiles.
+      # Fetch the component when it is missing. Best-effort (`|| true`): on images
+      # that already have it the download itself can error, and the Build step
+      # below is the real gate either way (it only needs the SDK).
+      - name: Ensure the iOS platform is installed (best-effort)
+        run: xcodebuild -downloadPlatform iOS || true
       - name: Build (iOS)
         run: xcodebuild -scheme SwiftMail -destination 'generic/platform=iOS' build
 

--- a/Sources/SwiftMail/IMAP/IMAPNamedConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPNamedConnection.swift
@@ -21,11 +21,9 @@ public actor IMAPNamedConnection {
     private var authenticationWaiters: [CheckedContinuation<Void, any Error>] = []
     private var isAuthenticationInFlight = false
 
-    #if DEBUG
     var authenticationWaiterCountForTesting: Int {
         authenticationWaiters.count
     }
-    #endif
 
     init(
         name: String,

--- a/Sources/SwiftMail/IMAP/IMAPNamedConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPNamedConnection.swift
@@ -18,6 +18,8 @@ public actor IMAPNamedConnection {
     /// The timestamp of the last successfully completed command on this connection.
     /// Useful for implementing staleness checks in ephemeral connection patterns.
     public private(set) var lastActivity: Date?
+    private var authenticationWaiters: [CheckedContinuation<Void, any Error>] = []
+    private var isAuthenticationInFlight = false
 
     init(
         name: String,
@@ -70,8 +72,37 @@ public actor IMAPNamedConnection {
     }
 
     func ensureAuthenticated() async throws {
-        if !connection.isAuthenticated {
+        guard !connection.isAuthenticated else { return }
+
+        if isAuthenticationInFlight {
+            try await withCheckedThrowingContinuation { continuation in
+                authenticationWaiters.append(continuation)
+            }
+            return
+        }
+
+        isAuthenticationInFlight = true
+        do {
             try await authenticateOnConnection(connection)
+            completeAuthenticationWaiters(with: .success(()))
+        } catch {
+            completeAuthenticationWaiters(with: .failure(error))
+            throw error
+        }
+    }
+
+    private func completeAuthenticationWaiters(with result: Result<Void, any Error>) {
+        isAuthenticationInFlight = false
+        let waiters = authenticationWaiters
+        authenticationWaiters.removeAll()
+
+        for waiter in waiters {
+            switch result {
+                case .success:
+                    waiter.resume()
+                case .failure(let error):
+                    waiter.resume(throwing: error)
+            }
         }
     }
 

--- a/Sources/SwiftMail/IMAP/IMAPNamedConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPNamedConnection.swift
@@ -21,6 +21,12 @@ public actor IMAPNamedConnection {
     private var authenticationWaiters: [CheckedContinuation<Void, any Error>] = []
     private var isAuthenticationInFlight = false
 
+    #if DEBUG
+    var authenticationWaiterCountForTesting: Int {
+        authenticationWaiters.count
+    }
+    #endif
+
     init(
         name: String,
         connection: IMAPConnection,
@@ -81,6 +87,8 @@ public actor IMAPNamedConnection {
             return
         }
 
+        // Concurrent callers share this leader's result. Failure clears the
+        // in-flight state so a later call can retry normally.
         isAuthenticationInFlight = true
         do {
             try await authenticateOnConnection(connection)

--- a/Sources/SwiftMail/IMAP/IMAPServer+Connection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Connection.swift
@@ -158,10 +158,17 @@ extension IMAPServer {
             return existing.handle
         }
 
+        if pendingNamedConnectionWaiters[normalizedName] != nil {
+            return try await withCheckedThrowingContinuation { continuation in
+                pendingNamedConnectionWaiters[normalizedName, default: []].append(continuation)
+            }
+        }
+
         guard let authentication else {
             throw IMAPError.commandFailed("Authentication required before creating a named connection")
         }
 
+        pendingNamedConnectionWaiters[normalizedName] = []
         let connection = makeNamedConnection(name: normalizedName)
 
         do {
@@ -177,10 +184,28 @@ extension IMAPServer {
             )
 
             namedConnections[normalizedName] = NamedConnection(connection: connection, handle: handle)
+            completePendingNamedConnection(named: normalizedName, with: .success(handle))
             return handle
         } catch {
             try? await connection.disconnect()
+            completePendingNamedConnection(named: normalizedName, with: .failure(error))
             throw error
+        }
+    }
+
+    private func completePendingNamedConnection(
+        named name: String,
+        with result: Result<IMAPNamedConnection, any Error>
+    ) {
+        let waiters = pendingNamedConnectionWaiters.removeValue(forKey: name) ?? []
+
+        for waiter in waiters {
+            switch result {
+                case .success(let handle):
+                    waiter.resume(returning: handle)
+                case .failure(let error):
+                    waiter.resume(throwing: error)
+            }
         }
     }
 

--- a/Sources/SwiftMail/IMAP/IMAPServer+Connection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Connection.swift
@@ -160,7 +160,7 @@ extension IMAPServer {
 
         if pendingNamedConnectionWaiters[normalizedName] != nil {
             return try await withCheckedThrowingContinuation { continuation in
-                pendingNamedConnectionWaiters[normalizedName, default: []].append(continuation)
+                pendingNamedConnectionWaiters[normalizedName]?.append(continuation)
             }
         }
 
@@ -168,6 +168,8 @@ extension IMAPServer {
             throw IMAPError.commandFailed("Authentication required before creating a named connection")
         }
 
+        // Concurrent callers share the leader's result. Success returns the same
+        // handle; failure clears this sentinel so a later call can retry normally.
         pendingNamedConnectionWaiters[normalizedName] = []
         let connection = makeNamedConnection(name: normalizedName)
 

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -59,6 +59,9 @@ public actor IMAPServer {
     /// User-managed named connections keyed by requested name.
     var namedConnections: [String: NamedConnection] = [:]
 
+    /// Waiters for named connections currently being created.
+    var pendingNamedConnectionWaiters: [String: [CheckedContinuation<IMAPNamedConnection, any Error>]] = [:]
+
     /// Authentication configuration for spawning new connections.
     var authentication: Authentication?
 

--- a/Tests/SwiftIMAPTests/IMAPNamedConnectionTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPNamedConnectionTests.swift
@@ -4,6 +4,28 @@ import NIOIMAPCore
 import Testing
 @testable import SwiftMail
 
+private actor AuthenticationGate {
+    private var starts = 0
+    private var releaseContinuations: [CheckedContinuation<Void, Never>] = []
+
+    func startAndWait() async {
+        starts += 1
+        await withCheckedContinuation { continuation in
+            releaseContinuations.append(continuation)
+        }
+    }
+
+    func startCount() -> Int {
+        starts
+    }
+
+    func releaseAll() {
+        let continuations = releaseContinuations
+        releaseContinuations.removeAll()
+        continuations.forEach { $0.resume() }
+    }
+}
+
 @Suite(.serialized, .timeLimit(.minutes(1)))
 struct IMAPNamedConnectionTests {
     private func makeConnection(
@@ -50,6 +72,84 @@ struct IMAPNamedConnectionTests {
         let activity = await named.lastActivity
         #expect(activity == nil)
     }
+
+    @Test
+    func concurrentAuthenticationRequestsShareSingleInFlightAttempt() async throws {
+        let gate = AuthenticationGate()
+        let named = makeConnection(authenticate: { connection in
+            await gate.startAndWait()
+            connection.isSessionAuthenticated = true
+        })
+
+        let first = Task {
+            try await named.ensureAuthenticated()
+        }
+
+        while await gate.startCount() < 1 {
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+
+        let second = Task {
+            try await named.ensureAuthenticated()
+        }
+
+        try await Task.sleep(nanoseconds: 50_000_000)
+        #expect(await gate.startCount() == 1)
+
+        await gate.releaseAll()
+        try await first.value
+        try await second.value
+    }
+
+    #if os(macOS)
+        @Test
+        func concurrentSameNameConnectionRequestsShareSingleHandle() async throws {
+            let tempRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            let maildir = tempRoot.appendingPathComponent("Maildir")
+            let curDir = maildir.appendingPathComponent("cur")
+            let newDir = maildir.appendingPathComponent("new")
+
+            try FileManager.default.createDirectory(at: curDir, withIntermediateDirectories: true)
+            try FileManager.default.createDirectory(at: newDir, withIntermediateDirectories: true)
+            defer {
+                try? FileManager.default.removeItem(at: tempRoot)
+            }
+
+            let sampleMessage = """
+            From: Test <sender@example.com>\r
+            To: Test <recipient@example.com>\r
+            Subject: Test\r
+            Date: Thu, 01 Jan 2026 00:00:00 +0000\r
+            Message-ID: <test@example.com>\r
+            Content-Type: text/plain; charset=utf-8\r
+            \r
+            Body.\r
+            """
+            try sampleMessage.data(using: .utf8)?.write(to: curDir.appendingPathComponent("1.eml"))
+
+            let testServer = try IMAPTestServer(
+                host: "localhost",
+                port: 0,
+                username: "u",
+                password: "p",
+                loginResponseDelay: 0.15,
+                maildirURL: maildir
+            )
+            try testServer.start()
+            defer { testServer.stop() }
+
+            let server = IMAPServer(host: "127.0.0.1", port: testServer.port, useTLS: false)
+            try await server.connect()
+            try await server.login(username: "u", password: "p")
+
+            async let first = server.connection(named: "shared")
+            async let second = server.connection(named: "shared")
+            let handles = try await (first, second)
+
+            #expect(ObjectIdentifier(handles.0) == ObjectIdentifier(handles.1))
+            try await server.disconnect()
+        }
+    #endif
 
     @Test
     func uidExpungeRequiresUIDPlusCapability() async {

--- a/Tests/SwiftIMAPTests/IMAPNamedConnectionTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPNamedConnectionTests.swift
@@ -28,10 +28,19 @@ private actor AuthenticationGate {
 
 @Suite(.serialized, .timeLimit(.minutes(1)))
 struct IMAPNamedConnectionTests {
+    private struct NamedConnectionHarness {
+        let named: IMAPNamedConnection
+        let group: MultiThreadedEventLoopGroup
+
+        func shutdown() async {
+            try? await group.shutdownGracefully()
+        }
+    }
+
     private func makeConnection(
         name: String = "test",
         authenticate: @escaping @Sendable (IMAPConnection) async throws -> Void = { _ in }
-    ) -> IMAPNamedConnection {
+    ) -> NamedConnectionHarness {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let connection = IMAPConnection(
             host: "localhost",
@@ -44,14 +53,35 @@ struct IMAPNamedConnectionTests {
             connectionID: "test-\(name)",
             connectionRole: "test"
         )
-        return IMAPNamedConnection(name: name, connection: connection, authenticateOnConnection: authenticate)
+        let named = IMAPNamedConnection(name: name, connection: connection, authenticateOnConnection: authenticate)
+        return NamedConnectionHarness(named: named, group: group)
+    }
+
+    private func waitForAuthenticationWaiter(
+        on named: IMAPNamedConnection,
+        gate: AuthenticationGate
+    ) async throws {
+        for _ in 0..<100 {
+            if await named.authenticationWaiterCountForTesting == 1 {
+                return
+            }
+            if await gate.startCount() > 1 {
+                Issue.record("Expected second authentication request to wait behind the leader")
+                return
+            }
+            try await Task.sleep(nanoseconds: 1_000_000)
+        }
+
+        Issue.record("Expected second authentication request to park as a waiter")
     }
 
     @Test
     func lastActivityIsNilBeforeAnyCommands() async {
-        let named = makeConnection()
-        let activity = await named.lastActivity
+        let harness = makeConnection()
+
+        let activity = await harness.named.lastActivity
         #expect(activity == nil)
+        await harness.shutdown()
     }
 
     @Test
@@ -59,46 +89,54 @@ struct IMAPNamedConnectionTests {
         // Authentication closure throws before executeCommand reaches the
         // underlying connection, so lastActivity must stay nil and no transport
         // should be opened.
-        let named = makeConnection(authenticate: { _ in
+        let harness = makeConnection(authenticate: { _ in
             throw IMAPError.authFailed("auth error")
         })
 
         do {
-            _ = try await named.noop()
+            _ = try await harness.named.noop()
         } catch {
             // expected – authentication throws before any command reaches the server
         }
 
-        let activity = await named.lastActivity
+        let activity = await harness.named.lastActivity
         #expect(activity == nil)
+        await harness.shutdown()
     }
 
     @Test
     func concurrentAuthenticationRequestsShareSingleInFlightAttempt() async throws {
         let gate = AuthenticationGate()
-        let named = makeConnection(authenticate: { connection in
+        let harness = makeConnection(authenticate: { connection in
             await gate.startAndWait()
             connection.isSessionAuthenticated = true
         })
 
-        let first = Task {
-            try await named.ensureAuthenticated()
+        do {
+            let first = Task {
+                try await harness.named.ensureAuthenticated()
+            }
+
+            while await gate.startCount() < 1 {
+                try await Task.sleep(nanoseconds: 1_000_000)
+            }
+
+            let second = Task {
+                try await harness.named.ensureAuthenticated()
+            }
+
+            try await waitForAuthenticationWaiter(on: harness.named, gate: gate)
+            #expect(await gate.startCount() == 1)
+
+            await gate.releaseAll()
+            try await first.value
+            try await second.value
+            await harness.shutdown()
+        } catch {
+            await gate.releaseAll()
+            await harness.shutdown()
+            throw error
         }
-
-        while await gate.startCount() < 1 {
-            try await Task.sleep(nanoseconds: 1_000_000)
-        }
-
-        let second = Task {
-            try await named.ensureAuthenticated()
-        }
-
-        try await Task.sleep(nanoseconds: 50_000_000)
-        #expect(await gate.startCount() == 1)
-
-        await gate.releaseAll()
-        try await first.value
-        try await second.value
     }
 
     #if os(macOS)
@@ -154,11 +192,6 @@ struct IMAPNamedConnectionTests {
     @Test
     func uidExpungeRequiresUIDPlusCapability() async {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer {
-            Task {
-                try? await group.shutdownGracefully()
-            }
-        }
 
         let connection = IMAPConnection(
             host: "localhost",
@@ -186,16 +219,12 @@ struct IMAPNamedConnectionTests {
         } catch {
             Issue.record("Expected IMAPError.commandNotSupported, got \(error)")
         }
+        try? await group.shutdownGracefully()
     }
 
     @Test
     func sortedSearchRequiresSortCapability() async {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer {
-            Task {
-                try? await group.shutdownGracefully()
-            }
-        }
 
         let connection = IMAPConnection(
             host: "localhost",
@@ -226,5 +255,6 @@ struct IMAPNamedConnectionTests {
         } catch {
             Issue.record("Expected IMAPError.commandNotSupported, got \(error)")
         }
+        try? await group.shutdownGracefully()
     }
 }

--- a/Tests/SwiftIMAPTests/IMAPTestServer.swift
+++ b/Tests/SwiftIMAPTests/IMAPTestServer.swift
@@ -44,6 +44,7 @@ final class IMAPTestServer {
     private var acceptSource: DispatchSourceRead?
     private let queue = DispatchQueue(label: "IMAPTestServer")
     private let messages: [Message]
+    private let loginResponseDelay: TimeInterval
     private var clientFds: [Int32] = []
     private let metricsQueue = DispatchQueue(label: "IMAPTestServer.metrics")
     private var idleCommandCountStorage = 0
@@ -53,12 +54,14 @@ final class IMAPTestServer {
         port: Int = 0,
         username: String = "testuser",
         password: String = "testpass",
+        loginResponseDelay: TimeInterval = 0,
         maildirURL: URL
     ) throws {
         self.host = host
         self.port = port
         self.username = username
         self.password = password
+        self.loginResponseDelay = loginResponseDelay
         self.messages = try Self.loadMaildir(maildirURL)
     }
 
@@ -252,6 +255,9 @@ final class IMAPTestServer {
                 return "* CAPABILITY IMAP4rev1 AUTH=PLAIN LITERAL+ ID NAMESPACE UIDPLUS IDLE\r\n"
                     + "\(tag) OK CAPABILITY completed\r\n"
             case "LOGIN":
+                if loginResponseDelay > 0 {
+                    Thread.sleep(forTimeInterval: loginResponseDelay)
+                }
                 authenticated = true
                 return "\(tag) OK LOGIN completed\r\n"
             case "SELECT":

--- a/Tests/SwiftIMAPTests/IMAPTestServer.swift
+++ b/Tests/SwiftIMAPTests/IMAPTestServer.swift
@@ -145,7 +145,9 @@ final class IMAPTestServer {
 
         let activeClientFds = markStoppingAndSnapshotClientFds()
         for fileDescriptor in activeClientFds {
-            shutdown(fileDescriptor, SHUT_RDWR)
+            // `SHUT_RDWR` imports as `Int32` on Darwin but `Int` on Glibc; cast so
+            // the `shutdown(2)` call (which wants `Int32`) compiles on Linux too.
+            shutdown(fileDescriptor, Int32(SHUT_RDWR))
         }
 
         if !activeClientFds.isEmpty {

--- a/Tests/SwiftIMAPTests/IMAPTestServer.swift
+++ b/Tests/SwiftIMAPTests/IMAPTestServer.swift
@@ -45,9 +45,12 @@ final class IMAPTestServer {
     private let queue = DispatchQueue(label: "IMAPTestServer")
     private let messages: [Message]
     private let loginResponseDelay: TimeInterval
-    private var clientFds: [Int32] = []
     private let metricsQueue = DispatchQueue(label: "IMAPTestServer.metrics")
     private var idleCommandCountStorage = 0
+    private var clientFds: Set<Int32> = []
+    private let clientFdsLock = NSLock()
+    private let clientGroup = DispatchGroup()
+    private var isStopping = false
 
     init(
         host: String = "localhost",
@@ -74,6 +77,8 @@ final class IMAPTestServer {
     }
 
     func start() throws {
+        resetClientTrackingForStart()
+
         #if os(Linux)
             listenFd = socket(AF_INET, Int32(SOCK_STREAM.rawValue), 0)
         #else
@@ -137,10 +142,19 @@ final class IMAPTestServer {
     func stop() {
         acceptSource?.cancel()
         acceptSource = nil
-        for fileDescriptor in clientFds {
+
+        let activeClientFds = markStoppingAndSnapshotClientFds()
+        for fileDescriptor in activeClientFds {
+            shutdown(fileDescriptor, SHUT_RDWR)
+        }
+
+        if !activeClientFds.isEmpty {
+            _ = clientGroup.wait(timeout: .now() + .seconds(2))
+        }
+
+        for fileDescriptor in drainClientFds() {
             close(fileDescriptor)
         }
-        clientFds.removeAll()
     }
 
     // MARK: - Connection Handling
@@ -154,15 +168,27 @@ final class IMAPTestServer {
             }
         }
         guard clientFd >= 0 else { return }
-        clientFds.append(clientFd)
+        guard registerClient(fd: clientFd) else {
+            close(clientFd)
+            return
+        }
 
         // Handle on a background queue
+        let clientGroup = clientGroup
+        clientGroup.enter()
         DispatchQueue.global().async { [weak self] in
-            self?.handleClient(fd: clientFd)
+            defer { clientGroup.leave() }
+            guard let self else {
+                close(clientFd)
+                return
+            }
+            self.handleClient(fd: clientFd)
         }
     }
 
     private func handleClient(fd fileDescriptor: Int32) {
+        defer { closeTrackedClient(fd: fileDescriptor) }
+
         // Send greeting
         sendLine(fd: fileDescriptor, "* OK IMAP test server ready\r\n")
 
@@ -219,13 +245,53 @@ final class IMAPTestServer {
                 sendLine(fd: fileDescriptor, response)
 
                 if command == "LOGOUT" {
-                    close(fileDescriptor)
                     return
                 }
             }
         }
+    }
 
-        close(fileDescriptor)
+    private func resetClientTrackingForStart() {
+        clientFdsLock.lock()
+        isStopping = false
+        clientFds.removeAll()
+        clientFdsLock.unlock()
+    }
+
+    private func registerClient(fd fileDescriptor: Int32) -> Bool {
+        clientFdsLock.lock()
+        defer { clientFdsLock.unlock() }
+
+        guard !isStopping else { return false }
+        clientFds.insert(fileDescriptor)
+        return true
+    }
+
+    private func markStoppingAndSnapshotClientFds() -> [Int32] {
+        clientFdsLock.lock()
+        defer { clientFdsLock.unlock() }
+
+        isStopping = true
+        return Array(clientFds)
+    }
+
+    private func drainClientFds() -> [Int32] {
+        clientFdsLock.lock()
+        defer { clientFdsLock.unlock() }
+
+        let fileDescriptors = Array(clientFds)
+        clientFds.removeAll()
+        return fileDescriptors
+    }
+
+    private func closeTrackedClient(fd fileDescriptor: Int32) {
+        clientFdsLock.lock()
+        let shouldClose = clientFds.remove(fileDescriptor) != nil
+        clientFdsLock.unlock()
+
+        if shouldClose {
+            close(fileDescriptor)
+        }
     }
 
     private func sendLine(fd fileDescriptor: Int32, _ text: String) {


### PR DESCRIPTION
Summary:
- Coalesce concurrent `IMAPServer.connection(named:)` creation for the same normalized connection name.
- Coalesce concurrent authentication attempts inside `IMAPNamedConnection` so same-handle callers share one in-flight authentication attempt.
- Preserve retry behavior after failures by clearing the in-flight sentinel before returning to later callers.
- Add regression coverage for same-name connection sharing and same-handle authentication sharing.

Review follow-up:
- Await event-loop group shutdown in the touched tests instead of launching detached teardown tasks.
- Replace the fixed-sleep auth regression check with a deterministic waiter-count signal.
- Keep the single-flight helper local to the two actor-owned call sites; this avoids introducing a broader abstraction for a private two-site pattern.
- Coalesced waiters intentionally inherit the leader result. If that result fails, a later call can retry normally.
- Make the internal waiter-count testing hook available in release test builds; it remains internal and only reachable from tests via `@testable import`.

Validation:
- `swift test --filter IMAPNamedConnectionTests` — 6 Swift Testing tests passed locally.
- `swiftlint lint --strict --no-cache` — 0 violations locally.
- `swift test -c release --filter IMAPNamedConnectionTests` — no longer reports the `authenticationWaiterCountForTesting` error; the release build still stops on existing `IMAPResponseBufferLimitTests` testing hooks outside this PR.
- GitHub Actions for the previous head were green for macOS, iOS, Linux, Android, and SwiftLint; checks are rerunning for head `a61413b`.