### PR TITLE
PR #185 + CI/deadlock fixes: TLS floor, parser limits, and four hang root-causes

### DIFF
--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -89,14 +89,39 @@ jobs:
 
   build-linux:
     runs-on: ubuntu-latest
+    # Without a limit a hung test run occupies the runner for the 6-hour GitHub
+    # default — several did exactly that before the watchdog below existed.
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
       - name: Verify Swift version
         run: swift --version
       - name: Build (Linux)
         run: swift build --build-tests -v
+      # Same watchdog as build-macos, with gdb standing in for sample(1): a
+      # deadlocked test run must fail with thread backtraces in the log, not
+      # sit silently until the job timeout.
       - name: Test (Linux)
-        run: swift test -v --skip-build
+        run: |
+          swift test -v --skip-build &
+          TEST_PID=$!
+          (
+            sleep 360 >/dev/null 2>&1
+            echo "::error::Test run still running after 6 minutes - dumping thread backtraces"
+            for pid in $(pgrep -f 'swiftpm-testing|SwiftMailPackageTests'); do
+              echo "=== backtraces of PID $pid ($(ps -o comm= -p $pid)) ==="
+              sudo gdb -p "$pid" -batch -ex 'thread apply all bt' 2>&1 | tail -200 || true
+            done
+            pkill -9 -f 'swiftpm-testing|SwiftMailPackageTests' 2>/dev/null || true
+            kill -9 "$TEST_PID" 2>/dev/null || true
+          ) &
+          WATCHDOG_PID=$!
+          set +e
+          wait "$TEST_PID"
+          STATUS=$?
+          set -e
+          kill "$WATCHDOG_PID" 2>/dev/null || true
+          exit "$STATUS"
 
   build-windows:
     # Windows build + test. No vcpkg / system C libraries are needed: the only

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -49,6 +49,9 @@ jobs:
               echo "=== sample of PID $pid ($(ps -o comm= -p $pid)) ==="
               sample "$pid" 3 -file /dev/stdout || true
             done
+            # The helper processes are children of the driver but survive its death;
+            # kill them too so the step ends now instead of at the job timeout.
+            pkill -9 -f 'swiftpm-testing|SwiftMailPackageTests' 2>/dev/null || true
             kill -9 "$TEST_PID" 2>/dev/null || true
           ) &
           WATCHDOG_PID=$!

--- a/.github/workflows/swift.yml
+++ b/.github/workflows/swift.yml
@@ -15,32 +15,63 @@ jobs:
 
   build-macos:
     runs-on: macos-latest
-    timeout-minutes: 10
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
       # swift-testing 6.3.2 (shared by the test targets) has a swift-tools-version
-      # 6.2 manifest, which the runner's default Xcode (Swift 6.1.2) cannot
-      # resolve. Xcode 26.0 ships Swift 6.2 — same version already used by the
-      # iOS job, so it is known to be available on the runner.
-      - name: Select Xcode 26.0
+      # 6.2 manifest, so the selected Xcode must ship Swift 6.2+. `macos-latest`
+      # rotated to the macos-26 image (2026-07-15), whose stable Xcodes all
+      # qualify — track the newest one rather than pinning a version that the
+      # next image rotation strands without platform components.
+      - name: Select latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "26.0"
+          xcode-version: latest-stable
       - name: Verify Swift version
         run: swift --version
       - name: Build (macOS)
         run: swift build --build-tests -v
+      # The watchdog exists because a test-run deadlock surfaces here as a silent
+      # 10-minute stall followed by "cancelled" — no output, no stacks, nothing to
+      # debug with. If the run is still alive after the deadline it samples every
+      # test process so the log shows exactly which threads are stuck where, then
+      # fails the step honestly instead of letting the job timeout eat it.
       - name: Test (macOS)
-        run: swift test -v --skip-build
+        run: |
+          swift test -v --skip-build &
+          TEST_PID=$!
+          (
+            # /dev/null keeps the orphaned sleep from holding the step's output
+            # pipe open (the runner waits on that pipe) after a normal fast run.
+            sleep 360 >/dev/null 2>&1
+            echo "::error::Test run still running after 6 minutes - dumping thread samples"
+            for pid in $(pgrep -f 'swiftpm-testing|SwiftMailPackageTests'); do
+              echo "=== sample of PID $pid ($(ps -o comm= -p $pid)) ==="
+              sample "$pid" 3 -file /dev/stdout || true
+            done
+            kill -9 "$TEST_PID" 2>/dev/null || true
+          ) &
+          WATCHDOG_PID=$!
+          set +e
+          wait "$TEST_PID"
+          STATUS=$?
+          set -e
+          kill "$WATCHDOG_PID" 2>/dev/null || true
+          exit "$STATUS"
 
   build-ios:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v6
-      - name: Select Xcode 26.0
+      # latest-stable rather than a pin: the image's newest Xcode is the one
+      # whose platform components are preinstalled. The pinned 26.0 outlived its
+      # image — on macos-26 it has no iOS platform, and `-downloadPlatform` for
+      # it fails with "Unable to connect to simulator", so the build died with
+      # "iOS 26.0 is not installed" before compiling anything.
+      - name: Select latest stable Xcode
         uses: maxim-lobanov/setup-xcode@v1
         with:
-          xcode-version: "26.0"
+          xcode-version: latest-stable
       # Xcode 16+ ships platform SDKs as on-demand components, so a freshly
       # rotated `macos-latest` image can have the selected Xcode without the iOS
       # platform installed — `-destination 'generic/platform=iOS'` then resolves

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/IdleHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/IdleHandler.swift
@@ -56,14 +56,32 @@ final class IdleHandler: BaseIMAPCommandHandler<Void>, IMAPCommandHandler, @unch
         continuation.finish()
     }
 
+    /// - Note: `continuation.finish()` is the point of this override.
+    ///
+    ///   The tagged paths above finish the stream; the connection dying did not. A caller sitting
+    ///   in `for await event in stream` therefore waited forever once the transport went away —
+    ///   the stream had no more producer and no end. `AsyncStream` cannot know that on its own:
+    ///   an unfinished continuation is indistinguishable from a quiet mailbox.
+    ///
+    ///   This matters most for the case it was reported under: a parser-limit violation closes
+    ///   the channel (see ``IMAPResponseLimitGuard``), and without finishing here, "fail closed"
+    ///   would only be half true — socket shut, caller still hanging.
     override func channelInactive(context: ChannelHandlerContext) {
         recordCompletionReason(.channelInactive)
         super.channelInactive(context: context)
+        continuation.finish()
     }
 
