### PR TITLE
Expose BODYSTRUCTURE octet count as MessagePart.size (supersedes #184)

### DIFF
--- a/Sources/SwiftMail/IMAP/Models/MessagePart+BodyStructure.swift
+++ b/Sources/SwiftMail/IMAP/Models/MessagePart+BodyStructure.swift
@@ -40,6 +40,9 @@ extension Array where Element == MessagePart {
         var filename = dispositionAndFilename.filename
         let disposition = dispositionAndFilename.disposition
         let contentId: String? = part.fields.id.map { String($0) }.flatMap { $0.isEmpty ? nil : $0 }
+        // BODYSTRUCTURE reports the body size in octets; NIOIMAP parses a
+        // missing/zero field as 0, which we surface as nil.
+        let size: Int? = part.fields.octetCount > 0 ? part.fields.octetCount : nil
 
         // message/rfc822: extract envelope metadata and derive a filename
         // from the subject when one isn't already set.
@@ -58,6 +61,7 @@ extension Array where Element == MessagePart {
             encoding: encoding?.isEmpty == true ? nil : encoding,
             filename: filename,
             contentId: contentId,
+            size: size,
             data: nil,
             embeddedMessageInfo: embeddedMessageInfo
         ))

--- a/Sources/SwiftMail/IMAP/Models/MessagePart+BodyStructure.swift
+++ b/Sources/SwiftMail/IMAP/Models/MessagePart+BodyStructure.swift
@@ -40,9 +40,9 @@ extension Array where Element == MessagePart {
         var filename = dispositionAndFilename.filename
         let disposition = dispositionAndFilename.disposition
         let contentId: String? = part.fields.id.map { String($0) }.flatMap { $0.isEmpty ? nil : $0 }
-        // BODYSTRUCTURE reports the body size in octets; NIOIMAP parses a
-        // missing/zero field as 0, which we surface as nil.
-        let size: Int? = part.fields.octetCount > 0 ? part.fields.octetCount : nil
+        // body-fld-octets is mandatory in BODYSTRUCTURE, so every parsed
+        // singlepart reports a size; zero is a valid size for an empty part.
+        let size = part.fields.octetCount
 
         // message/rfc822: extract envelope metadata and derive a filename
         // from the subject when one isn't already set.

--- a/Sources/SwiftMail/IMAP/Models/MessagePart.swift
+++ b/Sources/SwiftMail/IMAP/Models/MessagePart.swift
@@ -24,6 +24,9 @@ public struct MessagePart: Sendable {
     /// The content ID of the part (if any)
     public let contentId: String?
 
+    /// The size of the part body in octets, as reported by BODYSTRUCTURE (if any)
+    public let size: Int?
+
     /// The content data (if any)
     public var data: Data?
 
@@ -40,6 +43,7 @@ public struct MessagePart: Sendable {
     ///   - encoding: The content transfer encoding (e.g., "base64", "quoted-printable")
     ///   - filename: The filename (if any)
     ///   - contentId: The content ID
+    ///   - size: The body size in octets from BODYSTRUCTURE (optional)
     ///   - data: The content data (optional)
     ///   - embeddedMessageInfo: Envelope headers for message/rfc822 parts (optional)
     public init(
@@ -49,6 +53,7 @@ public struct MessagePart: Sendable {
         encoding: String? = nil,
         filename: String? = nil,
         contentId: String? = nil,
+        size: Int? = nil,
         data: Data? = nil,
         embeddedMessageInfo: MessageInfo? = nil
     ) {
@@ -58,6 +63,7 @@ public struct MessagePart: Sendable {
         self.encoding = encoding
         self.filename = filename
         self.contentId = contentId
+        self.size = size
         self.data = data
         self.embeddedMessageInfo = embeddedMessageInfo
     }
@@ -77,6 +83,7 @@ public struct MessagePart: Sendable {
         encoding: String? = nil,
         filename: String? = nil,
         contentId: String? = nil,
+        size: Int? = nil,
         data: Data? = nil,
         embeddedMessageInfo: MessageInfo? = nil
     ) {
@@ -86,6 +93,7 @@ public struct MessagePart: Sendable {
         self.encoding = encoding
         self.filename = filename
         self.contentId = contentId
+        self.size = size
         self.data = data
         self.embeddedMessageInfo = embeddedMessageInfo
     }
@@ -161,7 +169,7 @@ public struct MessagePart: Sendable {
 // MARK: - Codable Implementation
 extension MessagePart: Codable {
     private enum CodingKeys: String, CodingKey {
-        case section, contentType, disposition, encoding, filename, contentId, data, embeddedMessageInfo
+        case section, contentType, disposition, encoding, filename, contentId, size, data, embeddedMessageInfo
     }
 
     public func encode(to encoder: Encoder) throws {
@@ -173,6 +181,7 @@ extension MessagePart: Codable {
         try container.encodeIfPresent(encoding, forKey: .encoding)
         try container.encodeIfPresent(filename, forKey: .filename)
         try container.encodeIfPresent(contentId, forKey: .contentId)
+        try container.encodeIfPresent(size, forKey: .size)
         try container.encodeIfPresent(data, forKey: .data)
         try container.encodeIfPresent(embeddedMessageInfo, forKey: .embeddedMessageInfo)
     }
@@ -186,6 +195,7 @@ extension MessagePart: Codable {
         encoding = try container.decodeIfPresent(String.self, forKey: .encoding)
         filename = try container.decodeIfPresent(String.self, forKey: .filename)
         contentId = try container.decodeIfPresent(String.self, forKey: .contentId)
+        size = try container.decodeIfPresent(Int.self, forKey: .size)
         data = try container.decodeIfPresent(Data.self, forKey: .data)
         embeddedMessageInfo = try container.decodeIfPresent(MessageInfo.self, forKey: .embeddedMessageInfo)
     }

--- a/Sources/SwiftMail/IMAP/Models/MessagePart.swift
+++ b/Sources/SwiftMail/IMAP/Models/MessagePart.swift
@@ -24,7 +24,9 @@ public struct MessagePart: Sendable {
     /// The content ID of the part (if any)
     public let contentId: String?
 
-    /// The size of the part body in octets, as reported by BODYSTRUCTURE (if any)
+    /// The size of the part body in octets, as reported by BODYSTRUCTURE.
+    /// Zero is a valid size (an empty part); `nil` means the size is unknown
+    /// because the part was not built from a BODYSTRUCTURE response.
     public let size: Int?
 
     /// The content data (if any)

--- a/Tests/SwiftIMAPTests/MessagePartSizeTests.swift
+++ b/Tests/SwiftIMAPTests/MessagePartSizeTests.swift
@@ -22,12 +22,12 @@ struct MessagePartSizeTests {
         #expect(parts[0].size == 123_456)
     }
 
-    @Test func zeroOctetCountYieldsNilSize() {
+    @Test func zeroOctetCountIsPreservedAsSize() {
         let text = BodyStructure.Singlepart.Text(mediaSubtype: "plain", lineCount: 10)
         let part = BodyStructure.Singlepart(kind: .text(text), fields: fields(octetCount: 0))
         let parts = [MessagePart](.singlepart(part))
         #expect(parts.count == 1)
-        #expect(parts[0].size == nil)
+        #expect(parts[0].size == 0)
     }
 
     @Test func multipartChildrenEachCarryTheirOwnSize() {

--- a/Tests/SwiftIMAPTests/MessagePartSizeTests.swift
+++ b/Tests/SwiftIMAPTests/MessagePartSizeTests.swift
@@ -1,0 +1,49 @@
+import Foundation
+import Testing
+@testable import SwiftMail
+import NIOIMAPCore
+import NIO
+
+/// Tests that BODYSTRUCTURE octet counts surface as MessagePart.size.
+@Suite(.serialized, .timeLimit(.minutes(1)))
+struct MessagePartSizeTests {
+
+    private func fields(octetCount: Int) -> BodyStructure.Fields {
+        BodyStructure.Fields(parameters: [:], id: nil, contentDescription: nil, encoding: nil, octetCount: octetCount)
+    }
+
+    @Test func singlepartCarriesOctetCountAsSize() {
+        let basic = BodyStructure.Singlepart(
+            kind: .basic(.init(topLevel: .application, sub: "pdf")),
+            fields: fields(octetCount: 123_456)
+        )
+        let parts = [MessagePart](.singlepart(basic))
+        #expect(parts.count == 1)
+        #expect(parts[0].size == 123_456)
+    }
+
+    @Test func zeroOctetCountYieldsNilSize() {
+        let text = BodyStructure.Singlepart.Text(mediaSubtype: "plain", lineCount: 10)
+        let part = BodyStructure.Singlepart(kind: .text(text), fields: fields(octetCount: 0))
+        let parts = [MessagePart](.singlepart(part))
+        #expect(parts.count == 1)
+        #expect(parts[0].size == nil)
+    }
+
+    @Test func multipartChildrenEachCarryTheirOwnSize() {
+        let text = BodyStructure.Singlepart.Text(mediaSubtype: "plain", lineCount: 5)
+        let child1 = BodyStructure.Singlepart(kind: .text(text), fields: fields(octetCount: 42))
+        let child2 = BodyStructure.Singlepart(
+            kind: .basic(.init(topLevel: .image, sub: "jpeg")),
+            fields: fields(octetCount: 9_000)
+        )
+        let multipart = BodyStructure.Multipart(
+            parts: [.singlepart(child1), .singlepart(child2)],
+            mediaSubtype: .mixed
+        )
+        let parts = [MessagePart](.multipart(multipart))
+        #expect(parts.count == 2)
+        #expect(parts[0].size == 42)
+        #expect(parts[1].size == 9_000)
+    }
+}


### PR DESCRIPTION
## What

Carries #184 forward with the review finding fixed. The branch contains the original feature commit from @appinteractive as-is (`6245c30`), with `main` merged in on top plus a follow-up fix — so merging this PR (with a merge commit) makes GitHub mark #184 as merged automatically.

`MessagePart` gains an optional `size` property populated from the BODYSTRUCTURE `body-fld-octets` field, so clients can show size labels and enforce download caps from the structure fetch alone, without fetching part bytes:

```swift
/// The size of the part body in octets, as reported by BODYSTRUCTURE.
/// Zero is a valid size (an empty part); `nil` means the size is unknown
/// because the part was not built from a BODYSTRUCTURE response.
public let size: Int?
```

## Fix over #184

The review on #184 flagged that the conversion collapsed a reported octet count of `0` to `nil`. In the pinned NIOIMAP 0.3.0 parser `body-fld-octets` is mandatory — a missing field makes the BODYSTRUCTURE invalid and never reaches this converter — so `0` is a legitimately reported size of an empty part, not a missing-value sentinel. The converter now passes the octet count through unchanged, keeping empty parts distinguishable from parts whose size metadata is unavailable (e.g. not built from BODYSTRUCTURE). The doc comment spells out these semantics, and the test asserting `0 → nil` now asserts `0` is preserved.

## Changes

- `MessagePart`: new `size: Int?` property, threaded through both public initializers and the `Codable` implementation (encoded with `encodeIfPresent`, so existing archives decode fine).
- `MessagePart+BodyStructure`: read `fields.octetCount` when flattening singleparts, passing it through as-is.
- `MessagePartSizeTests`: singlepart carries the octet count, zero is preserved, multipart children each carry their own size.

Note: the size is the *encoded* (transfer-encoding) octet count per RFC 3501 — for base64 parts roughly 4/3 of the decoded file size.

## Test plan

- [x] `swift build` clean
- [x] Full suite: 352 tests in 48 suites pass locally on macOS

🤖 Generated with [Claude Code](https://claude.com/claude-code)