### PR TITLE
Expose BODYSTRUCTURE octet count as MessagePart.size

### DIFF
--- a/Sources/SwiftMail/IMAP/Models/MessagePart+BodyStructure.swift
+++ b/Sources/SwiftMail/IMAP/Models/MessagePart+BodyStructure.swift
@@ -40,6 +40,9 @@ extension Array where Element == MessagePart {
         var filename = dispositionAndFilename.filename
         let disposition = dispositionAndFilename.disposition
         let contentId: String? = part.fields.id.map { String($0) }.flatMap { $0.isEmpty ? nil : $0 }
+        // BODYSTRUCTURE reports the body size in octets; NIOIMAP parses a
+        // missing/zero field as 0, which we surface as nil.
+        let size: Int? = part.fields.octetCount > 0 ? part.fields.octetCount : nil
 
         // message/rfc822: extract envelope metadata and derive a filename
         // from the subject when one isn't already set.
@@ -58,6 +61,7 @@ extension Array where Element == MessagePart {
             encoding: encoding?.isEmpty == true ? nil : encoding,
             filename: filename,
             contentId: contentId,
+            size: size,
             data: nil,
             embeddedMessageInfo: embeddedMessageInfo
         ))

--- a/Sources/SwiftMail/IMAP/Models/MessagePart.swift
+++ b/Sources/SwiftMail/IMAP/Models/MessagePart.swift
@@ -24,6 +24,9 @@ public struct MessagePart: Sendable {
     /// The content ID of the part (if any)
     public let contentId: String?
 
+    /// The size of the part body in octets, as reported by BODYSTRUCTURE (if any)
+    public let size: Int?
+
     /// The content data (if any)
     public var data: Data?
 
@@ -40,6 +43,7 @@ public struct MessagePart: Sendable {
     ///   - encoding: The content transfer encoding (e.g., "base64", "quoted-printable")
     ///   - filename: The filename (if any)
     ///   - contentId: The content ID
+    ///   - size: The body size in octets from BODYSTRUCTURE (optional)
     ///   - data: The content data (optional)
     ///   - embeddedMessageInfo: Envelope headers for message/rfc822 parts (optional)
     public init(
@@ -49,6 +53,7 @@ public struct MessagePart: Sendable {
         encoding: String? = nil,
         filename: String? = nil,
         contentId: String? = nil,
+        size: Int? = nil,
         data: Data? = nil,
         embeddedMessageInfo: MessageInfo? = nil
     ) {
@@ -58,6 +63,7 @@ public struct MessagePart: Sendable {
         self.encoding = encoding
         self.filename = filename
         self.contentId = contentId
+        self.size = size
         self.data = data
         self.embeddedMessageInfo = embeddedMessageInfo
     }
@@ -77,6 +83,7 @@ public struct MessagePart: Sendable {
         encoding: String? = nil,
         filename: String? = nil,
         contentId: String? = nil,
+        size: Int? = nil,
         data: Data? = nil,
         embeddedMessageInfo: MessageInfo? = nil
     ) {
@@ -86,6 +93,7 @@ public struct MessagePart: Sendable {
         self.encoding = encoding
         self.filename = filename
         self.contentId = contentId
+        self.size = size
         self.data = data
         self.embeddedMessageInfo = embeddedMessageInfo
     }
@@ -161,7 +169,7 @@ public struct MessagePart: Sendable {
 // MARK: - Codable Implementation
 extension MessagePart: Codable {
     private enum CodingKeys: String, CodingKey {
-        case section, contentType, disposition, encoding, filename, contentId, data, embeddedMessageInfo
+        case section, contentType, disposition, encoding, filename, contentId, size, data, embeddedMessageInfo
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -173,6 +181,7 @@ extension MessagePart: Codable {
         try container.encodeIfPresent(encoding, forKey: .encoding)
         try container.encodeIfPresent(filename, forKey: .filename)
         try container.encodeIfPresent(contentId, forKey: .contentId)
+        try container.encodeIfPresent(size, forKey: .size)
         try container.encodeIfPresent(data, forKey: .data)
         try container.encodeIfPresent(embeddedMessageInfo, forKey: .embeddedMessageInfo)
     }
@@ -186,6 +195,7 @@ extension MessagePart: Codable {
         encoding = try container.decodeIfPresent(String.self, forKey: .encoding)
         filename = try container.decodeIfPresent(String.self, forKey: .filename)
         contentId = try container.decodeIfPresent(String.self, forKey: .contentId)
+        size = try container.decodeIfPresent(Int.self, forKey: .size)
         data = try container.decodeIfPresent(Data.self, forKey: .data)
         embeddedMessageInfo = try container.decodeIfPresent(MessageInfo.self, forKey: .embeddedMessageInfo)
     }

--- a/Tests/SwiftIMAPTests/MessagePartSizeTests.swift
+++ b/Tests/SwiftIMAPTests/MessagePartSizeTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+@testable import SwiftMail
+import NIOIMAPCore
+import NIO
+
+/// Tests that BODYSTRUCTURE octet counts surface as MessagePart.size.
+@Suite(.serialized, .timeLimit(.minutes(1)))
+struct MessagePartSizeTests {
+
+    private func fields(octetCount: Int) -> BodyStructure.Fields {
+        BodyStructure.Fields(parameters: [:], id: nil, contentDescription: nil, encoding: nil, octetCount: octetCount)
+    }
+
+    @Test func singlepartCarriesOctetCountAsSize() {
+        let basic = BodyStructure.Singlepart(
+            kind: .basic(.init(topLevel: .application, sub: "pdf")),
+            fields: fields(octetCount: 123_456)
+        )
+        let parts = [MessagePart](.singlepart(basic))
+        #expect(parts.count == 1)
+        #expect(parts[0].size == 123_456)
+    }
+
+    @Test func zeroOctetCountYieldsNilSize() {
+        let text = BodyStructure.Singlepart.Text(mediaSubtype: "plain", lineCount: 10)
+        let part = BodyStructure.Singlepart(kind: .text(text), fields: fields(octetCount: 0))
+        let parts = [MessagePart](.singlepart(part))
+        #expect(parts.count == 1)
+        #expect(parts[0].size == nil)
+    }
+
+    @Test func multipartChildrenEachCarryTheirOwnSize() {
+        let text = BodyStructure.Singlepart.Text(mediaSubtype: "plain", lineCount: 5)
+        let child1 = BodyStructure.Singlepart(kind: .text(text), fields: fields(octetCount: 42))
+        let child2 = BodyStructure.Singlepart(
+            kind: .basic(.init(topLevel: .image, sub: "jpeg")),
+            fields: fields(octetCount: 9_000)
+        )
+        let multipart = BodyStructure.Multipart(
+            parts: [.singlepart(child1), .singlepart(child2)],
+            mediaSubtype: .mixed
+        )
+        let parts = [MessagePart](.multipart(multipart))
+        #expect(parts.count == 2)
+        #expect(parts[0].size == 42)
+        #expect(parts[1].size == 9_000)
+    }
+}


### PR DESCRIPTION
## What

BODYSTRUCTURE reports each body part's size in octets, but the value was dropped when building `MessagePart` from a parsed `BodyStructure`. This carries it through as a new optional property:

```swift
/// The size of the part body in octets, as reported by BODYSTRUCTURE (if any)
public let size: Int?
```

NIOIMAP parses a missing/zero field as `0`, which is surfaced as `nil`.

## Why

With part sizes available from the envelope/structure fetch alone, clients can show size labels and enforce download caps (e.g. skip auto-fetching a 40 MB scan for a thumbnail) without fetching any part bytes. We use this in a mail client that builds an attachment metadata index from BODYSTRUCTURE during sync.

## Changes

- `MessagePart`: new `size: Int?` property, threaded through both public initializers and the `Codable` implementation (encoded with `encodeIfPresent`, so existing archives decode fine).
- `MessagePart+BodyStructure`: read `fields.octetCount` when flattening singleparts; `> 0` becomes the size, otherwise `nil`.
- New `MessagePartSizeTests`: singlepart carries the octet count, zero yields `nil`, multipart children each carry their own size.

Note: the size is the *encoded* (transfer-encoding) octet count per RFC 3501 — for base64 parts roughly 4/3 of the decoded file size. Documented as "as reported by BODYSTRUCTURE" to keep that semantic.