+    /// - Note: Finishes the stream for the same reason as ``channelInactive(context:)``.
+    ///
+    ///   `super.errorCaught` fails the private promise, but nothing awaits it until a later DONE
+    ///   or checkpoint — so an error during IDLE used to leave the caller's stream open with no
+    ///   producer behind it. Finishing here ends the loop; the error itself still surfaces
+    ///   through the promise for whoever is waiting on it.
     override func errorCaught(context: ChannelHandlerContext, error: Error) {
         recordCompletionReason(.error)
         super.errorCaught(context: context, error: error)
+        continuation.finish()
     }
 
     private func recordCompletionReason(_ reason: CompletionReason) {

--- a/Sources/SwiftMail/IMAP/IMAPConnection+Connection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+Connection.swift
@@ -45,6 +45,7 @@ extension IMAPConnection {
     ) -> ClientBootstrap {
         let host = self.host
         let certificateVerificationPolicy = self.certificateVerificationPolicy
+        let minimumTLSVersion = self.minimumTLSVersion
         let duplexLogger = self.duplexLogger
         let responseBuffer = self.responseBuffer
         let responseBufferLimit = self.responseBufferLimit
@@ -55,18 +56,14 @@ extension IMAPConnection {
             .channelOption(ChannelOptions.tcpOption(.tcp_nodelay), value: 1)
             .channelInitializer { channel in
                 do {
-                    let parserOptions = ResponseParser.Options(
-                        bufferLimit: responseBufferLimit,
-                        messageAttributeLimit: parserLimits.messageAttributeLimit,
-                        bodySizeLimit: parserLimits.bodySizeLimit,
-                        literalSizeLimit: parserLimits.literalSizeLimit
-                    )
+                    let parserOptions = parserLimits.makeParserOptions(bufferLimit: responseBufferLimit)
 
                     if case .implicitTLS = initialTLSMode {
                         let sslHandler = try Self.makeTLSHandler(
                             for: channel,
                             host: host,
-                            certificateVerificationPolicy: certificateVerificationPolicy
+                            certificateVerificationPolicy: certificateVerificationPolicy,
+                            minimumTLSVersion: minimumTLSVersion
                         )
                         try channel.pipeline.syncOperations.addHandler(sslHandler)
                     }

--- a/Sources/SwiftMail/IMAP/IMAPConnection+Connection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+Connection.swift
@@ -50,6 +50,8 @@ extension IMAPConnection {
         let responseBuffer = self.responseBuffer
         let responseBufferLimit = self.responseBufferLimit
         let parserLimits = self.parserLimits
+        let logger = self.logger
+        let connectionContext = self.connectionContext
 
         return ClientBootstrap(group: group)
             .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
@@ -70,6 +72,16 @@ extension IMAPConnection {
 
                     try channel.pipeline.syncOperations.addHandlers([
                         IMAPClientHandler(parserOptions: parserOptions),
+                        // Directly behind the decoder: it sees every response and every
+                        // parser-limit error before any command handler does. The parser bounds
+                        // a single body section; this bounds the whole FETCH response, which is
+                        // what `bodySizeLimit` promises — and it closes the connection on a
+                        // violation instead of letting a rejected response sit in the decoder.
+                        IMAPResponseLimitGuard(
+                            bodySizeLimit: parserLimits.bodySizeLimit,
+                            logger: logger,
+                            connectionContext: connectionContext
+                        ),
                         duplexLogger,
                         greetingHandler,
                         responseBuffer

--- a/Sources/SwiftMail/IMAP/IMAPConnection+Connection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+Connection.swift
@@ -48,6 +48,7 @@ extension IMAPConnection {
         let duplexLogger = self.duplexLogger
         let responseBuffer = self.responseBuffer
         let responseBufferLimit = self.responseBufferLimit
+        let parserLimits = self.parserLimits
 
         return ClientBootstrap(group: group)
             .channelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
@@ -56,9 +57,9 @@ extension IMAPConnection {
                 do {
                     let parserOptions = ResponseParser.Options(
                         bufferLimit: responseBufferLimit,
-                        messageAttributeLimit: .max,
-                        bodySizeLimit: .max,
-                        literalSizeLimit: IMAPDefaults.literalSizeLimit
+                        messageAttributeLimit: parserLimits.messageAttributeLimit,
+                        bodySizeLimit: parserLimits.bodySizeLimit,
+                        literalSizeLimit: parserLimits.literalSizeLimit
                     )
 
                     if case .implicitTLS = initialTLSMode {

--- a/Sources/SwiftMail/IMAP/IMAPConnection+PipelinedFetch.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+PipelinedFetch.swift
@@ -71,19 +71,27 @@ extension IMAPConnection {
             scheduledTimeout: scheduledTimeout
         )
 
-        let results = await collectPipelinedFetchResults(
-            tagToRequest: registered.tagToRequest,
-            futures: registered.futures
-        )
+        // `defer`, because a limit violation now throws out of the collection step and the
+        // cleanup has to happen either way — otherwise a hostile server could leave the
+        // dispatcher installed and `hasActiveHandler` set, which would wedge the next command.
+        defer {
+            scheduledTimeout.cancel()
+            responseBuffer.hasActiveHandler = false
+            duplexLogger.flushInboundBuffer()
+        }
 
-        scheduledTimeout.cancel()
-        responseBuffer.hasActiveHandler = false
-        duplexLogger.flushInboundBuffer()
-
-        // Remove dispatcher — may already be removed if channelInactive fired
-        try? await channel.pipeline.removeHandler(dispatcher)
-
-        return results
+        do {
+            let results = try await collectPipelinedFetchResults(
+                tagToRequest: registered.tagToRequest,
+                futures: registered.futures
+            )
+            // Remove dispatcher — may already be removed if channelInactive fired
+            try? await channel.pipeline.removeHandler(dispatcher)
+            return results
+        } catch {
+            try? await channel.pipeline.removeHandler(dispatcher)
+            throw error
+        }
     }
 
     private func preparePipelinedFetchChannel() async throws -> Channel {
@@ -173,11 +181,26 @@ extension IMAPConnection {
         }
     }
 
+    /// Collects the per-request results, tolerating individual failures — **except** limit
+    /// violations, which are rethrown.
+    ///
+    /// ## Why limit violations are not tolerated
+    /// Swallowing a failed request and moving on is the point of pipelining: one bad UID must not
+    /// sink the batch. But a parser-limit violation is not a property of one request — it means
+    /// **the peer sent more than we allow**, and it poisons the shared decoder. Reported as an
+    /// empty success, it looked to the caller exactly like "this message has no such section",
+    /// and the connection stayed in use with a decoder that would raise the same error on the
+    /// next read. A guard whose violation is indistinguishable from an ordinary empty result is
+    /// not a guard.
+    ///
+    /// The channel itself is closed by ``IMAPResponseLimitGuard`` when the violation happens;
+    /// this makes sure the caller is told rather than handed an empty array.
     private func collectPipelinedFetchResults(
         tagToRequest: [TaggedFetchRequest],
         futures: [EventLoopFuture<Data>]
-    ) async -> [PipelinedFetchResult] {
+    ) async throws -> [PipelinedFetchResult] {
         var results: [PipelinedFetchResult] = []
+        var limitViolation: Error?
 
         for (index, request) in tagToRequest.enumerated() {
             do {
@@ -186,10 +209,20 @@ extension IMAPConnection {
             } catch {
                 let uidValue = request.uid.value
                 let sectionDescription = request.section.description
-                logger.debug("Pipelined fetch failed for UID \(uidValue) section \(sectionDescription): \(error)")
+                if IMAPResponseLimitGuard.isLimitViolation(error) {
+                    // Remember the first one, but keep draining the remaining futures: leaving
+                    // them unawaited would trip NIO's leaked-promise check.
+                    let message = "\(connectionContext) Pipelined fetch hit a parser limit on UID "
+                        + "\(uidValue) section \(sectionDescription): \(error)"
+                    logger.warning("\(message)")
+                    if limitViolation == nil { limitViolation = error }
+                } else {
+                    logger.debug("Pipelined fetch failed for UID \(uidValue) section \(sectionDescription): \(error)")
+                }
             }
         }
 
+        if let limitViolation { throw limitViolation }
         return results
     }
 }

--- a/Sources/SwiftMail/IMAP/IMAPConnection+PipelinedFetch.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+PipelinedFetch.swift
@@ -71,10 +71,12 @@ extension IMAPConnection {
             scheduledTimeout: scheduledTimeout
         )
 
-        // `defer`, because a limit violation now throws out of the collection step and the
-        // cleanup has to happen either way — otherwise a hostile server could leave the
-        // dispatcher installed and `hasActiveHandler` set, which would wedge the next command.
-        defer {
+        // Runs on both paths, because a limit violation now throws out of the collection step —
+        // otherwise a hostile server could leave the dispatcher installed and `hasActiveHandler`
+        // set, which would wedge the next command. Ordering matters: the response buffer has to
+        // resume buffering *before* the dispatcher is removed, or an unsolicited response
+        // (BYE, EXISTS) arriving during the removal await is neither dispatched nor buffered.
+        func restoreChannelState() {
             scheduledTimeout.cancel()
             responseBuffer.hasActiveHandler = false
             duplexLogger.flushInboundBuffer()
@@ -85,10 +87,12 @@ extension IMAPConnection {
                 tagToRequest: registered.tagToRequest,
                 futures: registered.futures
             )
+            restoreChannelState()
             // Remove dispatcher — may already be removed if channelInactive fired
             try? await channel.pipeline.removeHandler(dispatcher)
             return results
         } catch {
+            restoreChannelState()
             try? await channel.pipeline.removeHandler(dispatcher)
             throw error
         }

--- a/Sources/SwiftMail/IMAP/IMAPConnection+TLS.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+TLS.swift
@@ -6,8 +6,8 @@ import NIOSSL
 
 extension IMAPConnection {
     /// - Note: `minimumTLSVersion` has **no default on purpose.** It used to default to
-    ///   `.tlsv1_2`, and the implicit-TLS call site simply omitted it — so a caller asking for
-    ///   `.tlsv1_3` on port 993 silently got a TLS 1.2 floor. A default here makes forgetting the
+    ///   `.tlsv12`, and the implicit-TLS call site simply omitted it — so a caller asking for
+    ///   `.tlsv13` on port 993 silently got a TLS 1.2 floor. A default here makes forgetting the
     ///   argument indistinguishable from choosing a value, and the compiler cannot help. Every
     ///   call site now has to say what it means.
     static func makeTLSHandler(

--- a/Sources/SwiftMail/IMAP/IMAPConnection+TLS.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+TLS.swift
@@ -8,10 +8,12 @@ extension IMAPConnection {
     static func makeTLSHandler(
         for channel: Channel,
         host: String,
-        certificateVerificationPolicy: MailCertificateVerificationPolicy
+        certificateVerificationPolicy: MailCertificateVerificationPolicy,
+        minimumTLSVersion: MailTLSMinimumVersion = .tlsv1_2
     ) throws -> NIOSSLClientHandler {
         let configuration = MailTLSConfiguration.makeClientConfiguration(
-            certificateVerificationPolicy: certificateVerificationPolicy
+            certificateVerificationPolicy: certificateVerificationPolicy,
+            minimumTLSVersion: minimumTLSVersion
         )
         let context = try NIOSSLContext(configuration: configuration)
         let serverHostname = MailTLSConfiguration.serverHostnameForTLSHandler(host: host)
@@ -61,11 +63,13 @@ extension IMAPConnection {
 
         let host = self.host
         let certificateVerificationPolicy = self.certificateVerificationPolicy
+        let minimumTLSVersion = self.minimumTLSVersion
         try await channel.eventLoop.submit {
             let sslHandler = try Self.makeTLSHandler(
                 for: channel,
                 host: host,
-                certificateVerificationPolicy: certificateVerificationPolicy
+                certificateVerificationPolicy: certificateVerificationPolicy,
+                minimumTLSVersion: minimumTLSVersion
             )
             try channel.pipeline.syncOperations.addHandler(sslHandler, position: .first)
         }.get()

--- a/Sources/SwiftMail/IMAP/IMAPConnection+TLS.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+TLS.swift
@@ -5,11 +5,16 @@ import NIO
 import NIOSSL
 
 extension IMAPConnection {
+    /// - Note: `minimumTLSVersion` has **no default on purpose.** It used to default to
+    ///   `.tlsv1_2`, and the implicit-TLS call site simply omitted it — so a caller asking for
+    ///   `.tlsv1_3` on port 993 silently got a TLS 1.2 floor. A default here makes forgetting the
+    ///   argument indistinguishable from choosing a value, and the compiler cannot help. Every
+    ///   call site now has to say what it means.
     static func makeTLSHandler(
         for channel: Channel,
         host: String,
         certificateVerificationPolicy: MailCertificateVerificationPolicy,
-        minimumTLSVersion: MailTLSMinimumVersion = .tlsv1_2
+        minimumTLSVersion: MailTLSMinimumVersion
     ) throws -> NIOSSLClientHandler {
         let configuration = MailTLSConfiguration.makeClientConfiguration(
             certificateVerificationPolicy: certificateVerificationPolicy,

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -18,6 +18,7 @@ final class IMAPConnection {
     let port: Int
     let transportSecurity: MailTransportSecurity
     let certificateVerificationPolicy: MailCertificateVerificationPolicy
+    let minimumTLSVersion: MailTLSMinimumVersion
     let responseBufferLimit: Int
     let group: EventLoopGroup
     let connectionID: String
@@ -42,6 +43,7 @@ final class IMAPConnection {
         port: Int,
         transportSecurity: MailTransportSecurity = .automatic,
         certificateVerificationPolicy: MailCertificateVerificationPolicy = .fullVerification,
+        minimumTLSVersion: MailTLSMinimumVersion = .tlsv1_2,
         group: EventLoopGroup,
         loggerLabel: String,
         outboundLabel: String,
@@ -54,6 +56,7 @@ final class IMAPConnection {
         self.port = port
         self.transportSecurity = transportSecurity
         self.certificateVerificationPolicy = certificateVerificationPolicy
+        self.minimumTLSVersion = minimumTLSVersion
         self.responseBufferLimit = responseBufferLimit
         self.group = group
         self.connectionID = connectionID

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -39,12 +39,19 @@ final class IMAPConnection {
     let logger: Logging.Logger
     let duplexLogger: IMAPLogger
 
+    /// - Note: `minimumTLSVersion` and `parserLimits` deliberately have **no defaults.**
+    ///   They used to, and `makeIdleConnection`/`makeNamedConnection` simply left them out — so
+    ///   a server configured with a TLS 1.3 floor and 64 MiB parser limits spawned IDLE and named
+    ///   connections with a TLS 1.2 floor and *unbounded* limits, while `IMAPServer`'s
+    ///   documentation claimed the policy governed every transport. A default turns "forgot to
+    ///   pass the security policy" into "chose the lax one", and neither the compiler nor a
+    ///   reviewer can see the difference. Without defaults, omitting one is a build error.
     init(
         host: String,
         port: Int,
         transportSecurity: MailTransportSecurity = .automatic,
         certificateVerificationPolicy: MailCertificateVerificationPolicy = .fullVerification,
-        minimumTLSVersion: MailTLSMinimumVersion = .tlsv1_2,
+        minimumTLSVersion: MailTLSMinimumVersion,
         group: EventLoopGroup,
         loggerLabel: String,
         outboundLabel: String,
@@ -52,7 +59,7 @@ final class IMAPConnection {
         connectionID: String,
         connectionRole: String,
         responseBufferLimit: Int = IMAPServer.defaultResponseBufferLimit,
-        parserLimits: IMAPParserLimits = .default
+        parserLimits: IMAPParserLimits
     ) {
         self.host = host
         self.port = port
@@ -91,6 +98,11 @@ final class IMAPConnection {
         )
     }
 
+    /// Legacy convenience initializer taking `useTLS` instead of a `MailTransportSecurity`.
+    ///
+    /// Security policy is explicit here for the same reason the designated initializer has no
+    /// defaults: this call site was invisible to a grep for `IMAPConnection(` and only surfaced
+    /// once the compiler demanded the arguments.
     convenience init(
         host: String,
         port: Int,
@@ -101,20 +113,24 @@ final class IMAPConnection {
         inboundLabel: String,
         connectionID: String,
         connectionRole: String,
-        responseBufferLimit: Int = IMAPServer.defaultResponseBufferLimit
+        responseBufferLimit: Int = IMAPServer.defaultResponseBufferLimit,
+        minimumTLSVersion: MailTLSMinimumVersion = .tlsv1_2,
+        parserLimits: IMAPParserLimits = .default
     ) {
         self.init(
             host: host,
             port: port,
             transportSecurity: Self.resolveLegacyTransportSecurity(port: port, useTLS: useTLS),
             certificateVerificationPolicy: .fullVerification,
+            minimumTLSVersion: minimumTLSVersion,
             group: group,
             loggerLabel: loggerLabel,
             outboundLabel: outboundLabel,
             inboundLabel: inboundLabel,
             connectionID: connectionID,
             connectionRole: connectionRole,
-            responseBufferLimit: responseBufferLimit
+            responseBufferLimit: responseBufferLimit,
+            parserLimits: parserLimits
         )
     }
 

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -20,6 +20,7 @@ final class IMAPConnection {
     let certificateVerificationPolicy: MailCertificateVerificationPolicy
     let minimumTLSVersion: MailTLSMinimumVersion
     let responseBufferLimit: Int
+    let parserLimits: IMAPParserLimits
     let group: EventLoopGroup
     let connectionID: String
     let connectionRole: String
@@ -50,7 +51,8 @@ final class IMAPConnection {
         inboundLabel: String,
         connectionID: String,
         connectionRole: String,
-        responseBufferLimit: Int = IMAPServer.defaultResponseBufferLimit
+        responseBufferLimit: Int = IMAPServer.defaultResponseBufferLimit,
+        parserLimits: IMAPParserLimits = .default
     ) {
         self.host = host
         self.port = port
@@ -58,6 +60,7 @@ final class IMAPConnection {
         self.certificateVerificationPolicy = certificateVerificationPolicy
         self.minimumTLSVersion = minimumTLSVersion
         self.responseBufferLimit = responseBufferLimit
+        self.parserLimits = parserLimits
         self.group = group
         self.connectionID = connectionID
         self.connectionRole = connectionRole

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -114,7 +114,7 @@ final class IMAPConnection {
         connectionID: String,
         connectionRole: String,
         responseBufferLimit: Int = IMAPServer.defaultResponseBufferLimit,
-        minimumTLSVersion: MailTLSMinimumVersion = .tlsv1_2,
+        minimumTLSVersion: MailTLSMinimumVersion = .tlsv12,
         parserLimits: IMAPParserLimits = .default
     ) {
         self.init(

--- a/Sources/SwiftMail/IMAP/IMAPParserLimits.swift
+++ b/Sources/SwiftMail/IMAP/IMAPParserLimits.swift
@@ -39,7 +39,23 @@ public struct IMAPParserLimits: Sendable, Equatable {
     ///
     /// Message bodies are bounded by ``bodySizeLimit`` instead, so this can stay small.
     /// Defaults to `NIOIMAPCore.IMAPDefaults.literalSizeLimit` (4 KB).
+    ///
+    /// - Important: **Cannot exceed 8 KiB**, and the initializer rejects larger values rather
+    ///   than accept a limit it cannot keep. `IMAPClientHandler` constructs its
+    ///   `NIOSingleStepByteToMessageProcessor` with `maximumBufferSize:
+    ///   IMAPDefaults.lineLengthLimit` (8,192 bytes), hardcoded and independent of these
+    ///   options. A larger literal therefore parses only when the network happens to deliver it
+    ///   in few enough reads; if fragmentation leaves more than 8 KiB buffered before the
+    ///   literal completes, it fails with `PayloadTooLargeError` — below every configured limit.
+    ///   A configuration whose behaviour depends on packet boundaries is not a limit, it is a
+    ///   coin toss, so ``maximumSupportedLiteralSizeLimit`` is enforced up front.
     public var literalSizeLimit: Int
+
+    /// The largest value ``literalSizeLimit`` can take: `IMAPDefaults.lineLengthLimit` (8 KiB).
+    ///
+    /// Raising it further needs a configurable `maximumBufferSize` in `IMAPClientHandler`, which
+    /// the pinned NIOIMAP does not offer.
+    public static let maximumSupportedLiteralSizeLimit = IMAPDefaults.lineLengthLimit
 
     /// SwiftMail's previous behaviour: bodies and attribute counts unbounded.
     public static let `default` = IMAPParserLimits()
@@ -52,6 +68,15 @@ public struct IMAPParserLimits: Sendable, Equatable {
         precondition(bodySizeLimit > 0, "bodySizeLimit must be greater than 0")
         precondition(messageAttributeLimit > 0, "messageAttributeLimit must be greater than 0")
         precondition(literalSizeLimit > 0, "literalSizeLimit must be greater than 0")
+        precondition(
+            literalSizeLimit <= Self.maximumSupportedLiteralSizeLimit,
+            """
+            literalSizeLimit must not exceed \(Self.maximumSupportedLiteralSizeLimit) bytes: \
+            IMAPClientHandler caps its decoder buffer at IMAPDefaults.lineLengthLimit, so a \
+            larger literal only parses when the network happens to deliver it in few enough \
+            reads. Accepting the value would promise a bound that depends on packet boundaries.
+            """
+        )
         self.bodySizeLimit = bodySizeLimit
         self.messageAttributeLimit = messageAttributeLimit
         self.literalSizeLimit = literalSizeLimit

--- a/Sources/SwiftMail/IMAP/IMAPParserLimits.swift
+++ b/Sources/SwiftMail/IMAP/IMAPParserLimits.swift
@@ -56,4 +56,37 @@ public struct IMAPParserLimits: Sendable, Equatable {
         self.messageAttributeLimit = messageAttributeLimit
         self.literalSizeLimit = literalSizeLimit
     }
+
+    /// Translates these limits into `ResponseParser.Options`.
+    ///
+    /// ## Why this is a method and not four call sites
+    /// Because the translation is not the identity, and every place that spelled it out by hand
+    /// was a place it could drift. It already had: only the primary connection ever received
+    /// these limits at all.
+    ///
+    /// ## Why the `+ 1`
+    /// These properties are documented as *maxima* — a body of exactly `bodySizeLimit` is legal.
+    /// The parser, however, enforces strict inequalities:
+    ///
+    /// ```swift
+    /// guard size < self.bodySizeLimit else { throw ExceededMaximumBodySizeError(…) }
+    /// guard attributeCount < self.messageAttributeLimit else { throw … }
+    /// ```
+    ///
+    /// So passing the value through unchanged makes the effective maximum one *less* than the
+    /// documented one: `bodySizeLimit: 64 * 1024 * 1024` rejects a message of exactly 64 MiB, and
+    /// `messageAttributeLimit: 1` rejects a single-attribute FETCH — the attribute itself parses,
+    /// then the closing `)` runs the same guard with the count already incremented.
+    ///
+    /// Rather than redefine the public contract as an exclusive bound (surprising: nobody reads
+    /// "maximum" as "one less than this"), the conversion adds one. Saturating, because the
+    /// defaults are `.max` and overflow would trap — and there `.max` already means unbounded.
+    func makeParserOptions(bufferLimit: Int) -> ResponseParser.Options {
+        ResponseParser.Options(
+            bufferLimit: bufferLimit,
+            messageAttributeLimit: messageAttributeLimit == .max ? .max : messageAttributeLimit + 1,
+            bodySizeLimit: bodySizeLimit == .max ? .max : bodySizeLimit + 1,
+            literalSizeLimit: literalSizeLimit
+        )
+    }
 }

--- a/Sources/SwiftMail/IMAP/IMAPParserLimits.swift
+++ b/Sources/SwiftMail/IMAP/IMAPParserLimits.swift
@@ -1,0 +1,59 @@
+import NIOIMAPCore
+
+/// Bounds the IMAP response parser enforces against a malicious or malfunctioning server.
+///
+/// A server controls both the length prefixes and the number of attributes it sends. Without
+/// bounds, a hostile or broken server can force unbounded allocation from a single response —
+/// the same class of issue that produced advisories in other IMAP clients, for example Ruby's
+/// net-imap (GHSA-j3g3-5qv5-52mj, unbounded literal size) and mutt (CVE-2021-3657).
+///
+/// The defaults preserve SwiftMail's existing behaviour, so adopting this type changes nothing
+/// until a caller opts into tighter bounds:
+///
+/// ```swift
+/// let server = IMAPServer(
+///     host: "imap.example.com",
+///     port: 993,
+///     parserLimits: IMAPParserLimits(
+///         bodySizeLimit: 64 * 1024 * 1024,  // refuse absurd single messages
+///         messageAttributeLimit: 1024
+///     )
+/// )
+/// ```
+///
+/// - Note: ``IMAPServer/defaultResponseBufferLimit`` bounds the parser's *working buffer*.
+///   These limits bound what a single response may *declare*, which is a separate concern.
+public struct IMAPParserLimits: Sendable, Equatable {
+
+    /// Maximum size of message body data in a single response.
+    ///
+    /// Defaults to `UInt64.max` (unbounded), matching SwiftMail's previous behaviour.
+    public var bodySizeLimit: UInt64
+
+    /// Maximum number of attributes (`BODY`, `FLAGS`, `ENVELOPE`, …) in one FETCH response.
+    ///
+    /// Defaults to `Int.max` (unbounded), matching SwiftMail's previous behaviour.
+    public var messageAttributeLimit: Int
+
+    /// Maximum size of a single protocol literal — mailbox names and similar.
+    ///
+    /// Message bodies are bounded by ``bodySizeLimit`` instead, so this can stay small.
+    /// Defaults to `NIOIMAPCore.IMAPDefaults.literalSizeLimit` (4 KB).
+    public var literalSizeLimit: Int
+
+    /// SwiftMail's previous behaviour: bodies and attribute counts unbounded.
+    public static let `default` = IMAPParserLimits()
+
+    public init(
+        bodySizeLimit: UInt64 = .max,
+        messageAttributeLimit: Int = .max,
+        literalSizeLimit: Int = IMAPDefaults.literalSizeLimit
+    ) {
+        precondition(bodySizeLimit > 0, "bodySizeLimit must be greater than 0")
+        precondition(messageAttributeLimit > 0, "messageAttributeLimit must be greater than 0")
+        precondition(literalSizeLimit > 0, "literalSizeLimit must be greater than 0")
+        self.bodySizeLimit = bodySizeLimit
+        self.messageAttributeLimit = messageAttributeLimit
+        self.literalSizeLimit = literalSizeLimit
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAPParserLimits.swift
+++ b/Sources/SwiftMail/IMAP/IMAPParserLimits.swift
@@ -54,7 +54,7 @@ public struct IMAPParserLimits: Sendable, Equatable {
     /// The largest value ``literalSizeLimit`` can take: `IMAPDefaults.lineLengthLimit` (8 KiB).
     ///
     /// Raising it further needs a configurable `maximumBufferSize` in `IMAPClientHandler`, which
-    /// the pinned NIOIMAP does not offer.
+    /// NIOIMAP does not offer as of 0.3.0.
     public static let maximumSupportedLiteralSizeLimit = IMAPDefaults.lineLengthLimit
 
     /// SwiftMail's previous behaviour: bodies and attribute counts unbounded.

--- a/Sources/SwiftMail/IMAP/IMAPResponseLimitGuard.swift
+++ b/Sources/SwiftMail/IMAP/IMAPResponseLimitGuard.swift
@@ -108,9 +108,19 @@ final class IMAPResponseLimitGuard: ChannelInboundHandler {
     /// Deliberately narrow: only errors that mean *„this peer sent more than we allow"*. A
     /// connection is not torn down for anything else — `errorCaught` sees unrelated failures too,
     /// and closing on those would change behaviour far outside this feature.
+    ///
+    /// - Important: `ResponseDecoder` wraps **every** parser error in `IMAPDecoderError` before
+    ///   `IMAPClientHandler` fires it down the pipeline, so the wrapper has to be unwrapped
+    ///   first — matching only the bare types means never matching anything the real decoder
+    ///   produces. (The bare types are still matched for the guard's own
+    ///   `ExceededResponseBodySizeError`, which it throws unwrapped.)
     static func isLimitViolation(_ error: Error) -> Bool {
-        error is ExceededMaximumBodySizeError
+        if let decoderError = error as? IMAPDecoderError {
+            return isLimitViolation(decoderError.parserError)
+        }
+        return error is ExceededMaximumBodySizeError
             || error is ExceededMaximumMessageAttributesError
+            || error is ExceededLiteralSizeLimitError
             || error is ExceededResponseBodySizeError
     }
 }

--- a/Sources/SwiftMail/IMAP/IMAPResponseLimitGuard.swift
+++ b/Sources/SwiftMail/IMAP/IMAPResponseLimitGuard.swift
@@ -1,0 +1,134 @@
+import Foundation
+@preconcurrency import NIOIMAP
+import NIOIMAPCore
+import NIO
+import Logging
+
+/// Enforces ``IMAPParserLimits/bodySizeLimit`` across a whole FETCH response, and makes every
+/// parser-limit violation fail closed.
+///
+/// ## Why this exists at the pipeline level
+/// `ResponseParser` applies `bodySizeLimit` to **each streaming body section on its own** and
+/// keeps no response-wide total. SwiftMail's own consumers, meanwhile, accumulate: both
+/// `FetchPartHandler` and `PipelinedFetchPartHandler` append every streaming attribute into a
+/// single `Data` until the FETCH finishes. So with `bodySizeLimit: 64 MiB` a server could return
+/// any number of 50 MiB sections in one FETCH — each one passing the check, all of them landing
+/// in one buffer. The documented memory guard was bypassable.
+///
+/// The total could be counted in those two handlers, but then it would hold only for the two
+/// that exist today, and only for as long as nobody adds a third. The limit is a **transport**
+/// promise — `IMAPServer` documents it as server-level policy — so it is enforced on the
+/// transport, once, for every consumer including future ones.
+///
+/// ## Why it also closes the connection
+/// Because a limit that is reported but not acted on is not a limit. Parser-limit errors
+/// previously did not fail closed: during IDLE, `IdleHandler.errorCaught` only failed a private
+/// promise that nothing was awaiting until a later DONE, while the decoder kept the rejected
+/// bytes and appended every subsequent read to them before raising the same error again — the
+/// post-decode buffer cap is skipped when decoding throws. A peer could keep growing memory
+/// while the caller's `AsyncStream` sat there waiting. The guard therefore closes the channel on
+/// any limit violation: the connection has already proven it is hostile or broken, and the one
+/// thing that must not happen is to keep reading from it.
+final class IMAPResponseLimitGuard: ChannelInboundHandler {
+    typealias InboundIn = Response
+    typealias InboundOut = Response
+
+    /// The aggregate ceiling for one FETCH response. `nil` = unbounded (`.max`), the default.
+    private let bodySizeLimit: UInt64?
+
+    /// Bytes declared by streaming sections of the FETCH response currently being parsed.
+    private var accumulated: UInt64 = 0
+
+    private let logger: Logging.Logger
+    private let connectionContext: String
+
+    init(bodySizeLimit: UInt64, logger: Logging.Logger, connectionContext: String) {
+        self.bodySizeLimit = bodySizeLimit == .max ? nil : bodySizeLimit
+        self.logger = logger
+        self.connectionContext = connectionContext
+    }
+
+    func channelRead(context: ChannelHandlerContext, data: NIOAny) {
+        let response = unwrapInboundIn(data)
+
+        if let bodySizeLimit, case .fetch(let fetch) = response {
+            switch fetch {
+                case .start, .startUID:
+                    // A new message's FETCH begins — the total is per response, not per session.
+                    accumulated = 0
+
+                case .streamingBegin(_, let byteCount):
+                    // `byteCount` is what the server *declares*, which is exactly what has to be
+                    // bounded: acting on the declaration is the whole point of a limit. The
+                    // bytes themselves arrive afterwards, and by then the allocation is decided.
+                    accumulated += UInt64(max(0, byteCount))
+                    if accumulated > bodySizeLimit {
+                        fail(
+                            context: context,
+                            error: ExceededResponseBodySizeError(
+                                accumulatedCount: accumulated,
+                                maximumCount: bodySizeLimit
+                            )
+                        )
+                        return
+                    }
+
+                case .finish:
+                    accumulated = 0
+
+                default:
+                    break
+            }
+        }
+
+        context.fireChannelRead(wrapInboundOut(response))
+    }
+
+    /// Parser-limit errors from the decoder pass through here on their way up the pipeline.
+    ///
+    /// They are forwarded — the command handlers still need to fail their promises — and *then*
+    /// the channel is closed. Without the close, the decoder keeps the rejected bytes and every
+    /// further read is appended to them.
+    func errorCaught(context: ChannelHandlerContext, error: Error) {
+        guard Self.isLimitViolation(error) else {
+            context.fireErrorCaught(error)
+            return
+        }
+        fail(context: context, error: error)
+    }
+
+    private func fail(context: ChannelHandlerContext, error: Error) {
+        logger.warning("\(connectionContext) Parser limit exceeded, closing connection: \(error)")
+        context.fireErrorCaught(error)
+        context.close(promise: nil)
+    }
+
+    /// Is this one of the errors our limits produce?
+    ///
+    /// Deliberately narrow: only errors that mean *„this peer sent more than we allow"*. A
+    /// connection is not torn down for anything else — `errorCaught` sees unrelated failures too,
+    /// and closing on those would change behaviour far outside this feature.
+    static func isLimitViolation(_ error: Error) -> Bool {
+        error is ExceededMaximumBodySizeError
+            || error is ExceededMaximumMessageAttributesError
+            || error is ExceededResponseBodySizeError
+    }
+}
+
+/// The whole FETCH response declared more body data than ``IMAPParserLimits/bodySizeLimit``.
+///
+/// Distinct from NIOIMAPCore's `ExceededMaximumBodySizeError`, which reports a *single* section
+/// exceeding the limit. This one reports the total across the response — the case the parser
+/// cannot see, because it never accumulates.
+public struct ExceededResponseBodySizeError: Error, Equatable, CustomStringConvertible {
+    /// Bytes declared so far by streaming sections of this FETCH response.
+    public let accumulatedCount: UInt64
+
+    /// The configured ``IMAPParserLimits/bodySizeLimit``.
+    public let maximumCount: UInt64
+
+    public var description: String {
+        "FETCH response declared \(accumulatedCount) bytes of body data across its sections, "
+            + "exceeding the configured limit of \(maximumCount)"
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAPServer+Connection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Connection.swift
@@ -246,13 +246,15 @@ extension IMAPServer {
             port: port,
             transportSecurity: transportSecurity,
             certificateVerificationPolicy: certificateVerificationPolicy,
+            minimumTLSVersion: minimumTLSVersion,
             group: group,
             loggerLabel: loggerLabel,
             outboundLabel: outboundLabel,
             inboundLabel: inboundLabel,
             connectionID: shortID,
             connectionRole: "idle:\(sanitizedMailbox)",
-            responseBufferLimit: responseBufferLimit
+            responseBufferLimit: responseBufferLimit,
+            parserLimits: parserLimits
         )
     }
 
@@ -270,13 +272,15 @@ extension IMAPServer {
             port: port,
             transportSecurity: transportSecurity,
             certificateVerificationPolicy: certificateVerificationPolicy,
+            minimumTLSVersion: minimumTLSVersion,
             group: group,
             loggerLabel: loggerLabel,
             outboundLabel: outboundLabel,
             inboundLabel: inboundLabel,
             connectionID: "named-\(shortID)",
             connectionRole: "named:\(sanitizedName)",
-            responseBufferLimit: responseBufferLimit
+            responseBufferLimit: responseBufferLimit,
+            parserLimits: parserLimits
         )
     }
 

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -246,10 +246,11 @@ public actor IMAPServer {
     #endif
 
     deinit {
-        // Schedule shutdown on a background thread to avoid EventLoop issues
-        Task {  @MainActor [group] in
-            try? await group.shutdownGracefully()
-        }
+        // Same non-blocking pattern as SMTPServer.deinit. The callback form needs
+        // neither a Task nor an actor hop: the previous @MainActor task variant
+        // quietly serialized every shutdown through the main actor and never ran at
+        // all in processes that do not drain the main queue.
+        group.shutdownGracefully { _ in }
     }
 
     // MARK: - Mailbox State (used by helpers in extensions)

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -42,6 +42,9 @@ public actor IMAPServer {
     /// Certificate verification preference used by all TLS transports for this server.
     let certificateVerificationPolicy: MailCertificateVerificationPolicy
 
+    /// Lowest TLS version any transport for this server may negotiate.
+    let minimumTLSVersion: MailTLSMinimumVersion
+
     /// Maximum number of bytes the IMAP response parser may buffer before failing.
     /// Large SEARCH/FETCH responses from dense mailboxes can exceed a small buffer
     /// and surface as `PayloadTooLargeError`; raise this for very large mailboxes.
@@ -158,6 +161,7 @@ public actor IMAPServer {
         port: Int,
         transportSecurity: MailTransportSecurity = .automatic,
         certificateVerificationPolicy: MailCertificateVerificationPolicy = .fullVerification,
+        minimumTLSVersion: MailTLSMinimumVersion = .tlsv1_2,
         numberOfThreads: Int = 1,
         responseBufferLimit: Int = IMAPServer.defaultResponseBufferLimit
     ) {
@@ -166,6 +170,7 @@ public actor IMAPServer {
         self.port = port
         self.transportSecurity = transportSecurity
         self.certificateVerificationPolicy = certificateVerificationPolicy
+        self.minimumTLSVersion = minimumTLSVersion
         self.responseBufferLimit = responseBufferLimit
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: numberOfThreads)
 
@@ -180,6 +185,7 @@ public actor IMAPServer {
             port: port,
             transportSecurity: transportSecurity,
             certificateVerificationPolicy: certificateVerificationPolicy,
+            minimumTLSVersion: minimumTLSVersion,
             group: group,
             loggerLabel: primaryLoggerLabel,
             outboundLabel: outboundLabel,

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -50,6 +50,9 @@ public actor IMAPServer {
     /// and surface as `PayloadTooLargeError`; raise this for very large mailboxes.
     let responseBufferLimit: Int
 
+    /// Bounds the response parser enforces against a hostile or malfunctioning server.
+    let parserLimits: IMAPParserLimits
+
     /** The event loop group for handling asynchronous operations */
     let group: EventLoopGroup
 
@@ -146,7 +149,14 @@ public actor IMAPServer {
      - transportSecurity: The transport security policy to use. `.automatic` infers from standard IMAP
      ports; explicit values override that inference.
      - certificateVerificationPolicy: The certificate verification policy to use for TLS connections.
+     - minimumTLSVersion: The lowest TLS version any transport may negotiate. Defaults to
+     ``MailTLSMinimumVersion/tlsv1_2``, the lowest version RFC 8996 still permits. Pass
+     ``MailTLSMinimumVersion/tlsv1_3`` when every server you talk to supports it, which makes
+     a downgrade impossible regardless of what the server offers.
      - numberOfThreads: The number of threads to use for the event loop group
+     - parserLimits: Bounds the response parser enforces against a hostile or malfunctioning
+     server. Defaults to ``IMAPParserLimits/default``, which leaves body size and attribute
+     count unbounded — the behaviour before this parameter existed.
      - responseBufferLimit: Maximum bytes the IMAP response parser may buffer
      before failing with `PayloadTooLargeError`. Defaults to
      ``IMAPServer/defaultResponseBufferLimit`` (1 MB), which handles large SEARCH
@@ -163,7 +173,8 @@ public actor IMAPServer {
         certificateVerificationPolicy: MailCertificateVerificationPolicy = .fullVerification,
         minimumTLSVersion: MailTLSMinimumVersion = .tlsv1_2,
         numberOfThreads: Int = 1,
-        responseBufferLimit: Int = IMAPServer.defaultResponseBufferLimit
+        responseBufferLimit: Int = IMAPServer.defaultResponseBufferLimit,
+        parserLimits: IMAPParserLimits = .default
     ) {
         precondition(responseBufferLimit > 0, "responseBufferLimit must be greater than 0 bytes")
         self.host = host
@@ -172,6 +183,7 @@ public actor IMAPServer {
         self.certificateVerificationPolicy = certificateVerificationPolicy
         self.minimumTLSVersion = minimumTLSVersion
         self.responseBufferLimit = responseBufferLimit
+        self.parserLimits = parserLimits
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: numberOfThreads)
 
         // Initialize loggers
@@ -192,7 +204,8 @@ public actor IMAPServer {
             inboundLabel: inboundLabel,
             connectionID: "primary",
             connectionRole: "primary",
-            responseBufferLimit: responseBufferLimit
+            responseBufferLimit: responseBufferLimit,
+            parserLimits: parserLimits
         )
     }
 

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -150,8 +150,8 @@ public actor IMAPServer {
      ports; explicit values override that inference.
      - certificateVerificationPolicy: The certificate verification policy to use for TLS connections.
      - minimumTLSVersion: The lowest TLS version any transport may negotiate. Defaults to
-     ``MailTLSMinimumVersion/tlsv1_2``, the lowest version RFC 8996 still permits. Pass
-     ``MailTLSMinimumVersion/tlsv1_3`` when every server you talk to supports it, which makes
+     ``MailTLSMinimumVersion/tlsv12``, the lowest version RFC 8996 still permits. Pass
+     ``MailTLSMinimumVersion/tlsv13`` when every server you talk to supports it, which makes
      a downgrade impossible regardless of what the server offers.
      - numberOfThreads: The number of threads to use for the event loop group
      - parserLimits: Bounds the response parser enforces against a hostile or malfunctioning
@@ -171,7 +171,7 @@ public actor IMAPServer {
         port: Int,
         transportSecurity: MailTransportSecurity = .automatic,
         certificateVerificationPolicy: MailCertificateVerificationPolicy = .fullVerification,
-        minimumTLSVersion: MailTLSMinimumVersion = .tlsv1_2,
+        minimumTLSVersion: MailTLSMinimumVersion = .tlsv12,
         numberOfThreads: Int = 1,
         responseBufferLimit: Int = IMAPServer.defaultResponseBufferLimit,
         parserLimits: IMAPParserLimits = .default

--- a/Sources/SwiftMail/MailTransportSecurity.swift
+++ b/Sources/SwiftMail/MailTransportSecurity.swift
@@ -28,11 +28,44 @@ public enum MailCertificateVerificationPolicy: Sendable, Equatable {
     case noVerification
 }
 
+/// The lowest TLS protocol version a connection is allowed to negotiate.
+///
+/// Without this, connections inherit NIOSSL's `TLSConfiguration.makeClientConfiguration()`
+/// default, which is TLS 1.0 — deprecated by
+/// [RFC 8996](https://datatracker.ietf.org/doc/html/rfc8996) since March 2021.
+///
+/// Callers who know every server they talk to speaks TLS 1.3 can raise the floor and make
+/// downgrades impossible regardless of what the server offers.
+public enum MailTLSMinimumVersion: Sendable, Equatable {
+    /// TLS 1.0. Deprecated by RFC 8996 — only for legacy servers that offer nothing newer.
+    case tlsv1
+
+    /// TLS 1.1. Deprecated by RFC 8996.
+    case tlsv1_1
+
+    /// TLS 1.2. The default, and the lowest version RFC 8996 still permits.
+    case tlsv1_2
+
+    /// TLS 1.3. The strongest floor; refuses to negotiate anything older.
+    case tlsv1_3
+
+    var nioTLSVersion: TLSVersion {
+        switch self {
+            case .tlsv1: return .tlsv1
+            case .tlsv1_1: return .tlsv11
+            case .tlsv1_2: return .tlsv12
+            case .tlsv1_3: return .tlsv13
+        }
+    }
+}
+
 enum MailTLSConfiguration {
     static func makeClientConfiguration(
-        certificateVerificationPolicy: MailCertificateVerificationPolicy
+        certificateVerificationPolicy: MailCertificateVerificationPolicy,
+        minimumTLSVersion: MailTLSMinimumVersion = .tlsv1_2
     ) -> TLSConfiguration {
         var configuration = TLSConfiguration.makeClientConfiguration()
+        configuration.minimumTLSVersion = minimumTLSVersion.nioTLSVersion
         switch certificateVerificationPolicy {
             case .fullVerification:
                 configuration.certificateVerification = .fullVerification

--- a/Sources/SwiftMail/MailTransportSecurity.swift
+++ b/Sources/SwiftMail/MailTransportSecurity.swift
@@ -60,9 +60,14 @@ public enum MailTLSMinimumVersion: Sendable, Equatable {
 }
 
 enum MailTLSConfiguration {
+    /// - Note: `minimumTLSVersion` has no default for the same reason
+    ///   `IMAPConnection.makeTLSHandler` has none: a default here turns "forgot to thread the
+    ///   configured floor through" into "silently chose TLS 1.2", which is exactly the shape of
+    ///   the implicit-TLS defect this change fixed. The *library-wide* default lives on the
+    ///   public `IMAPServer`/`SMTPServer` initializers, where choosing it is visible.
     static func makeClientConfiguration(
         certificateVerificationPolicy: MailCertificateVerificationPolicy,
-        minimumTLSVersion: MailTLSMinimumVersion = .tlsv12
+        minimumTLSVersion: MailTLSMinimumVersion
     ) -> TLSConfiguration {
         var configuration = TLSConfiguration.makeClientConfiguration()
         configuration.minimumTLSVersion = minimumTLSVersion.nioTLSVersion

--- a/Sources/SwiftMail/MailTransportSecurity.swift
+++ b/Sources/SwiftMail/MailTransportSecurity.swift
@@ -41,20 +41,20 @@ public enum MailTLSMinimumVersion: Sendable, Equatable {
     case tlsv1
 
     /// TLS 1.1. Deprecated by RFC 8996.
-    case tlsv1_1
+    case tlsv11
 
     /// TLS 1.2. The default, and the lowest version RFC 8996 still permits.
-    case tlsv1_2
+    case tlsv12
 
     /// TLS 1.3. The strongest floor; refuses to negotiate anything older.
-    case tlsv1_3
+    case tlsv13
 
     var nioTLSVersion: TLSVersion {
         switch self {
             case .tlsv1: return .tlsv1
-            case .tlsv1_1: return .tlsv11
-            case .tlsv1_2: return .tlsv12
-            case .tlsv1_3: return .tlsv13
+            case .tlsv11: return .tlsv11
+            case .tlsv12: return .tlsv12
+            case .tlsv13: return .tlsv13
         }
     }
 }
@@ -62,7 +62,7 @@ public enum MailTLSMinimumVersion: Sendable, Equatable {
 enum MailTLSConfiguration {
     static func makeClientConfiguration(
         certificateVerificationPolicy: MailCertificateVerificationPolicy,
-        minimumTLSVersion: MailTLSMinimumVersion = .tlsv1_2
+        minimumTLSVersion: MailTLSMinimumVersion = .tlsv12
     ) -> TLSConfiguration {
         var configuration = TLSConfiguration.makeClientConfiguration()
         configuration.minimumTLSVersion = minimumTLSVersion.nioTLSVersion

--- a/Sources/SwiftMail/SMTP/SMTPServer+Connection.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer+Connection.swift
@@ -62,6 +62,7 @@ extension SMTPServer {
     private func makeClientBootstrap(useImplicitTLS: Bool) -> ClientBootstrap {
         let host = self.host
         let certificateVerificationPolicy = self.certificateVerificationPolicy
+        let minimumTLSVersion = self.minimumTLSVersion
         let duplexLogger = self.duplexLogger
 
         return ClientBootstrap(group: group)
@@ -72,7 +73,8 @@ extension SMTPServer {
                     do {
                         // Create SSL context with proper configuration for secure connection
                         let tlsConfig = MailTLSConfiguration.makeClientConfiguration(
-                            certificateVerificationPolicy: certificateVerificationPolicy
+                            certificateVerificationPolicy: certificateVerificationPolicy,
+                            minimumTLSVersion: minimumTLSVersion
                         )
 
                         let sslContext = try NIOSSLContext(configuration: tlsConfig)
@@ -279,7 +281,8 @@ extension SMTPServer {
 
         // Create SSL context with proper configuration for secure connection
         let tlsConfig = MailTLSConfiguration.makeClientConfiguration(
-            certificateVerificationPolicy: certificateVerificationPolicy
+            certificateVerificationPolicy: certificateVerificationPolicy,
+            minimumTLSVersion: minimumTLSVersion
         )
 
         // Capture the configuration before the closure to avoid concurrency issues

--- a/Sources/SwiftMail/SMTP/SMTPServer.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer.swift
@@ -158,7 +158,7 @@ public actor SMTPServer {
         port: Int,
         transportSecurity: MailTransportSecurity = .automatic,
         certificateVerificationPolicy: MailCertificateVerificationPolicy = .fullVerification,
-        minimumTLSVersion: MailTLSMinimumVersion = .tlsv1_2,
+        minimumTLSVersion: MailTLSMinimumVersion = .tlsv12,
         numberOfThreads: Int = 1
     ) {
         self.host = host

--- a/Sources/SwiftMail/SMTP/SMTPServer.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer.swift
@@ -175,7 +175,16 @@ public actor SMTPServer {
     }
 
     deinit {
-        try? group.syncShutdownGracefully()
+        // Must not block: deinit runs on whatever thread drops the last reference,
+        // which under Swift Concurrency is a cooperative-pool thread — on Darwin one
+        // of the process's ncpu default-QoS workqueue threads. syncShutdownGracefully()
+        // parks that thread on a semaphore whose signal is itself delivered via the
+        // default-QoS global queue, so once ncpu deinits are in flight at the same
+        // time no thread is left to deliver any of the signals and every waiter waits
+        // forever. A 3-core CI runner deadlocked exactly this way with three tests
+        // concurrently releasing servers. The callback form initiates the same
+        // shutdown without waiting for it.
+        group.shutdownGracefully { _ in }
     }
 
     // MARK: - Command Execution

--- a/Sources/SwiftMail/SMTP/SMTPServer.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer.swift
@@ -70,6 +70,9 @@ public actor SMTPServer {
     /** The certificate verification policy for TLS connections */
     let certificateVerificationPolicy: MailCertificateVerificationPolicy
 
+    /// Lowest TLS version any transport for this server may negotiate.
+    let minimumTLSVersion: MailTLSMinimumVersion
+
     /** The event loop group for handling asynchronous operations */
     let group: EventLoopGroup
 
@@ -155,12 +158,14 @@ public actor SMTPServer {
         port: Int,
         transportSecurity: MailTransportSecurity = .automatic,
         certificateVerificationPolicy: MailCertificateVerificationPolicy = .fullVerification,
+        minimumTLSVersion: MailTLSMinimumVersion = .tlsv1_2,
         numberOfThreads: Int = 1
     ) {
         self.host = host
         self.port = port
         self.transportSecurity = transportSecurity
         self.certificateVerificationPolicy = certificateVerificationPolicy
+        self.minimumTLSVersion = minimumTLSVersion
         self.group = MultiThreadedEventLoopGroup(numberOfThreads: numberOfThreads)
 
         let outboundLogger = Logger(label: "com.cocoanetics.SwiftMail.SMTP_OUT")

--- a/Tests/SwiftIMAPTests/EventLoopGroupTestSupport.swift
+++ b/Tests/SwiftIMAPTests/EventLoopGroupTestSupport.swift
@@ -1,0 +1,26 @@
+import Foundation
+import NIO
+
+/// Shuts `group` down deterministically **without** blocking a Swift Concurrency pool thread.
+///
+/// ## Why this is not just `try? group.syncShutdownGracefully()`
+/// Because that call, made directly from a swift-testing test, blocks a cooperative-pool thread.
+/// On a core-constrained CI runner it violates the pool's forward-progress guarantee and
+/// deadlocks the entire run — the macOS job hangs until its `timeout-minutes: 10` fires and the
+/// whole thing reports as *cancelled* rather than failed, which is a good deal harder to notice
+/// than a red X.
+///
+/// This is not a new discovery: `IMAPResponseBufferLimitTests` documented and solved it in #179,
+/// having watched a 7-minute hang. Dispatching the blocking call to a non-cooperative GCD queue
+/// and awaiting the continuation keeps the shutdown deterministic without ever blocking the pool.
+///
+/// It lives here rather than being copied into each suite so the next test that needs an event
+/// loop group finds the answer instead of the trap.
+func shutDownGracefully(_ group: MultiThreadedEventLoopGroup) async {
+    await withCheckedContinuation { continuation in
+        DispatchQueue.global().async {
+            try? group.syncShutdownGracefully()
+            continuation.resume()
+        }
+    }
+}

--- a/Tests/SwiftIMAPTests/EventLoopGroupTestSupport.swift
+++ b/Tests/SwiftIMAPTests/EventLoopGroupTestSupport.swift
@@ -1,25 +1,26 @@
 import Foundation
 import NIO
 
-/// Shuts `group` down deterministically **without** blocking a Swift Concurrency pool thread.
+/// Shuts `group` down deterministically without parking **any** thread on the result.
 ///
-/// ## Why this is not just `try? group.syncShutdownGracefully()`
-/// Because that call, made directly from a swift-testing test, blocks a cooperative-pool thread.
-/// On a core-constrained CI runner it violates the pool's forward-progress guarantee and
-/// deadlocks the entire run — the macOS job hangs until its `timeout-minutes: 10` fires and the
-/// whole thing reports as *cancelled* rather than failed, which is a good deal harder to notice
-/// than a red X.
+/// ## Why this is not `try? group.syncShutdownGracefully()`
+/// That call parks the calling thread on a semaphore whose signal is delivered via the
+/// default-QoS global queue. Called from a swift-testing test it parks a cooperative-pool
+/// thread; the pool is one thread per core, and the same threads back the default-QoS global
+/// queue — so on a core-constrained CI runner a handful of concurrent shutdowns consume every
+/// thread that could have delivered their wake-ups, and the whole run deadlocks until the job
+/// timeout reports it as *cancelled*. Moving the blocking call onto a GCD queue (this helper's
+/// first iteration, after #179 hit the 7-minute variant of the same hang) only relocates the
+/// parked thread into the very pool that has to deliver the signal.
 ///
-/// This is not a new discovery: `IMAPResponseBufferLimitTests` documented and solved it in #179,
-/// having watched a 7-minute hang. Dispatching the blocking call to a non-cooperative GCD queue
-/// and awaiting the continuation keeps the shutdown deterministic without ever blocking the pool.
+/// The callback form initiates the identical shutdown and resumes the continuation from NIO's
+/// completion callback directly: deterministic completion, zero threads parked anywhere.
 ///
 /// It lives here rather than being copied into each suite so the next test that needs an event
 /// loop group finds the answer instead of the trap.
 func shutDownGracefully(_ group: MultiThreadedEventLoopGroup) async {
     await withCheckedContinuation { continuation in
-        DispatchQueue.global().async {
-            try? group.syncShutdownGracefully()
+        group.shutdownGracefully { _ in
             continuation.resume()
         }
     }

--- a/Tests/SwiftIMAPTests/FetchRawMessageTests.swift
+++ b/Tests/SwiftIMAPTests/FetchRawMessageTests.swift
@@ -39,19 +39,20 @@ import Testing
                 maildirURL: maildir
             )
             try testServer.start()
-            defer { testServer.stop() }
 
-            let server = IMAPServer(host: "127.0.0.1", port: testServer.port, useTLS: false)
-            try await server.connect()
+            try await testServer.run {
+                let server = IMAPServer(host: "127.0.0.1", port: testServer.port, useTLS: false)
+                try await server.connect()
 
-            try await server.login(username: "testuser", password: "testpass")
-            _ = try await server.selectMailbox("INBOX")
+                try await server.login(username: "testuser", password: "testpass")
+                _ = try await server.selectMailbox("INBOX")
 
-            let raw = try await server.fetchRawMessage(identifier: UID(1))
-            #expect(raw == sampleMessage)
-            #expect(String(data: raw, encoding: .utf8)?.contains("Received: from mx.example.com") == true)
+                let raw = try await server.fetchRawMessage(identifier: UID(1))
+                #expect(raw == sampleMessage)
+                #expect(String(data: raw, encoding: .utf8)?.contains("Received: from mx.example.com") == true)
 
-            try await server.disconnect()
+                try await server.disconnect()
+            }
         }
     }
 #endif

--- a/Tests/SwiftIMAPTests/IMAPIdleCancellationTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPIdleCancellationTests.swift
@@ -142,12 +142,16 @@ struct IMAPIdleCancellationTests {
             host: "localhost",
             port: 143,
             transportSecurity: .plainText,
+            // Explicit since the designated initializer dropped its defaults: forgetting the
+            // security policy is now a build error rather than a silently lax connection.
+            minimumTLSVersion: .tlsv1_2,
             group: group,
             loggerLabel: "test.imap",
             outboundLabel: "test.imap.out",
             inboundLabel: "test.imap.in",
             connectionID: "test-idle-cancel",
-            connectionRole: "test"
+            connectionRole: "test",
+            parserLimits: .default
         )
         let channel = NIOAsyncTestingChannel()
         let address = try SocketAddress(ipAddress: "127.0.0.1", port: 143)

--- a/Tests/SwiftIMAPTests/IMAPIdleCancellationTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPIdleCancellationTests.swift
@@ -144,7 +144,7 @@ struct IMAPIdleCancellationTests {
             transportSecurity: .plainText,
             // Explicit since the designated initializer dropped its defaults: forgetting the
             // security policy is now a build error rather than a silently lax connection.
-            minimumTLSVersion: .tlsv1_2,
+            minimumTLSVersion: .tlsv12,
             group: group,
             loggerLabel: "test.imap",
             outboundLabel: "test.imap.out",

--- a/Tests/SwiftIMAPTests/IMAPIdleGroupLifecycleTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPIdleGroupLifecycleTests.swift
@@ -43,63 +43,61 @@ import Testing
         func idleSessionSurvivesServerDeallocation() async throws {
             let (testServer, tempRoot) = try makeTestServer()
             try testServer.start()
-            defer {
-                testServer.stop()
-                try? FileManager.default.removeItem(at: tempRoot)
+            defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+            try await testServer.run {
+                // Create server, start IDLE, then deallocate the server.
+                var session: IMAPIdleSession?
+                do {
+                    let server = IMAPServer(host: "127.0.0.1", port: testServer.port, useTLS: false)
+                    try await server.connect()
+                    try await server.login(username: "u", password: "p")
+                    session = try await server.idle(on: "INBOX")
+                    // server goes out of scope here — its deinit fires shutdownGracefully()
+                }
+
+                guard let session else {
+                    Issue.record("Failed to create IDLE session")
+                    return
+                }
+
+                // The session should still be usable after the server is deallocated.
+                // Give the deinit's shutdown a moment to execute.
+                try? await Task.sleep(nanoseconds: 500_000_000) // 0.5s
+
+                // Ending the session should not crash (no "event loop shut down" assertion).
+                try? await session.done()
             }
-
-            // Create server, start IDLE, then deallocate the server.
-            var session: IMAPIdleSession?
-            do {
-                let server = IMAPServer(host: "127.0.0.1", port: testServer.port, useTLS: false)
-                try await server.connect()
-                try await server.login(username: "u", password: "p")
-                session = try await server.idle(on: "INBOX")
-                // server goes out of scope here — its deinit fires shutdownGracefully()
-            }
-
-            guard let session else {
-                Issue.record("Failed to create IDLE session")
-                return
-            }
-
-            // The session should still be usable after the server is deallocated.
-            // Give the deinit's shutdown Task a moment to execute.
-            try? await Task.sleep(nanoseconds: 500_000_000) // 0.5s
-
-            // Ending the session should not crash (no "event loop shut down" assertion).
-            try? await session.done()
         }
 
         @Test
         func repeatedIdleRenewalsDoNotTripClientStateMachine() async throws {
             let (testServer, tempRoot) = try makeTestServer()
             try testServer.start()
-            defer {
-                testServer.stop()
-                try? FileManager.default.removeItem(at: tempRoot)
+            defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+            try await testServer.run {
+                let server = IMAPServer(host: "127.0.0.1", port: testServer.port, useTLS: false)
+                try await server.connect()
+                try await server.login(username: "u", password: "p")
+
+                let configuration = IMAPIdleConfiguration(
+                    renewalInterval: 0.05,
+                    noopInterval: 1,
+                    postIdleNoopEnabled: false,
+                    postIdleNoopDelay: 0,
+                    doneTimeout: 2,
+                    reconnectBaseDelay: 0.01,
+                    reconnectMaxDelay: 0.01,
+                    reconnectJitterFactor: 0
+                )
+                let session = try await server.idle(on: "INBOX", configuration: configuration)
+
+                try await Task.sleep(nanoseconds: 1_000_000_000)
+                #expect(testServer.idleCommandCount >= 2)
+                try await session.done()
+                try? await server.disconnect()
             }
-
-            let server = IMAPServer(host: "127.0.0.1", port: testServer.port, useTLS: false)
-            try await server.connect()
-            try await server.login(username: "u", password: "p")
-
-            let configuration = IMAPIdleConfiguration(
-                renewalInterval: 0.05,
-                noopInterval: 1,
-                postIdleNoopEnabled: false,
-                postIdleNoopDelay: 0,
-                doneTimeout: 2,
-                reconnectBaseDelay: 0.01,
-                reconnectMaxDelay: 0.01,
-                reconnectJitterFactor: 0
-            )
-            let session = try await server.idle(on: "INBOX", configuration: configuration)
-
-            try await Task.sleep(nanoseconds: 1_000_000_000)
-            #expect(testServer.idleCommandCount >= 2)
-            try await session.done()
-            try? await server.disconnect()
         }
 
         /// The idle group should be cleaned up when the initial connection fails.

--- a/Tests/SwiftIMAPTests/IMAPNamedConnectionTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPNamedConnectionTests.swift
@@ -174,18 +174,19 @@ struct IMAPNamedConnectionTests {
                 maildirURL: maildir
             )
             try testServer.start()
-            defer { testServer.stop() }
 
-            let server = IMAPServer(host: "127.0.0.1", port: testServer.port, useTLS: false)
-            try await server.connect()
-            try await server.login(username: "u", password: "p")
+            try await testServer.run {
+                let server = IMAPServer(host: "127.0.0.1", port: testServer.port, useTLS: false)
+                try await server.connect()
+                try await server.login(username: "u", password: "p")
 
-            async let first = server.connection(named: "shared")
-            async let second = server.connection(named: "shared")
-            let handles = try await (first, second)
+                async let first = server.connection(named: "shared")
+                async let second = server.connection(named: "shared")
+                let handles = try await (first, second)
 
-            #expect(ObjectIdentifier(handles.0) == ObjectIdentifier(handles.1))
-            try await server.disconnect()
+                #expect(ObjectIdentifier(handles.0) == ObjectIdentifier(handles.1))
+                try await server.disconnect()
+            }
         }
     #endif
 

--- a/Tests/SwiftIMAPTests/IMAPParserLimitsTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPParserLimitsTests.swift
@@ -1,0 +1,54 @@
+import Testing
+import NIOIMAPCore
+@testable import SwiftMail
+
+@Suite("IMAP parser limits")
+struct IMAPParserLimitsTests {
+
+    @Test("Defaults preserve the previous unbounded behaviour")
+    func defaultsAreUnbounded() {
+        let limits = IMAPParserLimits.default
+        #expect(limits.bodySizeLimit == UInt64.max)
+        #expect(limits.messageAttributeLimit == Int.max)
+        #expect(limits.literalSizeLimit == IMAPDefaults.literalSizeLimit)
+    }
+
+    @Test("Caller-supplied bounds are kept")
+    func customLimits() {
+        let limits = IMAPParserLimits(
+            bodySizeLimit: 64 * 1024 * 1024,
+            messageAttributeLimit: 1024,
+            literalSizeLimit: 8192
+        )
+        #expect(limits.bodySizeLimit == 64 * 1024 * 1024)
+        #expect(limits.messageAttributeLimit == 1024)
+        #expect(limits.literalSizeLimit == 8192)
+    }
+
+    @Test("Each field can be tightened on its own")
+    func partialOverride() {
+        let limits = IMAPParserLimits(bodySizeLimit: 1024)
+        #expect(limits.bodySizeLimit == 1024)
+        #expect(limits.messageAttributeLimit == Int.max)
+        #expect(limits.literalSizeLimit == IMAPDefaults.literalSizeLimit)
+    }
+
+    @Test("IMAPServer carries the caller's limits")
+    func imapServerStoresLimits() async {
+        let limits = IMAPParserLimits(bodySizeLimit: 32 * 1024 * 1024, messageAttributeLimit: 512)
+        let server = IMAPServer(host: "imap.example.com", port: 993, parserLimits: limits)
+        #expect(await server.parserLimits == limits)
+    }
+
+    @Test("IMAPServer defaults to the unbounded limits")
+    func imapServerDefault() async {
+        let server = IMAPServer(host: "imap.example.com", port: 993)
+        #expect(await server.parserLimits == .default)
+    }
+
+    @Test("Limits are value-comparable")
+    func equatable() {
+        #expect(IMAPParserLimits(bodySizeLimit: 100) == IMAPParserLimits(bodySizeLimit: 100))
+        #expect(IMAPParserLimits(bodySizeLimit: 100) != IMAPParserLimits(bodySizeLimit: 200))
+    }
+}

--- a/Tests/SwiftIMAPTests/IMAPParserLimitsTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPParserLimitsTests.swift
@@ -2,7 +2,14 @@ import Testing
 import NIOIMAPCore
 @testable import SwiftMail
 
-@Suite("IMAP parser limits")
+/// - Note: `.serialized` and `.timeLimit` are not decoration. Constructing an `IMAPServer` or
+///   `SMTPServer` allocates a `MultiThreadedEventLoopGroup`, and `SMTPServer.deinit` shuts it
+///   down with the **blocking** `syncShutdownGracefully()`. Released from a Swift Concurrency
+///   context, that costs a cooperative-pool thread; run in parallel with the rest of the suite on
+///   a core-constrained CI runner, the pool starves and the whole test run stalls. Every
+///   pre-existing suite here that constructs a server carries these traits — this one did not,
+///   and that is what hung the macOS job.
+@Suite("IMAP parser limits", .serialized, .timeLimit(.minutes(1)))
 struct IMAPParserLimitsTests {
 
     @Test("Defaults preserve the previous unbounded behaviour")

--- a/Tests/SwiftIMAPTests/IMAPParserLimitsTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPParserLimitsTests.swift
@@ -2,13 +2,11 @@ import Testing
 import NIOIMAPCore
 @testable import SwiftMail
 
-/// - Note: `.serialized` and `.timeLimit` are not decoration. Constructing an `IMAPServer` or
-///   `SMTPServer` allocates a `MultiThreadedEventLoopGroup`, and `SMTPServer.deinit` shuts it
-///   down with the **blocking** `syncShutdownGracefully()`. Released from a Swift Concurrency
-///   context, that costs a cooperative-pool thread; run in parallel with the rest of the suite on
-///   a core-constrained CI runner, the pool starves and the whole test run stalls. Every
-///   pre-existing suite here that constructs a server carries these traits — this one did not,
-///   and that is what hung the macOS job.
+/// - Note: `.serialized` and `.timeLimit` match the other server-constructing suites.
+///   Constructing an `IMAPServer` or `SMTPServer` allocates a `MultiThreadedEventLoopGroup`
+///   that is shut down on release; suites that release servers used to be able to deadlock a
+///   core-constrained CI runner when the deinit still *blocked* on that shutdown, so the traits
+///   keep server churn serialized and bounded in time as defense in depth.
 @Suite("IMAP parser limits", .serialized, .timeLimit(.minutes(1)))
 struct IMAPParserLimitsTests {
 

--- a/Tests/SwiftIMAPTests/IMAPPlaintextIntegrationTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPPlaintextIntegrationTests.swift
@@ -39,14 +39,15 @@ import Testing
                 maildirURL: maildir
             )
             try testServer.start()
-            defer { testServer.stop() }
 
-            let server = IMAPServer(host: "127.0.0.1", port: testServer.port, useTLS: false)
-            try await server.connect()
-            try await server.login(username: "testuser", password: "testpass")
-            let status = try await server.selectMailbox("INBOX")
-            #expect(status.messageCount == 1)
-            try await server.disconnect()
+            try await testServer.run {
+                let server = IMAPServer(host: "127.0.0.1", port: testServer.port, useTLS: false)
+                try await server.connect()
+                try await server.login(username: "testuser", password: "testpass")
+                let status = try await server.selectMailbox("INBOX")
+                #expect(status.messageCount == 1)
+                try await server.disconnect()
+            }
         }
     }
 #endif

--- a/Tests/SwiftIMAPTests/IMAPResponseBufferLimitTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPResponseBufferLimitTests.swift
@@ -5,22 +5,10 @@ import Testing
 
 @Suite(.serialized, .timeLimit(.minutes(1)))
 struct IMAPResponseBufferLimitTests {
-    /// Deterministically shuts `group` down via `syncShutdownGracefully()`, but runs
-    /// that blocking call OFF the Swift Concurrency cooperative pool. Calling
-    /// `syncShutdownGracefully()` directly from a swift-testing test blocks a
-    /// cooperative-pool thread; on a core-constrained CI runner that violates the
-    /// pool's forward-progress guarantee and deadlocks the whole run (a 7-minute
-    /// hang to the job timeout was observed). Dispatching to a non-cooperative GCD
-    /// global queue and awaiting the continuation keeps the shutdown deterministic
-    /// without ever blocking the pool.
-    private func shutDownGracefully(_ group: MultiThreadedEventLoopGroup) async {
-        await withCheckedContinuation { continuation in
-            DispatchQueue.global().async {
-                try? group.syncShutdownGracefully()
-                continuation.resume()
-            }
-        }
-    }
+    // Group shutdown goes through the shared shutDownGracefully(_:) helper in
+    // EventLoopGroupTestSupport.swift; this suite's private GCD-dispatch copy was
+    // its first iteration and parked a thread in the pool that delivers the
+    // shutdown's own completion — see the helper's comment for the full story.
 
     @Test("Default response buffer limit is 1 MB")
     func defaultIsOneMegabyte() async {

--- a/Tests/SwiftIMAPTests/IMAPResponseLimitGuardTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPResponseLimitGuardTests.swift
@@ -1,0 +1,168 @@
+import Testing
+import Foundation
+import NIO
+import NIOEmbedded
+import NIOIMAP
+import NIOIMAPCore
+import Logging
+@testable import SwiftMail
+
+/// Does `bodySizeLimit` bound the whole FETCH response, as documented — not just one section?
+///
+/// ## The gap these cover
+/// `ResponseParser` checks each streaming section on its own and keeps no total, while
+/// `FetchPartHandler` and `PipelinedFetchPartHandler` append every section into one `Data`. With
+/// `bodySizeLimit: 64 MiB`, a server could send any number of 50 MiB sections in a single FETCH:
+/// each passes the parser's check, all of them land in one buffer. The documented guard bounded
+/// nothing.
+///
+/// These tests drive the guard with the response sequence a hostile server would produce, so the
+/// bypass is reproducible. Remove `IMAPResponseLimitGuard` from the pipeline and
+/// `manySmallSectionsExceedTheTotal` goes green in the wrong direction — it stops throwing.
+@Suite("Body size limit covers the whole FETCH response")
+struct IMAPResponseLimitGuardTests {
+
+    /// - Note: The channel is **connected** before use. An `EmbeddedChannel` reports
+    ///   `isActive == false` until it is, which would make every "the guard closes the channel"
+    ///   assertion below pass for the wrong reason — green because the channel was never open,
+    ///   not because the guard closed it. A test that cannot fail proves nothing.
+    private func makeChannel(bodySizeLimit: UInt64) throws -> EmbeddedChannel {
+        let channel = EmbeddedChannel()
+        try channel.pipeline.syncOperations.addHandler(
+            IMAPResponseLimitGuard(
+                bodySizeLimit: bodySizeLimit,
+                logger: Logger(label: "test"),
+                connectionContext: "[test]"
+            )
+        )
+        try channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 993)).wait()
+        #expect(channel.isActive, "Precondition: the channel has to be open for a close to mean anything")
+        return channel
+    }
+
+    private func write(_ response: Response, to channel: EmbeddedChannel) throws {
+        try channel.writeInbound(response)
+    }
+
+    /// 🔴 The bypass: every section is legal on its own, the sum is not.
+    @Test("Many individually legal sections still exceed the response total")
+    func manySmallSectionsExceedTheTotal() throws {
+        let channel = try makeChannel(bodySizeLimit: 100)
+        try write(.fetch(.start(SequenceNumber(1))), to: channel)
+
+        // Four sections of 30 bytes: each far below 100, together 120.
+        try write(.fetch(.streamingBegin(kind: .body(section: .text, offset: nil), byteCount: 30)), to: channel)
+        try write(.fetch(.streamingBegin(kind: .body(section: .text, offset: nil), byteCount: 30)), to: channel)
+        try write(.fetch(.streamingBegin(kind: .body(section: .text, offset: nil), byteCount: 30)), to: channel)
+
+        #expect(throws: ExceededResponseBodySizeError.self) {
+            try channel.writeInbound(
+                Response.fetch(.streamingBegin(kind: .body(section: .text, offset: nil), byteCount: 30))
+            )
+        }
+        // A peer that sends this has proven itself; the connection must not stay open.
+        #expect(channel.isActive == false, "A limit violation has to close the connection")
+    }
+
+    /// The control: the same shape, just under the ceiling, must pass through untouched.
+    /// Without this, the test above would also pass if the guard rejected everything.
+    @Test("Sections that stay under the total pass through")
+    func sectionsUnderTheTotalPass() throws {
+        let channel = try makeChannel(bodySizeLimit: 100)
+        try write(.fetch(.start(SequenceNumber(1))), to: channel)
+        try write(.fetch(.streamingBegin(kind: .body(section: .text, offset: nil), byteCount: 40)), to: channel)
+        try write(.fetch(.streamingBegin(kind: .body(section: .text, offset: nil), byteCount: 40)), to: channel)
+        try write(.fetch(.finish), to: channel)
+
+        #expect(channel.isActive)
+        // Everything must arrive on the far side — the guard observes, it does not swallow.
+        var seen = 0
+        while try channel.readInbound(as: Response.self) != nil { seen += 1 }
+        #expect(seen == 4)
+    }
+
+    /// The total is *per response*. Two messages of 80 bytes each are not a 160-byte violation —
+    /// otherwise a long mailbox sync would trip the guard for doing exactly what it should.
+    @Test("The total resets for each message in the same FETCH")
+    func totalResetsPerMessage() throws {
+        let channel = try makeChannel(bodySizeLimit: 100)
+
+        for sequence in 1...5 {
+            try write(.fetch(.start(SequenceNumber(rawValue: UInt32(sequence)))), to: channel)
+            try write(.fetch(.streamingBegin(kind: .body(section: .text, offset: nil), byteCount: 80)), to: channel)
+            try write(.fetch(.finish), to: channel)
+        }
+
+        #expect(channel.isActive, "Five legal messages in a row are not a violation")
+    }
+
+    /// `.max` means unbounded — the guard must not add a ceiling where the caller asked for none.
+    @Test("The unbounded default lets everything through")
+    func unboundedDefaultPassesEverything() throws {
+        let channel = try makeChannel(bodySizeLimit: .max)
+        try write(.fetch(.start(SequenceNumber(1))), to: channel)
+        for _ in 0..<50 {
+            try write(
+                .fetch(.streamingBegin(kind: .body(section: .text, offset: nil), byteCount: Int.max / 100)),
+                to: channel
+            )
+        }
+        #expect(channel.isActive)
+    }
+}
+
+/// Do parser-limit errors fail closed?
+///
+/// They did not. During IDLE, an oversized body or an over-limit attribute count made
+/// `IMAPClientHandler` fire an error; `IdleHandler.errorCaught` only failed a private promise
+/// that nothing was awaiting until a later DONE. The decoder kept the rejected response and
+/// appended every subsequent read to it — the post-decode buffer cap is skipped when decoding
+/// throws — so a malicious peer could keep growing memory while the caller's `AsyncStream` hung.
+@Suite("Parser limit violations close the connection")
+struct IMAPLimitViolationFailsClosedTests {
+
+    /// - Note: Connected first — see the note in ``IMAPResponseLimitGuardTests``. Without it
+    ///   these assertions would be green because the channel was never open.
+    private func makeChannel() throws -> EmbeddedChannel {
+        let channel = EmbeddedChannel()
+        try channel.pipeline.syncOperations.addHandler(
+            IMAPResponseLimitGuard(
+                bodySizeLimit: .max,
+                logger: Logger(label: "test"),
+                connectionContext: "[test]"
+            )
+        )
+        try channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 993)).wait()
+        #expect(channel.isActive, "Precondition: the channel has to be open for a close to mean anything")
+        return channel
+    }
+
+    @Test("An oversized single body closes the channel")
+    func oversizedBodyCloses() throws {
+        let channel = try makeChannel()
+        channel.pipeline.fireErrorCaught(ExceededMaximumBodySizeError(actualCount: 100, maximumCount: 10))
+        channel.embeddedEventLoop.run()
+        #expect(channel.isActive == false)
+    }
+
+    @Test("An over-limit attribute count closes the channel")
+    func tooManyAttributesCloses() throws {
+        let channel = try makeChannel()
+        channel.pipeline.fireErrorCaught(
+            ExceededMaximumMessageAttributesError(actualCount: 100, maximumCount: 10)
+        )
+        channel.embeddedEventLoop.run()
+        #expect(channel.isActive == false)
+    }
+
+    /// Deliberately narrow. `errorCaught` sees unrelated failures too, and tearing the connection
+    /// down for those would change behaviour far outside this feature.
+    @Test("An unrelated error does not close the channel")
+    func unrelatedErrorDoesNotClose() throws {
+        let channel = try makeChannel()
+        struct SomeOtherError: Error {}
+        channel.pipeline.fireErrorCaught(SomeOtherError())
+        channel.embeddedEventLoop.run()
+        #expect(channel.isActive, "Only limit violations are grounds for closing")
+    }
+}

--- a/Tests/SwiftIMAPTests/IMAPResponseLimitGuardTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPResponseLimitGuardTests.swift
@@ -19,7 +19,7 @@ import Logging
 /// These tests drive the guard with the response sequence a hostile server would produce, so the
 /// bypass is reproducible. Remove `IMAPResponseLimitGuard` from the pipeline and
 /// `manySmallSectionsExceedTheTotal` goes green in the wrong direction — it stops throwing.
-@Suite("Body size limit covers the whole FETCH response")
+@Suite("Body size limit covers the whole FETCH response", .timeLimit(.minutes(1)))
 struct IMAPResponseLimitGuardTests {
 
     /// - Note: The channel is **connected** before use. An `EmbeddedChannel` reports
@@ -118,7 +118,7 @@ struct IMAPResponseLimitGuardTests {
 /// that nothing was awaiting until a later DONE. The decoder kept the rejected response and
 /// appended every subsequent read to it — the post-decode buffer cap is skipped when decoding
 /// throws — so a malicious peer could keep growing memory while the caller's `AsyncStream` hung.
-@Suite("Parser limit violations close the connection")
+@Suite("Parser limit violations close the connection", .timeLimit(.minutes(1)))
 struct IMAPLimitViolationFailsClosedTests {
 
     /// - Note: Connected first — see the note in ``IMAPResponseLimitGuardTests``. Without it

--- a/Tests/SwiftIMAPTests/IMAPResponseLimitGuardTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPResponseLimitGuardTests.swift
@@ -155,6 +155,52 @@ struct IMAPLimitViolationFailsClosedTests {
         #expect(channel.isActive == false)
     }
 
+    @Test("An oversized literal closes the channel")
+    func oversizedLiteralCloses() throws {
+        let channel = try makeChannel()
+        channel.pipeline.fireErrorCaught(ExceededLiteralSizeLimitError(actualCount: 8192, maximumCount: 4096))
+        channel.embeddedEventLoop.run()
+        #expect(channel.isActive == false)
+    }
+
+    /// The one that catches what the raw-error tests above cannot: `ResponseDecoder` wraps every
+    /// parser error in `IMAPDecoderError` before `IMAPClientHandler` fires it down the pipeline.
+    /// The tests above inject the bare types, so a guard that never unwrapped the wrapper — the
+    /// shipped defect — passed all of them while never firing in production. This one feeds raw
+    /// wire bytes through the real decoder with the real pipeline order, so the error arrives
+    /// exactly as a hostile server would deliver it.
+    @Test("A parser-limit error raised by the real decoder still closes the channel")
+    func decoderWrappedViolationCloses() throws {
+        let channel = EmbeddedChannel()
+        let limits = IMAPParserLimits(bodySizeLimit: 10)
+        try channel.pipeline.syncOperations.addHandlers([
+            IMAPClientHandler(parserOptions: limits.makeParserOptions(bufferLimit: 1024)),
+            IMAPResponseLimitGuard(
+                bodySizeLimit: limits.bodySizeLimit,
+                logger: Logger(label: "test"),
+                connectionContext: "[test]"
+            )
+        ])
+        try channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 993)).wait()
+        #expect(channel.isActive, "Precondition: the channel has to be open for a close to mean anything")
+
+        // The parser's state machine wants a greeting before anything else; without it the FETCH
+        // below fails as a plain syntax error, which the guard rightly ignores.
+        var greeting = channel.allocator.buffer(capacity: 16)
+        greeting.writeString("* OK ready\r\n")
+        try channel.writeInbound(greeting)
+
+        // A FETCH declaring a 100-byte body against a 10-byte limit. The parser rejects the
+        // declaration itself, so the body bytes never need to follow.
+        var buffer = channel.allocator.buffer(capacity: 64)
+        buffer.writeString("* 1 FETCH (BODY[TEXT] {100}\r\n")
+        #expect(throws: Error.self) {
+            try channel.writeInbound(buffer)
+        }
+        channel.embeddedEventLoop.run()
+        #expect(channel.isActive == false, "A violation from the real decoder has to close the connection")
+    }
+
     /// Deliberately narrow. `errorCaught` sees unrelated failures too, and tearing the connection
     /// down for those would change behaviour far outside this feature.
     @Test("An unrelated error does not close the channel")

--- a/Tests/SwiftIMAPTests/IMAPSecurityPolicyPropagationTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPSecurityPolicyPropagationTests.swift
@@ -14,7 +14,7 @@ import NIOIMAPCore
 ///
 /// These assert on the spawned connection itself rather than on a factory in isolation. Remove
 /// either argument from either factory and they go red.
-@Suite("Server policy reaches spawned connections")
+@Suite("Server policy reaches spawned connections", .serialized, .timeLimit(.minutes(1)))
 struct IMAPSecurityPolicyPropagationTests {
 
     private func makeServer() -> SwiftMail.IMAPServer {
@@ -40,13 +40,15 @@ struct IMAPSecurityPolicyPropagationTests {
     @Test("IDLE connections inherit the TLS floor and the parser limits")
     func idleConnectionInheritsPolicy() async {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
         let connection = await makeServer().makeIdleConnection(
             sessionID: UUID(), mailbox: "INBOX", group: group
         )
         #expect(connection.minimumTLSVersion == MailTLSMinimumVersion.tlsv13)
         #expect(connection.parserLimits.bodySizeLimit == 64 * 1024 * 1024)
         #expect(connection.parserLimits.messageAttributeLimit == 1024)
+        // Not in a `defer` with a detached `Task`: that would let the shutdown outlive the test.
+        // This function is async and cannot throw, so awaiting here is both simpler and correct.
+        await shutDownGracefully(group)
     }
 }
 

--- a/Tests/SwiftIMAPTests/IMAPSecurityPolicyPropagationTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPSecurityPolicyPropagationTests.swift
@@ -1,0 +1,91 @@
+import Testing
+import Foundation
+import NIO
+import NIOIMAPCore
+@testable import SwiftMail
+
+/// Does an `IMAPServer`'s security policy reach the connections it spawns?
+///
+/// `IMAPServer` documents `minimumTLSVersion` and `parserLimits` as server-level policy. They
+/// were applied to the primary connection only: `makeIdleConnection` and `makeNamedConnection`
+/// left both out, so a caller with a TLS 1.3 floor and 64 MiB parser limits got a TLS 1.2 floor
+/// and *unbounded* limits the moment IDLE or a named connection was used — silently, and exactly
+/// where a long-lived connection listens to whatever the server chooses to send.
+///
+/// These assert on the spawned connection itself rather than on a factory in isolation. Remove
+/// either argument from either factory and they go red.
+@Suite("Server policy reaches spawned connections")
+struct IMAPSecurityPolicyPropagationTests {
+
+    private func makeServer() -> SwiftMail.IMAPServer {
+        SwiftMail.IMAPServer(
+            host: "imap.example.com",
+            port: 993,
+            minimumTLSVersion: MailTLSMinimumVersion.tlsv1_3,
+            parserLimits: IMAPParserLimits(
+                bodySizeLimit: 64 * 1024 * 1024,
+                messageAttributeLimit: 1024
+            )
+        )
+    }
+
+    @Test("Named connections inherit the TLS floor and the parser limits")
+    func namedConnectionInheritsPolicy() async {
+        let connection = await makeServer().makeNamedConnection(name: "sync")
+        #expect(connection.minimumTLSVersion == MailTLSMinimumVersion.tlsv1_3)
+        #expect(connection.parserLimits.bodySizeLimit == 64 * 1024 * 1024)
+        #expect(connection.parserLimits.messageAttributeLimit == 1024)
+    }
+
+    @Test("IDLE connections inherit the TLS floor and the parser limits")
+    func idleConnectionInheritsPolicy() async {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        let connection = await makeServer().makeIdleConnection(
+            sessionID: UUID(), mailbox: "INBOX", group: group
+        )
+        #expect(connection.minimumTLSVersion == MailTLSMinimumVersion.tlsv1_3)
+        #expect(connection.parserLimits.bodySizeLimit == 64 * 1024 * 1024)
+        #expect(connection.parserLimits.messageAttributeLimit == 1024)
+    }
+}
+
+/// Do the documented limits mean what they say?
+///
+/// `IMAPParserLimits` documents its properties as *maxima*. The pinned parser enforces strict
+/// inequalities (`size < bodySizeLimit`, `attributeCount < messageAttributeLimit`, the latter
+/// checked again on the FETCH closing delimiter), so passing the values through unchanged made
+/// the effective maximum one less than the documented one: a 64 MiB limit rejected a message of
+/// exactly 64 MiB.
+@Suite("Parser limits are inclusive maxima")
+struct IMAPParserLimitsTranslationTests {
+
+    @Test("A body of exactly the documented maximum is still allowed")
+    func bodyLimitIsInclusive() {
+        let limits = IMAPParserLimits(bodySizeLimit: 64 * 1024 * 1024)
+        let options = limits.makeParserOptions(bufferLimit: 1024)
+        // The parser rejects `size >= bodySizeLimit`, so accepting exactly 64 MiB needs 64 MiB + 1.
+        #expect(options.bodySizeLimit == 64 * 1024 * 1024 + 1)
+    }
+
+    @Test("A FETCH with exactly the documented number of attributes is still allowed")
+    func attributeLimitIsInclusive() {
+        let options = IMAPParserLimits(messageAttributeLimit: 1024).makeParserOptions(bufferLimit: 1024)
+        #expect(options.messageAttributeLimit == 1025)
+    }
+
+    /// The `+ 1` must saturate: the defaults are `.max`, where `+ 1` would trap — and `.max`
+    /// already means unbounded, so there is nothing to widen.
+    @Test("Unbounded defaults do not overflow")
+    func defaultsDoNotOverflow() {
+        let options = IMAPParserLimits.default.makeParserOptions(bufferLimit: 1024)
+        #expect(options.bodySizeLimit == .max)
+        #expect(options.messageAttributeLimit == .max)
+    }
+
+    @Test("The buffer limit is passed through untouched — it bounds a different thing")
+    func bufferLimitIsUnchanged() {
+        let options = IMAPParserLimits.default.makeParserOptions(bufferLimit: 4096)
+        #expect(options.bufferLimit == 4096)
+    }
+}

--- a/Tests/SwiftIMAPTests/IMAPSecurityPolicyPropagationTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPSecurityPolicyPropagationTests.swift
@@ -21,7 +21,7 @@ struct IMAPSecurityPolicyPropagationTests {
         SwiftMail.IMAPServer(
             host: "imap.example.com",
             port: 993,
-            minimumTLSVersion: MailTLSMinimumVersion.tlsv1_3,
+            minimumTLSVersion: MailTLSMinimumVersion.tlsv13,
             parserLimits: IMAPParserLimits(
                 bodySizeLimit: 64 * 1024 * 1024,
                 messageAttributeLimit: 1024
@@ -32,7 +32,7 @@ struct IMAPSecurityPolicyPropagationTests {
     @Test("Named connections inherit the TLS floor and the parser limits")
     func namedConnectionInheritsPolicy() async {
         let connection = await makeServer().makeNamedConnection(name: "sync")
-        #expect(connection.minimumTLSVersion == MailTLSMinimumVersion.tlsv1_3)
+        #expect(connection.minimumTLSVersion == MailTLSMinimumVersion.tlsv13)
         #expect(connection.parserLimits.bodySizeLimit == 64 * 1024 * 1024)
         #expect(connection.parserLimits.messageAttributeLimit == 1024)
     }
@@ -44,7 +44,7 @@ struct IMAPSecurityPolicyPropagationTests {
         let connection = await makeServer().makeIdleConnection(
             sessionID: UUID(), mailbox: "INBOX", group: group
         )
-        #expect(connection.minimumTLSVersion == MailTLSMinimumVersion.tlsv1_3)
+        #expect(connection.minimumTLSVersion == MailTLSMinimumVersion.tlsv13)
         #expect(connection.parserLimits.bodySizeLimit == 64 * 1024 * 1024)
         #expect(connection.parserLimits.messageAttributeLimit == 1024)
     }

--- a/Tests/SwiftIMAPTests/IMAPTLSFloorEnforcementTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPTLSFloorEnforcementTests.swift
@@ -4,28 +4,10 @@ import NIO
 import NIOSSL
 @testable import SwiftMail
 
-/// Does the configured TLS floor actually reach the socket?
-///
-/// ## Why these tests speak to a real server instead of inspecting a `TLSConfiguration`
-/// Because the bug this file exists for was invisible at that level. `MailTLSConfigurationTests`
-/// asserts that `makeClientConfiguration(minimumTLSVersion: .tlsv1_3)` returns `.tlsv13` — and it
-/// always did. One of those tests is even called *"Raising the floor to TLS 1.3 makes a downgrade
-/// impossible"*. Meanwhile the implicit-TLS call site never passed the value, so on port 993 —
-/// the port every IMAPS client uses — the floor stayed at TLS 1.2 and a downgrade was entirely
-/// possible. The test could not have failed: it verified that a factory returns what it is given,
-/// while the defect was that nobody handed it the value.
-///
-/// A test that cannot produce the failure proves nothing about it. So these connect a real
-/// `IMAPConnection` to a real TLS endpoint that refuses to speak anything above TLS 1.2, and
-/// assert on the outcome. Delete the `minimumTLSVersion:` argument at any call site and one of
-/// them goes red.
-@Suite("TLS floor is honored on the wire")
-struct IMAPTLSFloorEnforcementTests {
-
-    // Self-signed, CN=localhost, generated for this test only and valid for 100 years so it
-    // cannot rot. The client uses `.noVerification`, so trust is not what is under test here —
-    // only the negotiated protocol version is.
-    static let certPEM = """
+// Self-signed, CN=localhost, generated for these tests only and valid for 100 years so it cannot
+// rot. The client uses `.noVerification`, so trust is not what is under test here — only the
+// negotiated protocol version is.
+private let testCertPEM = """
 -----BEGIN CERTIFICATE-----
 MIIDCzCCAfOgAwIBAgIUXe8RGk02W2OBGgsbJaE3Jz+qGDAwDQYJKoZIhvcNAQEL
 BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MCAXDTI2MDcxNzA2MzgwMVoYDzIxMjYw
@@ -47,7 +29,7 @@ Zd1/bKfP3R/4cigBAFE2
 -----END CERTIFICATE-----
 """
 
-    static let keyPEM = """
+private let testKeyPEM = """
 -----BEGIN PRIVATE KEY-----
 MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC6tGyMaCTVGIle
 GyZy0fRdOmTzTiuzt67OYOjeZRz1KxzfHPcx6Cm1eYv0x5WiMt6rEtv8wDEt3nxg
@@ -78,64 +60,82 @@ KHpDM5nC0c2igQREhdC5dYsH
 -----END PRIVATE KEY-----
 """
 
-    /// A TLS endpoint that will not negotiate above TLS 1.2, and greets like an IMAP server.
-    ///
-    /// This is the piece that makes the failure reproducible: a real downgraded peer. Without it
-    /// there is nothing for a TLS 1.3 floor to refuse.
-    private final class TLS12OnlyServer {
-        let channel: Channel
-        let group: EventLoopGroup
+/// Sends an IMAP greeting once TLS is up, so a successful handshake is observable.
+private final class GreetingSender: ChannelInboundHandler {
+    typealias InboundIn = ByteBuffer
+    typealias OutboundOut = ByteBuffer
 
-        var port: Int { channel.localAddress?.port ?? 0 }
-
-        init() throws {
-            group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-
-            let cert = try NIOSSLCertificate(bytes: Array(certPEM.utf8), format: .pem)
-            let key = try NIOSSLPrivateKey(bytes: Array(keyPEM.utf8), format: .pem)
-
-            var configuration = TLSConfiguration.makeServerConfiguration(
-                certificateChain: [.certificate(cert)],
-                privateKey: .privateKey(key)
-            )
-            // The whole point: this peer cannot go above 1.2.
-            configuration.minimumTLSVersion = .tlsv12
-            configuration.maximumTLSVersion = .tlsv12
-
-            let context = try NIOSSLContext(configuration: configuration)
-
-            channel = try ServerBootstrap(group: group)
-                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-                .childChannelInitializer { channel in
-                    do {
-                        try channel.pipeline.syncOperations.addHandler(NIOSSLServerHandler(context: context))
-                        try channel.pipeline.syncOperations.addHandler(GreetingSender())
-                        return channel.eventLoop.makeSucceededFuture(())
-                    } catch {
-                        return channel.eventLoop.makeFailedFuture(error)
-                    }
-                }
-                .bind(host: "127.0.0.1", port: 0)
-                .wait()
-        }
-
-        func shutdown() {
-            try? channel.close().wait()
-            try? group.syncShutdownGracefully()
-        }
-
-        /// Sends an IMAP greeting once TLS is up, so a successful handshake is observable.
-        private final class GreetingSender: ChannelInboundHandler {
-            typealias InboundIn = ByteBuffer
-            typealias OutboundOut = ByteBuffer
-
-            func channelActive(context: ChannelHandlerContext) {
-                var buffer = context.channel.allocator.buffer(capacity: 64)
-                buffer.writeString("* OK [CAPABILITY IMAP4rev1] Test server ready\r\n")
-                context.writeAndFlush(self.wrapOutboundOut(buffer), promise: nil)
-            }
-        }
+    func channelActive(context: ChannelHandlerContext) {
+        var buffer = context.channel.allocator.buffer(capacity: 64)
+        buffer.writeString("* OK [CAPABILITY IMAP4rev1] Test server ready\r\n")
+        context.writeAndFlush(self.wrapOutboundOut(buffer), promise: nil)
     }
+}
+
+/// A TLS endpoint that will not negotiate above TLS 1.2, and greets like an IMAP server.
+///
+/// This is the piece that makes the failure reproducible: a real downgraded peer. Without one
+/// there is nothing for a TLS 1.3 floor to refuse, which is exactly why the existing
+/// configuration-level tests could not catch this.
+private final class TLS12OnlyServer {
+    let channel: Channel
+    let group: EventLoopGroup
+
+    var port: Int { channel.localAddress?.port ?? 0 }
+
+    init() throws {
+        group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+
+        let cert = try NIOSSLCertificate(bytes: Array(testCertPEM.utf8), format: .pem)
+        let key = try NIOSSLPrivateKey(bytes: Array(testKeyPEM.utf8), format: .pem)
+
+        var configuration = TLSConfiguration.makeServerConfiguration(
+            certificateChain: [.certificate(cert)],
+            privateKey: .privateKey(key)
+        )
+        // The whole point: this peer cannot go above TLS 1.2.
+        configuration.minimumTLSVersion = .tlsv12
+        configuration.maximumTLSVersion = .tlsv12
+
+        let context = try NIOSSLContext(configuration: configuration)
+
+        channel = try ServerBootstrap(group: group)
+            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+            .childChannelInitializer { channel in
+                do {
+                    try channel.pipeline.syncOperations.addHandler(NIOSSLServerHandler(context: context))
+                    try channel.pipeline.syncOperations.addHandler(GreetingSender())
+                    return channel.eventLoop.makeSucceededFuture(())
+                } catch {
+                    return channel.eventLoop.makeFailedFuture(error)
+                }
+            }
+            .bind(host: "127.0.0.1", port: 0)
+            .wait()
+    }
+
+    func shutdown() {
+        try? channel.close().wait()
+        try? group.syncShutdownGracefully()
+    }
+}
+
+/// Does the configured TLS floor actually reach the socket?
+///
+/// ## Why these tests speak to a real server instead of inspecting a `TLSConfiguration`
+/// Because the defect this file exists for was invisible at that level. `MailTLSConfigurationTests`
+/// asserts that `makeClientConfiguration(minimumTLSVersion: .tlsv13)` returns `.tlsv13` — and it
+/// always did. One of its cases was even named *"Raising the floor to TLS 1.3 makes a downgrade
+/// impossible"*. Meanwhile the implicit-TLS call site never passed the value, so on port 993 — the
+/// port every IMAPS client uses — the floor stayed at TLS 1.2 and a downgrade was entirely
+/// possible. That test could not have failed: it verified that a factory returns what it is given,
+/// while the defect was that nobody handed it the value.
+///
+/// A test that cannot produce the failure proves nothing about it. So these connect a real
+/// `IMAPConnection` to a real TLS endpoint that refuses to speak anything above TLS 1.2 and assert
+/// on the outcome. Drop the `minimumTLSVersion:` argument at any call site and one goes red.
+@Suite("TLS floor is honored on the wire")
+struct IMAPTLSFloorEnforcementTests {
 
     private func makeConnection(
         port: Int,
@@ -159,7 +159,7 @@ KHpDM5nC0c2igQREhdC5dYsH
         )
     }
 
-    /// 🔴 The regression test for the reported defect: implicit TLS on port 993 ignored the floor.
+    /// The regression test for the reported defect: implicit TLS on port 993 ignored the floor.
     @Test("Implicit TLS refuses a TLS 1.2 peer when the floor is TLS 1.3")
     func implicitTLSHonorsFloor() async throws {
         let server = try TLS12OnlyServer()
@@ -168,15 +168,15 @@ KHpDM5nC0c2igQREhdC5dYsH
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { try? group.syncShutdownGracefully() }
 
-        let connection = makeConnection(port: server.port, minimumTLSVersion: .tlsv1_3, group: group)
+        let connection = makeConnection(port: server.port, minimumTLSVersion: .tlsv13, group: group)
         await #expect(throws: Error.self) {
             try await connection.connect()
         }
         try? await connection.disconnect()
     }
 
-    /// The control. Without it the test above proves only "connecting fails", which it would
-    /// also do if the port were closed, the certificate rejected, or the greeting malformed.
+    /// The control. Without it the test above proves only "connecting fails", which it would also
+    /// do if the port were closed, the certificate rejected, or the greeting malformed.
     @Test("The same peer connects when the floor is TLS 1.2")
     func tls12FloorConnects() async throws {
         let server = try TLS12OnlyServer()
@@ -185,7 +185,7 @@ KHpDM5nC0c2igQREhdC5dYsH
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         defer { try? group.syncShutdownGracefully() }
 
-        let connection = makeConnection(port: server.port, minimumTLSVersion: .tlsv1_2, group: group)
+        let connection = makeConnection(port: server.port, minimumTLSVersion: .tlsv12, group: group)
         try await connection.connect()
         try? await connection.disconnect()
     }

--- a/Tests/SwiftIMAPTests/IMAPTLSFloorEnforcementTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPTLSFloorEnforcementTests.swift
@@ -61,6 +61,33 @@ KHpDM5nC0c2igQREhdC5dYsH
 -----END PRIVATE KEY-----
 """
 
+/// Tears the two handshake channels down without deadlocking on the graceful TLS shutdown.
+///
+/// A bare `finish()` deadlocks here: it does `close().wait()`, and closing a channel whose
+/// handshake completed makes NIOSSL attempt a *graceful* TLS shutdown — it sends close_notify
+/// and completes the close only on the peer's reply or on a timeout it schedules on the event
+/// loop. The handshake pump has stopped by then and an `EmbeddedEventLoop`'s clock never
+/// advances on its own, so on Linux that `wait()` never returned and the whole test run hung
+/// until the CI job timeout (macOS happened to complete the close inline). So: initiate both
+/// closes, pump the close_notify exchange to completion, advance embedded time past any
+/// scheduled shutdown timeout, then finish, accepting an already-closed channel.
+private func shutDownHandshakeChannels(client: EmbeddedChannel, server: EmbeddedChannel) {
+    client.close(promise: nil)
+    server.close(promise: nil)
+    for _ in 0..<4 {
+        if let bytes = ((try? client.readOutbound(as: ByteBuffer.self)) ?? nil) {
+            _ = try? server.writeInbound(bytes)
+        }
+        if let bytes = ((try? server.readOutbound(as: ByteBuffer.self)) ?? nil) {
+            _ = try? client.writeInbound(bytes)
+        }
+    }
+    client.embeddedEventLoop.advanceTime(by: .seconds(10))
+    server.embeddedEventLoop.advanceTime(by: .seconds(10))
+    _ = try? client.finish(acceptAlreadyClosed: true)
+    _ = try? server.finish(acceptAlreadyClosed: true)
+}
+
 /// Runs a TLS handshake between two `EmbeddedChannel`s and returns the error, if any.
 ///
 /// ## Why in-memory rather than a real socket
@@ -81,10 +108,7 @@ private func handshakeError(
 ) throws -> Error? {
     let client = EmbeddedChannel()
     let server = EmbeddedChannel()
-    defer {
-        _ = try? client.finish()
-        _ = try? server.finish()
-    }
+    defer { shutDownHandshakeChannels(client: client, server: server) }
 
     let certificate = try NIOSSLCertificate(bytes: Array(testCertPEM.utf8), format: .pem)
     let privateKey = try NIOSSLPrivateKey(bytes: Array(testKeyPEM.utf8), format: .pem)

--- a/Tests/SwiftIMAPTests/IMAPTLSFloorEnforcementTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPTLSFloorEnforcementTests.swift
@@ -83,7 +83,14 @@ private final class TLS12OnlyServer {
 
     var port: Int { channel.localAddress?.port ?? 0 }
 
-    init() throws {
+    /// - Note: `async`, because `bind(...).wait()` blocks — and blocking here is what hung the
+    ///   macOS CI job. It is the same trap as `syncShutdownGracefully()` (see
+    ///   ``shutDownGracefully(_:)``) wearing a different hat: any `.wait()` reached from a
+    ///   swift-testing test blocks a cooperative-pool thread, and a core-constrained runner then
+    ///   loses its forward-progress guarantee. It also defeats `.timeLimit` — a blocked thread
+    ///   cannot be cancelled, so the suite runs into the job timeout instead of failing.
+    ///   Nothing else in this test suite calls `.wait()`; that was the hint.
+    init() async throws {
         group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
         let cert = try NIOSSLCertificate(bytes: Array(testCertPEM.utf8), format: .pem)
@@ -99,7 +106,7 @@ private final class TLS12OnlyServer {
 
         let context = try NIOSSLContext(configuration: configuration)
 
-        channel = try ServerBootstrap(group: group)
+        channel = try await ServerBootstrap(group: group)
             .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
             .childChannelInitializer { channel in
                 do {
@@ -111,7 +118,7 @@ private final class TLS12OnlyServer {
                 }
             }
             .bind(host: "127.0.0.1", port: 0)
-            .wait()
+            .get()
     }
 
     /// - Note: `async`, and the group shutdown goes through ``shutDownGracefully(_:)``.
@@ -164,7 +171,7 @@ struct IMAPTLSFloorEnforcementTests {
     /// The regression test for the reported defect: implicit TLS on port 993 ignored the floor.
     @Test("Implicit TLS refuses a TLS 1.2 peer when the floor is TLS 1.3")
     func implicitTLSHonorsFloor() async throws {
-        let server = try TLS12OnlyServer()
+        let server = try await TLS12OnlyServer()
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
         let connection = makeConnection(port: server.port, minimumTLSVersion: .tlsv13, group: group)
@@ -181,7 +188,7 @@ struct IMAPTLSFloorEnforcementTests {
     /// do if the port were closed, the certificate rejected, or the greeting malformed.
     @Test("The same peer connects when the floor is TLS 1.2")
     func tls12FloorConnects() async throws {
-        let server = try TLS12OnlyServer()
+        let server = try await TLS12OnlyServer()
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
 
         let connection = makeConnection(port: server.port, minimumTLSVersion: .tlsv12, group: group)

--- a/Tests/SwiftIMAPTests/IMAPTLSFloorEnforcementTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPTLSFloorEnforcementTests.swift
@@ -1,0 +1,192 @@
+import Testing
+import Foundation
+import NIO
+import NIOSSL
+@testable import SwiftMail
+
+/// Does the configured TLS floor actually reach the socket?
+///
+/// ## Why these tests speak to a real server instead of inspecting a `TLSConfiguration`
+/// Because the bug this file exists for was invisible at that level. `MailTLSConfigurationTests`
+/// asserts that `makeClientConfiguration(minimumTLSVersion: .tlsv1_3)` returns `.tlsv13` — and it
+/// always did. One of those tests is even called *"Raising the floor to TLS 1.3 makes a downgrade
+/// impossible"*. Meanwhile the implicit-TLS call site never passed the value, so on port 993 —
+/// the port every IMAPS client uses — the floor stayed at TLS 1.2 and a downgrade was entirely
+/// possible. The test could not have failed: it verified that a factory returns what it is given,
+/// while the defect was that nobody handed it the value.
+///
+/// A test that cannot produce the failure proves nothing about it. So these connect a real
+/// `IMAPConnection` to a real TLS endpoint that refuses to speak anything above TLS 1.2, and
+/// assert on the outcome. Delete the `minimumTLSVersion:` argument at any call site and one of
+/// them goes red.
+@Suite("TLS floor is honored on the wire")
+struct IMAPTLSFloorEnforcementTests {
+
+    // Self-signed, CN=localhost, generated for this test only and valid for 100 years so it
+    // cannot rot. The client uses `.noVerification`, so trust is not what is under test here —
+    // only the negotiated protocol version is.
+    static let certPEM = """
+-----BEGIN CERTIFICATE-----
+MIIDCzCCAfOgAwIBAgIUXe8RGk02W2OBGgsbJaE3Jz+qGDAwDQYJKoZIhvcNAQEL
+BQAwFDESMBAGA1UEAwwJbG9jYWxob3N0MCAXDTI2MDcxNzA2MzgwMVoYDzIxMjYw
+NjIzMDYzODAxWjAUMRIwEAYDVQQDDAlsb2NhbGhvc3QwggEiMA0GCSqGSIb3DQEB
+AQUAA4IBDwAwggEKAoIBAQC6tGyMaCTVGIleGyZy0fRdOmTzTiuzt67OYOjeZRz1
+KxzfHPcx6Cm1eYv0x5WiMt6rEtv8wDEt3nxg2UQVi6NYx7NV8OVXex1dHnYmcxvv
+5NrwM2f2SEKL9dZKJeNbYMeHEEPkN4HSVr/Lpw4VwhJhZx5HOTPdLbkkrNiVOXfD
+nM1SahyGtPF9xpwfxZJGkdsq5CLyPEX7Vju1zumJpCV9nsR/fl9h2WsfTckYq6Pu
+gvC3SKi0lW6BbNVsbmC7mPtLu8AM+9bb/3ZiDxBZiukBkP88H5Qm+Yuc5UhvTSJJ
+8DlG58jAIJhX0GTr8dAKnr5Ew9xq8snHmPe9vV6yO7edAgMBAAGjUzBRMB0GA1Ud
+DgQWBBTJLtTBgKxmIz00Glojehq4GEl4oTAfBgNVHSMEGDAWgBTJLtTBgKxmIz00
+Glojehq4GEl4oTAPBgNVHRMBAf8EBTADAQH/MA0GCSqGSIb3DQEBCwUAA4IBAQCU
+i62pqGcUlAUC/+n/zke/WGbnc20VhwqsU+lu1pOisuycvBAmtjRJJPZzWf+vQjWf
+ipTv9l7QLY9924s7UcXvW9Kh0CIoqzByJeH+ZXrjqA3cNxjHbrZnnjdQ08Q0fRz7
+I79wtMJeH4vvrimh+RPzuE+8AAaYu9pCxrH6X24OqMidwIICgq8zZfuL08Dlalgs
+ftmQct191ESHfS6+xMejMo4tp7cJib5z5i1lInblRAKCEpTuBdwfRq0ZDf2NaRPS
+2apVKzJgv/Ogi1+PRCmbGH/CtBweOEH2Jc/cC2ufO8A0ED6bI2jGLQiYiUWugLO4
+Zd1/bKfP3R/4cigBAFE2
+-----END CERTIFICATE-----
+"""
+
+    static let keyPEM = """
+-----BEGIN PRIVATE KEY-----
+MIIEvgIBADANBgkqhkiG9w0BAQEFAASCBKgwggSkAgEAAoIBAQC6tGyMaCTVGIle
+GyZy0fRdOmTzTiuzt67OYOjeZRz1KxzfHPcx6Cm1eYv0x5WiMt6rEtv8wDEt3nxg
+2UQVi6NYx7NV8OVXex1dHnYmcxvv5NrwM2f2SEKL9dZKJeNbYMeHEEPkN4HSVr/L
+pw4VwhJhZx5HOTPdLbkkrNiVOXfDnM1SahyGtPF9xpwfxZJGkdsq5CLyPEX7Vju1
+zumJpCV9nsR/fl9h2WsfTckYq6PugvC3SKi0lW6BbNVsbmC7mPtLu8AM+9bb/3Zi
+DxBZiukBkP88H5Qm+Yuc5UhvTSJJ8DlG58jAIJhX0GTr8dAKnr5Ew9xq8snHmPe9
+vV6yO7edAgMBAAECggEAIzKOYC3l+7JjezU9G1pPah/vFhs/i+Lt9oQ4gmynd+TH
+zZwFUghFjKu8YcoagHh8l923UT/eRZpy8kMjXbh0c/E58tK2ObbBA2QRvA/pTWFk
+kPHwAHMA8KfI3TOlV/23v9OmKOj59XBbOgZlVl6+3lP1VlIHYAQVqj9XmVI7LMoZ
+R30Hrhy0C9dJguqlFwgkiiRnM/3SAtpeqYqSYInfBaxiM4YdTOCOKlnTXmiY9a4U
+GUvhof2H+OcY8JtADT26W7+FxXmzRnM8mGqQbiQu1PduJqOrG5eef2WSET6ikude
+B7HvydtBp2LtCzfqg/5GwV93NcCbBzfwCunp9CvRIQKBgQDhM0xAZUU24MXiGN/k
+nTD7NRoikLeLcnxGIAWt4c1f10bdTxeaJPZKeLqHuFu2y1IZkSVye30OyVyhVlZM
+EzMiLRPwAWt9Pg5zGTp7MU0y5jQWBNU2Dw6wVtNUTpZgd1nzrc2pRjZffdSVnuHD
+QJ47n69NHjrASWBiTCfPDM4b2QKBgQDUPVINDGW3vhtoPU47r4cM9XVvP1RTaoeV
+0UT0ukETm/Q9ouVFmcJDoOsyyMOkUgSbZ4gJ3QgBbrDp7y1jZ9vGpeZWAJfQhyi/
+6LngldwZKvW97gGfpbEWGTWKpO/IhlunxRJCihNsnkwHsudxjdWaiu04b3iDVReC
+N+EBtcKzZQKBgQDAX8HTgK8PohNogTdBY8Zj0Yjx3g3s4W+nt9MiJrH6HTw78USI
+OOrr0xYEukgebrFDheonUbYS25B1gftWIVCc8UUG0S+xXUGasQJ0GjmIMX5tENPR
+yisSGBmO+1MaNNpyfxYgdAoeqK7g4UiaMqj45gAqMJifig776XJYPOgUgQKBgFnI
+hwlWEUGlflqedJXzLyJgRAmHtNiE3E6YdJ9Cm3z8IFpiqrLC1NdfH6AgJgNBXwmO
+xpHFmzlf5h9QOtcufF6Ql9wR7CcexjJI9Tj4rF9JOSPbp3wtz7gVefzowTcG/4b9
+azgSyRzN6kPnftkesxnpY2jYXxbPzF4d3WWnynGxAoGBAMogoBY3AZ8wWruR7A3I
+Scf2C2aS8QMgz5JWkgoDnpC3NrpxA3uj7uUz847pzV3MkXzMrDm/UHAp2QoEMIkP
+dHofjPtGL9tWBGy3QyWm0BxKvxipJMaBy/HHwjIQw9RqOS/JYqVJIhPMlJmRYsYX
+KHpDM5nC0c2igQREhdC5dYsH
+-----END PRIVATE KEY-----
+"""
+
+    /// A TLS endpoint that will not negotiate above TLS 1.2, and greets like an IMAP server.
+    ///
+    /// This is the piece that makes the failure reproducible: a real downgraded peer. Without it
+    /// there is nothing for a TLS 1.3 floor to refuse.
+    private final class TLS12OnlyServer {
+        let channel: Channel
+        let group: EventLoopGroup
+
+        var port: Int { channel.localAddress?.port ?? 0 }
+
+        init() throws {
+            group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+
+            let cert = try NIOSSLCertificate(bytes: Array(certPEM.utf8), format: .pem)
+            let key = try NIOSSLPrivateKey(bytes: Array(keyPEM.utf8), format: .pem)
+
+            var configuration = TLSConfiguration.makeServerConfiguration(
+                certificateChain: [.certificate(cert)],
+                privateKey: .privateKey(key)
+            )
+            // The whole point: this peer cannot go above 1.2.
+            configuration.minimumTLSVersion = .tlsv12
+            configuration.maximumTLSVersion = .tlsv12
+
+            let context = try NIOSSLContext(configuration: configuration)
+
+            channel = try ServerBootstrap(group: group)
+                .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
+                .childChannelInitializer { channel in
+                    do {
+                        try channel.pipeline.syncOperations.addHandler(NIOSSLServerHandler(context: context))
+                        try channel.pipeline.syncOperations.addHandler(GreetingSender())
+                        return channel.eventLoop.makeSucceededFuture(())
+                    } catch {
+                        return channel.eventLoop.makeFailedFuture(error)
+                    }
+                }
+                .bind(host: "127.0.0.1", port: 0)
+                .wait()
+        }
+
+        func shutdown() {
+            try? channel.close().wait()
+            try? group.syncShutdownGracefully()
+        }
+
+        /// Sends an IMAP greeting once TLS is up, so a successful handshake is observable.
+        private final class GreetingSender: ChannelInboundHandler {
+            typealias InboundIn = ByteBuffer
+            typealias OutboundOut = ByteBuffer
+
+            func channelActive(context: ChannelHandlerContext) {
+                var buffer = context.channel.allocator.buffer(capacity: 64)
+                buffer.writeString("* OK [CAPABILITY IMAP4rev1] Test server ready\r\n")
+                context.writeAndFlush(self.wrapOutboundOut(buffer), promise: nil)
+            }
+        }
+    }
+
+    private func makeConnection(
+        port: Int,
+        minimumTLSVersion: MailTLSMinimumVersion,
+        group: EventLoopGroup
+    ) -> IMAPConnection {
+        IMAPConnection(
+            host: "localhost",
+            port: port,
+            transportSecurity: .implicitTLS,
+            // Not what is under test — the certificate is self-signed on purpose.
+            certificateVerificationPolicy: .noVerification,
+            minimumTLSVersion: minimumTLSVersion,
+            group: group,
+            loggerLabel: "test",
+            outboundLabel: "test.out",
+            inboundLabel: "test.in",
+            connectionID: "test",
+            connectionRole: "test",
+            parserLimits: .default
+        )
+    }
+
+    /// 🔴 The regression test for the reported defect: implicit TLS on port 993 ignored the floor.
+    @Test("Implicit TLS refuses a TLS 1.2 peer when the floor is TLS 1.3")
+    func implicitTLSHonorsFloor() async throws {
+        let server = try TLS12OnlyServer()
+        defer { server.shutdown() }
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+
+        let connection = makeConnection(port: server.port, minimumTLSVersion: .tlsv1_3, group: group)
+        await #expect(throws: Error.self) {
+            try await connection.connect()
+        }
+        try? await connection.disconnect()
+    }
+
+    /// The control. Without it the test above proves only "connecting fails", which it would
+    /// also do if the port were closed, the certificate rejected, or the greeting malformed.
+    @Test("The same peer connects when the floor is TLS 1.2")
+    func tls12FloorConnects() async throws {
+        let server = try TLS12OnlyServer()
+        defer { server.shutdown() }
+
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+
+        let connection = makeConnection(port: server.port, minimumTLSVersion: .tlsv1_2, group: group)
+        try await connection.connect()
+        try? await connection.disconnect()
+    }
+}

--- a/Tests/SwiftIMAPTests/IMAPTLSFloorEnforcementTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPTLSFloorEnforcementTests.swift
@@ -1,12 +1,13 @@
 import Testing
 import Foundation
 import NIO
+import NIOEmbedded
 import NIOSSL
 @testable import SwiftMail
 
 // Self-signed, CN=localhost, generated for these tests only and valid for 100 years so it cannot
-// rot. The client uses `.noVerification`, so trust is not what is under test here — only the
-// negotiated protocol version is.
+// rot. The client uses `.noVerification`: trust is not what is under test here, only the
+// negotiated protocol version.
 private let testCertPEM = """
 -----BEGIN CERTIFICATE-----
 MIIDCzCCAfOgAwIBAgIUXe8RGk02W2OBGgsbJaE3Jz+qGDAwDQYJKoZIhvcNAQEL
@@ -60,142 +61,122 @@ KHpDM5nC0c2igQREhdC5dYsH
 -----END PRIVATE KEY-----
 """
 
-/// Sends an IMAP greeting once TLS is up, so a successful handshake is observable.
-private final class GreetingSender: ChannelInboundHandler {
-    typealias InboundIn = ByteBuffer
-    typealias OutboundOut = ByteBuffer
-
-    func channelActive(context: ChannelHandlerContext) {
-        var buffer = context.channel.allocator.buffer(capacity: 64)
-        buffer.writeString("* OK [CAPABILITY IMAP4rev1] Test server ready\r\n")
-        context.writeAndFlush(self.wrapOutboundOut(buffer), promise: nil)
-    }
-}
-
-/// A TLS endpoint that will not negotiate above TLS 1.2, and greets like an IMAP server.
+/// Runs a TLS handshake between two `EmbeddedChannel`s and returns the error, if any.
 ///
-/// This is the piece that makes the failure reproducible: a real downgraded peer. Without one
-/// there is nothing for a TLS 1.3 floor to refuse, which is exactly why the existing
-/// configuration-level tests could not catch this.
-private final class TLS12OnlyServer {
-    let channel: Channel
-    let group: MultiThreadedEventLoopGroup
+/// ## Why in-memory rather than a real socket
+/// The first version of this test bound a real TLS server and connected to it. It worked, and it
+/// hung the macOS CI job: real sockets need a `MultiThreadedEventLoopGroup`, its teardown needs
+/// `syncShutdownGracefully()`, and every blocking step reachable from a swift-testing test costs
+/// a cooperative-pool thread. On a core-constrained runner the pool starves and the whole run
+/// stalls — 29 of 346 tests completed, then nothing, until the job timeout. It even defeats
+/// `.timeLimit`, because a blocked thread cannot be cancelled.
+///
+/// `EmbeddedChannel` has no threads, no sockets and no event loop to shut down: it runs
+/// everything inline on the calling thread. The handshake is real — same `NIOSSLClientHandler`
+/// built by the same `makeTLSHandler` the connection bootstrap uses, same BoringSSL, same
+/// version negotiation — only the transport is a byte pump instead of a socket.
+private func handshakeError(
+    clientFloor: MailTLSMinimumVersion,
+    serverMaximum: TLSVersion
+) throws -> Error? {
+    let client = EmbeddedChannel()
+    let server = EmbeddedChannel()
+    defer {
+        _ = try? client.finish()
+        _ = try? server.finish()
+    }
 
-    var port: Int { channel.localAddress?.port ?? 0 }
+    let certificate = try NIOSSLCertificate(bytes: Array(testCertPEM.utf8), format: .pem)
+    let privateKey = try NIOSSLPrivateKey(bytes: Array(testKeyPEM.utf8), format: .pem)
 
-    /// - Note: `async`, because `bind(...).wait()` blocks — and blocking here is what hung the
-    ///   macOS CI job. It is the same trap as `syncShutdownGracefully()` (see
-    ///   ``shutDownGracefully(_:)``) wearing a different hat: any `.wait()` reached from a
-    ///   swift-testing test blocks a cooperative-pool thread, and a core-constrained runner then
-    ///   loses its forward-progress guarantee. It also defeats `.timeLimit` — a blocked thread
-    ///   cannot be cancelled, so the suite runs into the job timeout instead of failing.
-    ///   Nothing else in this test suite calls `.wait()`; that was the hint.
-    init() async throws {
-        group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+    var serverConfiguration = TLSConfiguration.makeServerConfiguration(
+        certificateChain: [.certificate(certificate)],
+        privateKey: .privateKey(privateKey)
+    )
+    // The peer under test: it cannot go above this version.
+    serverConfiguration.maximumTLSVersion = serverMaximum
+    let serverContext = try NIOSSLContext(configuration: serverConfiguration)
+    try server.pipeline.syncOperations.addHandler(NIOSSLServerHandler(context: serverContext))
 
-        let cert = try NIOSSLCertificate(bytes: Array(testCertPEM.utf8), format: .pem)
-        let key = try NIOSSLPrivateKey(bytes: Array(testKeyPEM.utf8), format: .pem)
+    // The client handler comes from the same factory the real bootstrap calls, with the same
+    // arguments — this is the code path the reported defect lived in.
+    let clientHandler = try IMAPConnection.makeTLSHandler(
+        for: client,
+        host: "localhost",
+        certificateVerificationPolicy: .noVerification,
+        minimumTLSVersion: clientFloor
+    )
+    try client.pipeline.syncOperations.addHandler(clientHandler)
 
-        var configuration = TLSConfiguration.makeServerConfiguration(
-            certificateChain: [.certificate(cert)],
-            privateKey: .privateKey(key)
-        )
-        // The whole point: this peer cannot go above TLS 1.2.
-        configuration.minimumTLSVersion = .tlsv12
-        configuration.maximumTLSVersion = .tlsv12
+    try client.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 993)).wait()
+    try server.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 993)).wait()
 
-        let context = try NIOSSLContext(configuration: configuration)
-
-        channel = try await ServerBootstrap(group: group)
-            .serverChannelOption(ChannelOptions.socketOption(.so_reuseaddr), value: 1)
-            .childChannelInitializer { channel in
-                do {
-                    try channel.pipeline.syncOperations.addHandler(NIOSSLServerHandler(context: context))
-                    try channel.pipeline.syncOperations.addHandler(GreetingSender())
-                    return channel.eventLoop.makeSucceededFuture(())
-                } catch {
-                    return channel.eventLoop.makeFailedFuture(error)
-                }
+    // Pump bytes between the two until neither has anything left to say. Any handshake failure
+    // surfaces as a throw from `writeInbound`.
+    do {
+        var moved = true
+        while moved {
+            moved = false
+            if let outbound = try client.readOutbound(as: ByteBuffer.self) {
+                moved = true
+                try server.writeInbound(outbound)
             }
-            .bind(host: "127.0.0.1", port: 0)
-            .get()
-    }
-
-    /// - Note: `async`, and the group shutdown goes through ``shutDownGracefully(_:)``.
-    ///   Blocking here would deadlock the macOS CI job — see that function.
-    func shutdown() async {
-        try? await channel.close()
-        await shutDownGracefully(group)
+            if let outbound = try server.readOutbound(as: ByteBuffer.self) {
+                moved = true
+                try client.writeInbound(outbound)
+            }
+        }
+        return nil
+    } catch {
+        return error
     }
 }
 
-/// Does the configured TLS floor actually reach the socket?
+/// Is the configured TLS floor actually enforced during the handshake?
 ///
-/// ## Why these tests speak to a real server instead of inspecting a `TLSConfiguration`
-/// Because the defect this file exists for was invisible at that level. `MailTLSConfigurationTests`
-/// asserts that `makeClientConfiguration(minimumTLSVersion: .tlsv13)` returns `.tlsv13` — and it
-/// always did. One of its cases was even named *"Raising the floor to TLS 1.3 makes a downgrade
-/// impossible"*. Meanwhile the implicit-TLS call site never passed the value, so on port 993 — the
-/// port every IMAPS client uses — the floor stayed at TLS 1.2 and a downgrade was entirely
-/// possible. That test could not have failed: it verified that a factory returns what it is given,
-/// while the defect was that nobody handed it the value.
+/// ## What these cover that `MailTLSConfigurationTests` cannot
+/// That suite asserts `makeClientConfiguration(minimumTLSVersion: .tlsv13)` returns `.tlsv13` —
+/// and it always did. One of its cases was even named *"Raising the floor to TLS 1.3 makes a
+/// downgrade impossible"*, while a downgrade on port 993 was entirely possible: the implicit-TLS
+/// call site never passed the value. That test could not have failed, because it verified that a
+/// factory returns what it is handed, and the defect was that nobody handed it the value.
 ///
-/// A test that cannot produce the failure proves nothing about it. So these connect a real
-/// `IMAPConnection` to a real TLS endpoint that refuses to speak anything above TLS 1.2 and assert
-/// on the outcome. Drop the `minimumTLSVersion:` argument at any call site and one goes red.
-@Suite("TLS floor is honored on the wire", .serialized, .timeLimit(.minutes(1)))
+/// These run a real handshake against a peer pinned below the floor, through the same
+/// `makeTLSHandler` the bootstrap uses. Verified by reverting the fix: the first one fails.
+///
+/// ## What they do *not* cover — stated plainly, because the last omission cost a release
+/// They prove the floor is **enforced** once it reaches the handler. They do **not** prove the
+/// call sites **pass** it — which is precisely what the reported defect was. Calling
+/// `makeTLSHandler` directly, as these do, hands it the value the bootstrap forgot.
+///
+/// That gap is closed by the compiler rather than by a test: `makeTLSHandler` and
+/// `IMAPConnection`'s designated initializer no longer default `minimumTLSVersion`, so a call
+/// site that omits it does not build. A guarantee the compiler enforces is worth more than one a
+/// test checks — but it is a different guarantee, and pretending otherwise here would repeat the
+/// mistake this file exists to document. ``IMAPSecurityPolicyPropagationTests`` additionally
+/// asserts that spawned connections carry the configured value.
+@Suite("TLS floor is enforced during the handshake", .timeLimit(.minutes(1)))
 struct IMAPTLSFloorEnforcementTests {
 
-    private func makeConnection(
-        port: Int,
-        minimumTLSVersion: MailTLSMinimumVersion,
-        group: EventLoopGroup
-    ) -> IMAPConnection {
-        IMAPConnection(
-            host: "localhost",
-            port: port,
-            transportSecurity: .implicitTLS,
-            // Not what is under test — the certificate is self-signed on purpose.
-            certificateVerificationPolicy: .noVerification,
-            minimumTLSVersion: minimumTLSVersion,
-            group: group,
-            loggerLabel: "test",
-            outboundLabel: "test.out",
-            inboundLabel: "test.in",
-            connectionID: "test",
-            connectionRole: "test",
-            parserLimits: .default
-        )
+    /// The regression test for the reported defect.
+    @Test("A TLS 1.3 floor refuses a peer that stops at TLS 1.2")
+    func tls13FloorRefusesTLS12Peer() throws {
+        let error = try handshakeError(clientFloor: .tlsv13, serverMaximum: .tlsv12)
+        #expect(error != nil, "A TLS 1.2 peer must not be accepted when the floor is TLS 1.3")
     }
 
-    /// The regression test for the reported defect: implicit TLS on port 993 ignored the floor.
-    @Test("Implicit TLS refuses a TLS 1.2 peer when the floor is TLS 1.3")
-    func implicitTLSHonorsFloor() async throws {
-        let server = try await TLS12OnlyServer()
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-
-        let connection = makeConnection(port: server.port, minimumTLSVersion: .tlsv13, group: group)
-        await #expect(throws: Error.self) {
-            try await connection.connect()
-        }
-
-        try? await connection.disconnect()
-        await server.shutdown()
-        await shutDownGracefully(group)
+    /// The control. Without it the test above proves only "the handshake fails", which it would
+    /// also do for a bad certificate, a broken pump, or a misconfigured server.
+    @Test("The same peer is accepted when the floor is TLS 1.2")
+    func tls12FloorAcceptsTLS12Peer() throws {
+        let error = try handshakeError(clientFloor: .tlsv12, serverMaximum: .tlsv12)
+        #expect(error == nil, "Expected a clean handshake, got: \(String(describing: error))")
     }
 
-    /// The control. Without it the test above proves only "connecting fails", which it would also
-    /// do if the port were closed, the certificate rejected, or the greeting malformed.
-    @Test("The same peer connects when the floor is TLS 1.2")
-    func tls12FloorConnects() async throws {
-        let server = try await TLS12OnlyServer()
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-
-        let connection = makeConnection(port: server.port, minimumTLSVersion: .tlsv12, group: group)
-        try await connection.connect()
-
-        try? await connection.disconnect()
-        await server.shutdown()
-        await shutDownGracefully(group)
+    /// The floor is a floor, not an exact match: a peer that can go higher is fine.
+    @Test("A TLS 1.2 floor still negotiates TLS 1.3 with a capable peer")
+    func tls12FloorAcceptsTLS13Peer() throws {
+        let error = try handshakeError(clientFloor: .tlsv12, serverMaximum: .tlsv13)
+        #expect(error == nil, "Expected a clean handshake, got: \(String(describing: error))")
     }
 }

--- a/Tests/SwiftIMAPTests/IMAPTLSFloorEnforcementTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPTLSFloorEnforcementTests.swift
@@ -79,7 +79,7 @@ private final class GreetingSender: ChannelInboundHandler {
 /// configuration-level tests could not catch this.
 private final class TLS12OnlyServer {
     let channel: Channel
-    let group: EventLoopGroup
+    let group: MultiThreadedEventLoopGroup
 
     var port: Int { channel.localAddress?.port ?? 0 }
 
@@ -114,9 +114,11 @@ private final class TLS12OnlyServer {
             .wait()
     }
 
-    func shutdown() {
-        try? channel.close().wait()
-        try? group.syncShutdownGracefully()
+    /// - Note: `async`, and the group shutdown goes through ``shutDownGracefully(_:)``.
+    ///   Blocking here would deadlock the macOS CI job — see that function.
+    func shutdown() async {
+        try? await channel.close()
+        await shutDownGracefully(group)
     }
 }
 
@@ -134,7 +136,7 @@ private final class TLS12OnlyServer {
 /// A test that cannot produce the failure proves nothing about it. So these connect a real
 /// `IMAPConnection` to a real TLS endpoint that refuses to speak anything above TLS 1.2 and assert
 /// on the outcome. Drop the `minimumTLSVersion:` argument at any call site and one goes red.
-@Suite("TLS floor is honored on the wire")
+@Suite("TLS floor is honored on the wire", .serialized, .timeLimit(.minutes(1)))
 struct IMAPTLSFloorEnforcementTests {
 
     private func makeConnection(
@@ -163,16 +165,16 @@ struct IMAPTLSFloorEnforcementTests {
     @Test("Implicit TLS refuses a TLS 1.2 peer when the floor is TLS 1.3")
     func implicitTLSHonorsFloor() async throws {
         let server = try TLS12OnlyServer()
-        defer { server.shutdown() }
-
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
 
         let connection = makeConnection(port: server.port, minimumTLSVersion: .tlsv13, group: group)
         await #expect(throws: Error.self) {
             try await connection.connect()
         }
+
         try? await connection.disconnect()
+        await server.shutdown()
+        await shutDownGracefully(group)
     }
 
     /// The control. Without it the test above proves only "connecting fails", which it would also
@@ -180,13 +182,13 @@ struct IMAPTLSFloorEnforcementTests {
     @Test("The same peer connects when the floor is TLS 1.2")
     func tls12FloorConnects() async throws {
         let server = try TLS12OnlyServer()
-        defer { server.shutdown() }
-
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
 
         let connection = makeConnection(port: server.port, minimumTLSVersion: .tlsv12, group: group)
         try await connection.connect()
+
         try? await connection.disconnect()
+        await server.shutdown()
+        await shutDownGracefully(group)
     }
 }

--- a/Tests/SwiftIMAPTests/IMAPTestServer.swift
+++ b/Tests/SwiftIMAPTests/IMAPTestServer.swift
@@ -139,7 +139,15 @@ final class IMAPTestServer {
         source.resume()
     }
 
-    func stop() {
+    /// Stops the server and awaits the client handlers' drain.
+    ///
+    /// Async on purpose: the drain used to be `clientGroup.wait(timeout: 2s)`, which parks the
+    /// calling thread — from a swift-testing test that is a cooperative-pool thread, one of ncpu
+    /// on a core-constrained CI runner. The unbounded sibling of that pattern (blocking ELG
+    /// shutdown in `SMTPServer.deinit`) deadlocked the 3-core macOS runner outright. Here the
+    /// continuation is resumed from `DispatchGroup.notify` when the last handler leaves — same
+    /// determinism, same 2-second upper bound, zero threads parked.
+    func stop() async {
         acceptSource?.cancel()
         acceptSource = nil
 
@@ -151,11 +159,49 @@ final class IMAPTestServer {
         }
 
         if !activeClientFds.isEmpty {
-            _ = clientGroup.wait(timeout: .now() + .seconds(2))
+            await awaitClientDrain(timeoutSeconds: 2)
         }
 
         for fileDescriptor in drainClientFds() {
             close(fileDescriptor)
+        }
+    }
+
+    /// Runs `body`, then stops the server — on success and on throw alike. The scoped
+    /// replacement for `defer { stop() }`, which cannot await an async `stop()`.
+    func run<T>(_ body: () async throws -> T) async throws -> T {
+        do {
+            let result = try await body()
+            await stop()
+            return result
+        } catch {
+            await stop()
+            throw error
+        }
+    }
+
+    /// Resumes when the last client handler leaves `clientGroup`, or after `timeoutSeconds` —
+    /// whichever comes first. Both paths arrive as GCD callbacks; nothing blocks anywhere.
+    private func awaitClientDrain(timeoutSeconds: Double) async {
+        final class ResumeOnce: @unchecked Sendable {
+            private let lock = NSLock()
+            private var resumed = false
+            func claim() -> Bool {
+                lock.lock()
+                defer { lock.unlock() }
+                if resumed { return false }
+                resumed = true
+                return true
+            }
+        }
+        let once = ResumeOnce()
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            clientGroup.notify(queue: .global()) {
+                if once.claim() { continuation.resume() }
+            }
+            DispatchQueue.global().asyncAfter(deadline: .now() + timeoutSeconds) {
+                if once.claim() { continuation.resume() }
+            }
         }
     }
 

--- a/Tests/SwiftIMAPTests/IMAPTransportSecurityTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPTransportSecurityTests.swift
@@ -116,12 +116,14 @@ struct IMAPTransportSecurityTests {
                 host: "localhost",
                 port: 143,
                 transportSecurity: .startTLS,
+                minimumTLSVersion: .tlsv1_2,
                 group: group,
                 loggerLabel: "test.imap",
                 outboundLabel: "test.imap.out",
                 inboundLabel: "test.imap.in",
                 connectionID: "test-starttls-failure",
-                connectionRole: "test"
+                connectionRole: "test",
+                parserLimits: .default
             )
             let channel = EmbeddedChannel()
             let address = try SocketAddress(ipAddress: "127.0.0.1", port: 143)

--- a/Tests/SwiftIMAPTests/IMAPTransportSecurityTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPTransportSecurityTests.swift
@@ -116,7 +116,7 @@ struct IMAPTransportSecurityTests {
                 host: "localhost",
                 port: 143,
                 transportSecurity: .startTLS,
-                minimumTLSVersion: .tlsv1_2,
+                minimumTLSVersion: .tlsv12,
                 group: group,
                 loggerLabel: "test.imap",
                 outboundLabel: "test.imap.out",

--- a/Tests/SwiftIMAPTests/IMAPTransportSecurityTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPTransportSecurityTests.swift
@@ -10,12 +10,14 @@ struct IMAPTransportSecurityTests {
     @Test
     func certificateVerificationPolicyMapsToNIOSSLConfiguration() {
         let fullVerification = MailTLSConfiguration.makeClientConfiguration(
-            certificateVerificationPolicy: .fullVerification
+            certificateVerificationPolicy: .fullVerification,
+            minimumTLSVersion: .tlsv12
         )
         #expect(fullVerification.certificateVerification == .fullVerification)
 
         let noVerification = MailTLSConfiguration.makeClientConfiguration(
-            certificateVerificationPolicy: .noVerification
+            certificateVerificationPolicy: .noVerification,
+            minimumTLSVersion: .tlsv12
         )
         #expect(noVerification.certificateVerification == .none)
     }

--- a/Tests/SwiftIMAPTests/MailTLSConfigurationTests.swift
+++ b/Tests/SwiftIMAPTests/MailTLSConfigurationTests.swift
@@ -30,7 +30,13 @@ struct MailTLSConfigurationTests {
         #expect(configuration.minimumTLSVersion == nio)
     }
 
-    @Test("Raising the floor to TLS 1.3 makes a downgrade impossible")
+    /// - Important: This suite covers the *configuration factory* only — that it returns what it
+    ///   is handed. It says nothing about whether any connection passes the value in, which is
+    ///   where the implicit-TLS defect lived: this test was green throughout, under the name
+    ///   *"Raising the floor to TLS 1.3 makes a downgrade impossible"*, while a downgrade on
+    ///   port 993 was entirely possible. Enforcement on the wire is covered by
+    ///   ``IMAPTLSFloorEnforcementTests``, which talks to a TLS-1.2-only peer.
+    @Test("Requesting TLS 1.3 yields a configuration with a TLS 1.3 floor")
     func tls13Floor() {
         let configuration = MailTLSConfiguration.makeClientConfiguration(
             certificateVerificationPolicy: .fullVerification,

--- a/Tests/SwiftIMAPTests/MailTLSConfigurationTests.swift
+++ b/Tests/SwiftIMAPTests/MailTLSConfigurationTests.swift
@@ -2,7 +2,14 @@ import Testing
 import NIOSSL
 @testable import SwiftMail
 
-@Suite("TLS minimum version")
+/// - Note: `.serialized` and `.timeLimit` are not decoration. Constructing an `IMAPServer` or
+///   `SMTPServer` allocates a `MultiThreadedEventLoopGroup`, and `SMTPServer.deinit` shuts it
+///   down with the **blocking** `syncShutdownGracefully()`. Released from a Swift Concurrency
+///   context, that costs a cooperative-pool thread; run in parallel with the rest of the suite on
+///   a core-constrained CI runner, the pool starves and the whole test run stalls. Every
+///   pre-existing suite here that constructs a server carries these traits — this one did not,
+///   and that is what hung the macOS job.
+@Suite("TLS minimum version", .serialized, .timeLimit(.minutes(1)))
 struct MailTLSConfigurationTests {
 
     @Test("Default floor is TLS 1.2, not NIOSSL's TLS 1.0")

--- a/Tests/SwiftIMAPTests/MailTLSConfigurationTests.swift
+++ b/Tests/SwiftIMAPTests/MailTLSConfigurationTests.swift
@@ -12,8 +12,12 @@ struct MailTLSConfigurationTests {
 
     @Test("Default floor is TLS 1.2, not NIOSSL's TLS 1.0")
     func defaultIsTLS12() {
+        // The library-wide default lives on the server initializers — the factory itself
+        // takes the floor explicitly, so "forgot to pass it" cannot compile.
+        #expect(MailTLSMinimumVersion.tlsv12.nioTLSVersion == .tlsv12)
         let configuration = MailTLSConfiguration.makeClientConfiguration(
-            certificateVerificationPolicy: .fullVerification
+            certificateVerificationPolicy: .fullVerification,
+            minimumTLSVersion: .tlsv12
         )
         #expect(configuration.minimumTLSVersion == .tlsv12)
         // Guards the whole point of this change: NIOSSL's own default is .tlsv1,

--- a/Tests/SwiftIMAPTests/MailTLSConfigurationTests.swift
+++ b/Tests/SwiftIMAPTests/MailTLSConfigurationTests.swift
@@ -1,0 +1,80 @@
+import Testing
+import NIOSSL
+@testable import SwiftMail
+
+@Suite("TLS minimum version")
+struct MailTLSConfigurationTests {
+
+    @Test("Default floor is TLS 1.2, not NIOSSL's TLS 1.0")
+    func defaultIsTLS12() {
+        let configuration = MailTLSConfiguration.makeClientConfiguration(
+            certificateVerificationPolicy: .fullVerification
+        )
+        #expect(configuration.minimumTLSVersion == .tlsv12)
+        // Guards the whole point of this change: NIOSSL's own default is .tlsv1,
+        // which RFC 8996 deprecated in March 2021.
+        #expect(TLSConfiguration.makeClientConfiguration().minimumTLSVersion == .tlsv1)
+    }
+
+    @Test("Each case maps to the matching NIOSSL version", arguments: [
+        (MailTLSMinimumVersion.tlsv1, TLSVersion.tlsv1),
+        (MailTLSMinimumVersion.tlsv1_1, TLSVersion.tlsv11),
+        (MailTLSMinimumVersion.tlsv1_2, TLSVersion.tlsv12),
+        (MailTLSMinimumVersion.tlsv1_3, TLSVersion.tlsv13),
+    ])
+    func mapsToNIOVersion(_ mail: MailTLSMinimumVersion, _ nio: TLSVersion) {
+        let configuration = MailTLSConfiguration.makeClientConfiguration(
+            certificateVerificationPolicy: .fullVerification,
+            minimumTLSVersion: mail
+        )
+        #expect(configuration.minimumTLSVersion == nio)
+    }
+
+    @Test("Raising the floor to TLS 1.3 makes a downgrade impossible")
+    func tls13Floor() {
+        let configuration = MailTLSConfiguration.makeClientConfiguration(
+            certificateVerificationPolicy: .fullVerification,
+            minimumTLSVersion: .tlsv1_3
+        )
+        #expect(configuration.minimumTLSVersion == .tlsv13)
+    }
+
+    @Test("Certificate verification policy still applies alongside the TLS floor")
+    func verificationPolicyUnaffected() {
+        let verifying = MailTLSConfiguration.makeClientConfiguration(
+            certificateVerificationPolicy: .fullVerification,
+            minimumTLSVersion: .tlsv1_3
+        )
+        #expect(verifying.certificateVerification == .fullVerification)
+
+        let notVerifying = MailTLSConfiguration.makeClientConfiguration(
+            certificateVerificationPolicy: .noVerification,
+            minimumTLSVersion: .tlsv1_3
+        )
+        #expect(notVerifying.certificateVerification == .none)
+    }
+
+    @Test("IMAPServer carries the caller's TLS floor")
+    func imapServerStoresFloor() async {
+        let server = IMAPServer(host: "imap.example.com", port: 993, minimumTLSVersion: .tlsv1_3)
+        #expect(await server.minimumTLSVersion == .tlsv1_3)
+    }
+
+    @Test("IMAPServer defaults to TLS 1.2")
+    func imapServerDefault() async {
+        let server = IMAPServer(host: "imap.example.com", port: 993)
+        #expect(await server.minimumTLSVersion == .tlsv1_2)
+    }
+
+    @Test("SMTPServer carries the caller's TLS floor")
+    func smtpServerStoresFloor() async {
+        let server = SMTPServer(host: "smtp.example.com", port: 587, minimumTLSVersion: .tlsv1_3)
+        #expect(await server.minimumTLSVersion == .tlsv1_3)
+    }
+
+    @Test("SMTPServer defaults to TLS 1.2")
+    func smtpServerDefault() async {
+        let server = SMTPServer(host: "smtp.example.com", port: 587)
+        #expect(await server.minimumTLSVersion == .tlsv1_2)
+    }
+}

--- a/Tests/SwiftIMAPTests/MailTLSConfigurationTests.swift
+++ b/Tests/SwiftIMAPTests/MailTLSConfigurationTests.swift
@@ -18,9 +18,9 @@ struct MailTLSConfigurationTests {
 
     @Test("Each case maps to the matching NIOSSL version", arguments: [
         (MailTLSMinimumVersion.tlsv1, TLSVersion.tlsv1),
-        (MailTLSMinimumVersion.tlsv1_1, TLSVersion.tlsv11),
-        (MailTLSMinimumVersion.tlsv1_2, TLSVersion.tlsv12),
-        (MailTLSMinimumVersion.tlsv1_3, TLSVersion.tlsv13),
+        (MailTLSMinimumVersion.tlsv11, TLSVersion.tlsv11),
+        (MailTLSMinimumVersion.tlsv12, TLSVersion.tlsv12),
+        (MailTLSMinimumVersion.tlsv13, TLSVersion.tlsv13)
     ])
     func mapsToNIOVersion(_ mail: MailTLSMinimumVersion, _ nio: TLSVersion) {
         let configuration = MailTLSConfiguration.makeClientConfiguration(
@@ -40,7 +40,7 @@ struct MailTLSConfigurationTests {
     func tls13Floor() {
         let configuration = MailTLSConfiguration.makeClientConfiguration(
             certificateVerificationPolicy: .fullVerification,
-            minimumTLSVersion: .tlsv1_3
+            minimumTLSVersion: .tlsv13
         )
         #expect(configuration.minimumTLSVersion == .tlsv13)
     }
@@ -49,38 +49,38 @@ struct MailTLSConfigurationTests {
     func verificationPolicyUnaffected() {
         let verifying = MailTLSConfiguration.makeClientConfiguration(
             certificateVerificationPolicy: .fullVerification,
-            minimumTLSVersion: .tlsv1_3
+            minimumTLSVersion: .tlsv13
         )
         #expect(verifying.certificateVerification == .fullVerification)
 
         let notVerifying = MailTLSConfiguration.makeClientConfiguration(
             certificateVerificationPolicy: .noVerification,
-            minimumTLSVersion: .tlsv1_3
+            minimumTLSVersion: .tlsv13
         )
         #expect(notVerifying.certificateVerification == .none)
     }
 
     @Test("IMAPServer carries the caller's TLS floor")
     func imapServerStoresFloor() async {
-        let server = IMAPServer(host: "imap.example.com", port: 993, minimumTLSVersion: .tlsv1_3)
-        #expect(await server.minimumTLSVersion == .tlsv1_3)
+        let server = IMAPServer(host: "imap.example.com", port: 993, minimumTLSVersion: .tlsv13)
+        #expect(await server.minimumTLSVersion == .tlsv13)
     }
 
     @Test("IMAPServer defaults to TLS 1.2")
     func imapServerDefault() async {
         let server = IMAPServer(host: "imap.example.com", port: 993)
-        #expect(await server.minimumTLSVersion == .tlsv1_2)
+        #expect(await server.minimumTLSVersion == .tlsv12)
     }
 
     @Test("SMTPServer carries the caller's TLS floor")
     func smtpServerStoresFloor() async {
-        let server = SMTPServer(host: "smtp.example.com", port: 587, minimumTLSVersion: .tlsv1_3)
-        #expect(await server.minimumTLSVersion == .tlsv1_3)
+        let server = SMTPServer(host: "smtp.example.com", port: 587, minimumTLSVersion: .tlsv13)
+        #expect(await server.minimumTLSVersion == .tlsv13)
     }
 
     @Test("SMTPServer defaults to TLS 1.2")
     func smtpServerDefault() async {
         let server = SMTPServer(host: "smtp.example.com", port: 587)
-        #expect(await server.minimumTLSVersion == .tlsv1_2)
+        #expect(await server.minimumTLSVersion == .tlsv12)
     }
 }

--- a/Tests/SwiftIMAPTests/MailTLSConfigurationTests.swift
+++ b/Tests/SwiftIMAPTests/MailTLSConfigurationTests.swift
@@ -2,13 +2,11 @@ import Testing
 import NIOSSL
 @testable import SwiftMail
 
-/// - Note: `.serialized` and `.timeLimit` are not decoration. Constructing an `IMAPServer` or
-///   `SMTPServer` allocates a `MultiThreadedEventLoopGroup`, and `SMTPServer.deinit` shuts it
-///   down with the **blocking** `syncShutdownGracefully()`. Released from a Swift Concurrency
-///   context, that costs a cooperative-pool thread; run in parallel with the rest of the suite on
-///   a core-constrained CI runner, the pool starves and the whole test run stalls. Every
-///   pre-existing suite here that constructs a server carries these traits — this one did not,
-///   and that is what hung the macOS job.
+/// - Note: `.serialized` and `.timeLimit` match the other server-constructing suites.
+///   Constructing an `IMAPServer` or `SMTPServer` allocates a `MultiThreadedEventLoopGroup`
+///   that is shut down on release; suites that release servers used to be able to deadlock a
+///   core-constrained CI runner when the deinit still *blocked* on that shutdown, so the traits
+///   keep server churn serialized and bounded in time as defense in depth.
 @Suite("TLS minimum version", .serialized, .timeLimit(.minutes(1)))
 struct MailTLSConfigurationTests {
 


### PR DESCRIPTION
Supersedes #185 by including it verbatim (davyd15's nine commits, authorship intact — GitHub will mark #185 merged when this lands) plus five commits that make it mergeable and fix defects found in review.

## Why #185 could not merge

- **build-macos deadlocked**: `SMTPServer.deinit` blocks in `syncShutdownGracefully()`, whose semaphore signal needs the same default-QoS workqueue that backs the cooperative pool. #185's new `MailTLSConfigurationTests` was the third suite concurrently releasing SMTP servers — on the 3-core runner, three parked waiters consumed the whole pool and nothing could deliver any wake-up. Diagnosed from watchdog `sample` stacks of a hung run; main survives with two such suites by a single thread.
- **build-linux deadlocked** (since `b29316e`, some runs sat 5+ hours — the job had no timeout): the TLS floor tests' `EmbeddedChannel.finish()` does `close().wait()`, and NIOSSL's graceful shutdown waits for a close_notify reply that can never arrive once the test's byte pump has stopped. Diagnosed via lldb in a 4-CPU Docker repro; macOS happens to complete the close inline.
- **build-ios failed on main too**: the macos-26 image rotation (July 15) stranded the pinned Xcode 26.0 without its iOS platform.

## What the fix commits do

1. **CI**: both macOS jobs track `latest-stable` Xcode; build-macos and build-linux get watchdogs that dump thread stacks after 6 minutes and fail honestly instead of eating the job timeout; build-linux gets `timeout-minutes: 20`.
2. **Library**: `SMTPServer.deinit`/`IMAPServer.deinit` initiate ELG shutdown with the non-blocking callback form; pipelined-fetch cleanup restores buffering before removing the dispatcher (a reorder in #185 could drop unsolicited BYE/EXISTS during the removal await).
3. **The guard now fires in production**: `ResponseDecoder` wraps every parser error in `IMAPDecoderError`, which `isLimitViolation` never unwrapped — parser-raised violations did not fail closed outside tests (which injected bare error types). Also matches `ExceededLiteralSizeLimitError`, previously fail-open. New end-to-end test drives raw wire bytes through the real decoder.
4. **Tests**: TLS floor teardown pumps the close_notify exchange and advances embedded time; the shared ELG-shutdown helper resumes from NIO's completion callback instead of parking a GCD worker; `IMAPTestServer.stop()` awaits its client drain via continuation instead of a blocking 2 s `DispatchGroup.wait`.

## Verification

- [Run 29585219160](https://github.com/Cocoanetics/SwiftMail/actions/runs/29585219160): **macOS ✔ Linux ✔ iOS ✔ Android ✔** (Windows: known upstream-blocked, dispatch-only).
- Locally: 349 tests on macOS (incl. `LIBDISPATCH_COOPERATIVE_POOL_STRICT=1`), 343 on Linux in Docker where the suite previously hung, `swiftlint --strict` clean.
- Unmodified main was dispatched as a control: its build-ios fails identically (image rotation), its build-macos passes — isolating which failures were #185's and which were infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)