### PR TITLE
Update swift-nio-imap to 0.3.0

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -59,7 +59,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-nio-imap",
       "state" : {
-        "revision" : "bcf875610ca56dfd7bae869fa19ca3149c075908"
+        "revision" : "880366a41739a1a86d23b7857f533491b8a3cd07",
+        "version" : "0.3.0"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -49,14 +49,7 @@ let package = Package(
         // encoding, ProcessInfo.localIPAddress).
         .package(url: "https://github.com/Cocoanetics/SwiftCross", from: "1.2.0"),
         .package(url: "https://github.com/apple/swift-nio", from: "2.0.0"),
-        // Upstream now carries the Android/Bionic libc-guard fix for NIOIMAPCore
-        // (apple/swift-nio-imap#826), so depend on it directly instead of a fork.
-        // No release contains it yet (latest tag is 0.2.0) — pin the merge
-        // revision; switch to `from:` once a release ships.
-        .package(
-            url: "https://github.com/apple/swift-nio-imap",
-            revision: "bcf875610ca56dfd7bae869fa19ca3149c075908"
-        ),
+        .package(url: "https://github.com/apple/swift-nio-imap", from: "0.3.0"),
         // Pinned to the latest upstream main, which carries the Windows-SDK
         // BoringSSL header workarounds (_WINSOCKAPI_/NOMINMAX/NOCRYPT scoped to
         // the CNIOBoringSSL target, apple/swift-nio-ssl#585). No release contains

--- a/Tests/SwiftIMAPTests/ExtendedSearchHandlerTests.swift
+++ b/Tests/SwiftIMAPTests/ExtendedSearchHandlerTests.swift
@@ -1,6 +1,6 @@
 // Splitting this test file was tried but introduced a macOS CI hang;
 // see the IMAPTestServer.swift comment for context.
-// swiftlint:disable file_length type_body_length
+// swiftlint:disable type_body_length
 
 import Foundation
 import NIO
@@ -47,9 +47,7 @@ struct ExtendedSearchHandlerTests {
 
     @Test
     func testEsearchResponseUID() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let promise = channel.eventLoop.makePromise(of: ExtendedSearchResult<UID>.self)
         let handler = ExtendedSearchHandler<UID>(commandTag: "A001", promise: promise)
@@ -83,9 +81,7 @@ struct ExtendedSearchHandlerTests {
 
     @Test
     func testEsearchResponseSequenceNumber() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let promise = channel.eventLoop.makePromise(of: ExtendedSearchResult<SequenceNumber>.self)
         let handler = ExtendedSearchHandler<SequenceNumber>(commandTag: "A002", promise: promise)
@@ -113,9 +109,7 @@ struct ExtendedSearchHandlerTests {
 
     @Test
     func testFallbackPlainSearch() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let promise = channel.eventLoop.makePromise(of: ExtendedSearchResult<UID>.self)
         let handler = ExtendedSearchHandler<UID>(commandTag: "A003", promise: promise)
@@ -159,9 +153,7 @@ struct ExtendedSearchHandlerTests {
 
     @Test
     func testEsearchEmptyResult() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let promise = channel.eventLoop.makePromise(of: ExtendedSearchResult<UID>.self)
         let handler = ExtendedSearchHandler<UID>(commandTag: "A004", promise: promise)
@@ -189,9 +181,7 @@ struct ExtendedSearchHandlerTests {
 
     @Test
     func testCommandWireFormatWithEsearch() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let command = ExtendedSearchCommand<UID>(criteria: [SearchCriteria.all], useEsearch: true)
         let tagged = command.toTaggedCommand(tag: "C001")
@@ -214,9 +204,7 @@ struct ExtendedSearchHandlerTests {
 
     @Test
     func testSortedCommandWireFormatUsesUIDSort() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let command = ExtendedSearchCommand<UID>(
             criteria: [SearchCriteria.all],
@@ -242,9 +230,7 @@ struct ExtendedSearchHandlerTests {
 
     @Test
     func testCommandWireFormatWithoutEsearch() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let command = ExtendedSearchCommand<UID>(criteria: [SearchCriteria.all], useEsearch: false)
         let tagged = command.toTaggedCommand(tag: "C002")
@@ -263,9 +249,7 @@ struct ExtendedSearchHandlerTests {
 
     @Test
     func testCommandWireFormatSequenceNumberWithEsearch() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let command = ExtendedSearchCommand<SequenceNumber>(criteria: [SearchCriteria.all], useEsearch: true)
         let tagged = command.toTaggedCommand(tag: "C003")
@@ -285,9 +269,7 @@ struct ExtendedSearchHandlerTests {
 
     @Test
     func testIdentifierSetScopeIsIncludedInUIDSearch() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let ids = MessageIdentifierSet<UID>([UID(1), UID(2), UID(3)])
         let command = ExtendedSearchCommand<UID>(identifierSet: ids, criteria: [SearchCriteria.all], useEsearch: true)
@@ -307,9 +289,7 @@ struct ExtendedSearchHandlerTests {
 
     @Test
     func testNoIdentifierSetSearchesEntireMailbox() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let command = ExtendedSearchCommand<UID>(identifierSet: nil, criteria: [SearchCriteria.all], useEsearch: true)
         let tagged = command.toTaggedCommand(tag: "C006")
@@ -331,9 +311,7 @@ struct ExtendedSearchHandlerTests {
 
     @Test
     func testEsearchPartialResponse() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let promise = channel.eventLoop.makePromise(of: ExtendedSearchResult<UID>.self)
         let handler = ExtendedSearchHandler<UID>(commandTag: "A007", promise: promise)
@@ -379,9 +357,7 @@ struct ExtendedSearchHandlerTests {
 
     @Test
     func testCommandWireFormatWithPartial() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let partialRange = NIOIMAPCore.PartialRange.first(NIOIMAPCore.SequenceRange(1...100))
         let command = ExtendedSearchCommand<UID>(
@@ -406,4 +382,4 @@ struct ExtendedSearchHandlerTests {
         #expect(!wireString.contains("ALL"))
     }
 }
-// swiftlint:enable file_length type_body_length
+// swiftlint:enable type_body_length

--- a/Tests/SwiftIMAPTests/FetchMessageInfoHandlerTests.swift
+++ b/Tests/SwiftIMAPTests/FetchMessageInfoHandlerTests.swift
@@ -238,9 +238,7 @@ struct FetchMessageInfoHandlerTests {
     }
 
     private func executeFetch(_ rawResponses: [String]) async throws -> [MessageInfo] {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let promise = channel.eventLoop.makePromise(of: [MessageInfo].self)
         let handler = FetchMessageInfoHandler(commandTag: "A001", promise: promise)

--- a/Tests/SwiftIMAPTests/IMAPClientHandler+Sendable.swift
+++ b/Tests/SwiftIMAPTests/IMAPClientHandler+Sendable.swift
@@ -1,3 +1,0 @@
-@preconcurrency import NIOIMAP
-
-extension IMAPClientHandler: @retroactive @unchecked Sendable {}

--- a/Tests/SwiftIMAPTests/IMAPIdleCancellationTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPIdleCancellationTests.swift
@@ -152,7 +152,7 @@ struct IMAPIdleCancellationTests {
         let channel = NIOAsyncTestingChannel()
         let address = try SocketAddress(ipAddress: "127.0.0.1", port: 143)
         try await channel.connect(to: address)
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        try await channel.addIMAPClientHandler()
         try await channel.pipeline.addHandler(connection.duplexLogger)
         try await channel.pipeline.addHandler(connection.responseBuffer)
         connection.replaceChannelForTesting(channel)

--- a/Tests/SwiftIMAPTests/IMAPTestingChannel.swift
+++ b/Tests/SwiftIMAPTests/IMAPTestingChannel.swift
@@ -1,0 +1,23 @@
+import NIO
+import NIOEmbedded
+import NIOIMAP
+
+// NIOIMAP 0.3.0 declares `IMAPClientHandler` explicitly non-`Sendable` (it is tied
+// to a single `EventLoop`), so it can't be added via the async
+// `pipeline.addHandler(_:)`, which requires a `Sendable` handler. These helpers add
+// it through `syncOperations` instead, on the channel's event loop.
+extension NIOAsyncTestingChannel {
+    static func withIMAPClientHandler(
+        loop: NIOAsyncTestingEventLoop = NIOAsyncTestingEventLoop()
+    ) async throws -> NIOAsyncTestingChannel {
+        try await NIOAsyncTestingChannel(loop: loop) { channel in
+            try channel.pipeline.syncOperations.addHandler(IMAPClientHandler())
+        }
+    }
+
+    func addIMAPClientHandler() async throws {
+        try await self.eventLoop.submit {
+            try self.pipeline.syncOperations.addHandler(IMAPClientHandler())
+        }.get()
+    }
+}

--- a/Tests/SwiftIMAPTests/IdleHandlerTests.swift
+++ b/Tests/SwiftIMAPTests/IdleHandlerTests.swift
@@ -10,9 +10,7 @@ import Testing
 struct IdleHandlerTests {
     @Test
     func testIdleStartedKeepsHandlerActiveUntilTaggedOK() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         var continuationRef: AsyncStream<IMAPServerEvent>.Continuation?
         _ = AsyncStream<IMAPServerEvent> { continuation in
@@ -62,9 +60,7 @@ struct IdleHandlerTests {
 
     @Test
     func testByeDuringIdleCompletesWithoutDoneOrTaggedOK() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         var continuationRef: AsyncStream<IMAPServerEvent>.Continuation?
         let stream = AsyncStream<IMAPServerEvent> { continuation in

--- a/Tests/SwiftIMAPTests/PlainAuthenticationTests.swift
+++ b/Tests/SwiftIMAPTests/PlainAuthenticationTests.swift
@@ -39,9 +39,7 @@ struct PlainAuthenticationTests {
 
     @Test
     func testHandlerSucceedsOnTaggedOK() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let promise = channel.eventLoop.makePromise(of: [Capability].self)
         var creds = channel.allocator.buffer(capacity: 10)
@@ -69,9 +67,7 @@ struct PlainAuthenticationTests {
 
     @Test
     func testHandlerFailsOnTaggedNO() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let promise = channel.eventLoop.makePromise(of: [Capability].self)
         var creds = channel.allocator.buffer(capacity: 10)

--- a/Tests/SwiftIMAPTests/SearchCommandTests.swift
+++ b/Tests/SwiftIMAPTests/SearchCommandTests.swift
@@ -16,8 +16,7 @@ struct SearchCommandTests {
 
     @Test
     func testIdentifierSetScopeIncludedInUIDSearch() async throws {
-        let channel = NIOAsyncTestingChannel()
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let ids = MessageIdentifierSet<UID>([UID(10), UID(20), UID(30)])
         let command = SearchCommand<UID>(identifierSet: ids, criteria: [SearchCriteria.unseen])
@@ -37,8 +36,7 @@ struct SearchCommandTests {
 
     @Test
     func testUIDSortWireFormatUsesSortCommand() async throws {
-        let channel = NIOAsyncTestingChannel()
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let ids = MessageIdentifierSet<UID>([UID(10), UID(20), UID(30)])
         let command = SearchCommand<UID>(
@@ -65,8 +63,7 @@ struct SearchCommandTests {
 
     @Test
     func testNoIdentifierSetSearchesEntireMailbox() async throws {
-        let channel = NIOAsyncTestingChannel()
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let command = SearchCommand<UID>(identifierSet: nil, criteria: [SearchCriteria.unseen])
         let tagged = command.toTaggedCommand(tag: "S002")
@@ -85,8 +82,7 @@ struct SearchCommandTests {
 
     @Test
     func testIdentifierSetScopeIncludedInSequenceNumberSearch() async throws {
-        let channel = NIOAsyncTestingChannel()
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let ids = MessageIdentifierSet<SequenceNumber>([SequenceNumber(1), SequenceNumber(2)])
         let command = SearchCommand<SequenceNumber>(identifierSet: ids, criteria: [SearchCriteria.unseen])
@@ -107,8 +103,7 @@ struct SearchCommandTests {
 
     @Test
     func testUIDExpungeUsesUIDCommandWireFormat() async throws {
-        let channel = NIOAsyncTestingChannel()
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let command = UIDExpungeCommand(identifierSet: UIDSet([UID(10), UID(20), UID(30)]))
         let tagged = command.toTaggedCommand(tag: "S004")

--- a/Tests/SwiftIMAPTests/UntaggedResponseBufferTests.swift
+++ b/Tests/SwiftIMAPTests/UntaggedResponseBufferTests.swift
@@ -9,9 +9,7 @@ import Testing
 struct UntaggedResponseBufferTests {
     @Test
     func testTracksBufferedByeAsTerminationSignal() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let buffer = UntaggedResponseBuffer()
         try await channel.pipeline.addHandler(buffer)

--- a/Tests/SwiftIMAPTests/WithinSearchTests.swift
+++ b/Tests/SwiftIMAPTests/WithinSearchTests.swift
@@ -10,9 +10,7 @@ import Testing
 struct WithinSearchTests {
     @Test
     func testYoungerSearchKeyWireFormat() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let command = SearchCommand<SwiftMail.UID>(criteria: [SearchCriteria.younger(seconds: 3600)])
         let tagged = command.toTaggedCommand(tag: "W001")
@@ -31,9 +29,7 @@ struct WithinSearchTests {
 
     @Test
     func testOlderSearchKeyWireFormat() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let command = SearchCommand<SwiftMail.UID>(criteria: [SearchCriteria.older(seconds: 86400)])
         let tagged = command.toTaggedCommand(tag: "W002")
@@ -52,9 +48,7 @@ struct WithinSearchTests {
 
     @Test
     func testWithinCriteriaWithExtendedSearch() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let command = ExtendedSearchCommand<SwiftMail.UID>(
             criteria: [SearchCriteria.younger(seconds: 600)],
@@ -77,9 +71,7 @@ struct WithinSearchTests {
 
     @Test
     func testCombinedWithinAndOtherCriteria() async throws {
-        let channel = NIOAsyncTestingChannel()
-
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         let command = SearchCommand<SwiftMail.UID>(
             criteria: [SearchCriteria.younger(seconds: 3600), SearchCriteria.unseen]

--- a/Tests/SwiftIMAPTests/XOAUTH2AuthenticationHandlerTests.swift
+++ b/Tests/SwiftIMAPTests/XOAUTH2AuthenticationHandlerTests.swift
@@ -341,8 +341,7 @@ struct XOAUTH2AuthenticationHandlerTests {
         expectsChallenge: Bool,
         failContinuationWrite: Bool = false
     ) async throws -> ChannelSetup {
-        let channel = NIOAsyncTestingChannel()
-        try await channel.pipeline.addHandler(IMAPClientHandler())
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
         if failContinuationWrite {
             try await channel.pipeline.addHandler(FailContinuationWriteHandler())


### PR DESCRIPTION
## Summary
- Replace the pinned `swift-nio-imap` merge revision with a normal semver dependency, `from: "0.3.0"`, now that the release ships the Android/Bionic libc-guard fix for NIOIMAPCore that the pin existed for.
- NIOIMAP 0.3.0 now declares `IMAPClientHandler` explicitly non-`Sendable` (`@available(*, unavailable) extension IMAPClientHandler: Sendable {}`), which conflicts with the local test-only `@retroactive @unchecked Sendable` shim. Replace the shim with [`IMAPTestingChannel.swift`](Tests/SwiftIMAPTests/IMAPTestingChannel.swift), which adds the handler via NIO's `syncOperations` path (the supported route for non-`Sendable` handlers), and update the ~30 call sites that previously added the handler through the async `pipeline.addHandler(_:)`.
- Drop the now-superfluous `file_length` swiftlint disable in `ExtendedSearchHandlerTests.swift`, which shrank below the threshold after the test simplification.

Closes #182.

## Test plan
- [x] `swift package resolve` — resolves `swift-nio-imap` at tag `0.3.0`
- [x] `swift test --filter SwiftIMAPTests` — 227 tests passed
- [x] `swift test` — 317 tests passed
- [x] `swiftlint lint` — 0 violations
- [x] `git diff --check` — no whitespace issues

🤖 Generated with [Claude Code](https://claude.com/claude-code)