### PR TITLE
Add Gmail X-GM-EXT-1 attribute fetch (X-GM-MSGID, X-GM-THRID, X-GM-LABELS)

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Commands/FetchGmailAttributesCommand.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/FetchGmailAttributesCommand.swift
@@ -1,0 +1,23 @@
+import Foundation
+import NIOIMAPCore
+
+struct FetchGmailAttributesCommand: IMAPTaggedCommand {
+    typealias ResultType = [GmailMessageAttributes]
+    typealias HandlerType = FetchGmailAttributesHandler
+
+    let identifierSet: UIDSet
+    let timeoutSeconds = 10
+
+    func validate() throws {
+        guard !identifierSet.isEmpty else { throw IMAPError.emptyIdentifierSet }
+    }
+
+    func toTaggedCommand(tag: String) -> TaggedCommand {
+        // UID is requested explicitly: Gmail need not return messages in the
+        // requested order, so responses are keyed by returned UID, not position.
+        let attributes: [FetchAttribute] = [.uid, .gmailMessageID, .gmailThreadID, .gmailLabels]
+        return TaggedCommand(tag: tag, command: .uidFetch(
+            .set(identifierSet.toNIOSet()), attributes, []
+        ))
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAP/Commands/FetchGmailAttributesCommand.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/FetchGmailAttributesCommand.swift
@@ -2,7 +2,7 @@ import Foundation
 import NIOIMAPCore
 
 struct FetchGmailAttributesCommand: IMAPTaggedCommand {
-    typealias ResultType = [GmailMessageAttributes]
+    typealias ResultType = [GmailAttributeRecord]
     typealias HandlerType = FetchGmailAttributesHandler
 
     let identifierSet: UIDSet

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/FetchGmailAttributesHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/FetchGmailAttributesHandler.swift
@@ -1,17 +1,22 @@
 import Foundation
 import NIOIMAPCore
 
-struct GmailMessageAttributes: Sendable {
+/// Mutable accumulator used while parsing a Gmail attribute FETCH response.
+///
+/// Fields start `nil`/empty and are filled in as the corresponding FETCH data items
+/// arrive; `IMAPServer.fetchGmailAttributes(for:)` converts fully-populated records
+/// into the public, non-optional `GmailMessageAttributes`.
+struct GmailAttributeRecord: Sendable {
     var uid: UID?
     var messageID: UInt64?
     var threadID: UInt64?
     var labels: [String] = []
 }
 
-final class FetchGmailAttributesHandler: BaseIMAPCommandHandler<[GmailMessageAttributes]>,
+final class FetchGmailAttributesHandler: BaseIMAPCommandHandler<[GmailAttributeRecord]>,
     IMAPCommandHandler, @unchecked Sendable {
 
-    private var attributes: [GmailMessageAttributes] = []
+    private var attributes: [GmailAttributeRecord] = []
 
     override func handleTaggedOKResponse(_ response: TaggedResponse) {
         super.handleTaggedOKResponse(response)
@@ -31,7 +36,7 @@ final class FetchGmailAttributesHandler: BaseIMAPCommandHandler<[GmailMessageAtt
     private func processFetchResponse(_ fetchResponse: FetchResponse) {
         switch fetchResponse {
             case .start:
-                lock.withLock { self.attributes.append(GmailMessageAttributes()) }
+                lock.withLock { self.attributes.append(GmailAttributeRecord()) }
             case .simpleAttribute(let attribute):
                 lock.withLock {
                     guard let index = self.attributes.indices.last else { return }
@@ -43,7 +48,7 @@ final class FetchGmailAttributesHandler: BaseIMAPCommandHandler<[GmailMessageAtt
         }
     }
 
-    private static func apply(_ attribute: MessageAttribute, to record: inout GmailMessageAttributes) {
+    private static func apply(_ attribute: MessageAttribute, to record: inout GmailAttributeRecord) {
         switch attribute {
             case .uid(let uid): record.uid = UID(nio: uid)
             case .gmailMessageID(let messageID): record.messageID = messageID

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/FetchGmailAttributesHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/FetchGmailAttributesHandler.swift
@@ -1,0 +1,55 @@
+import Foundation
+import NIOIMAPCore
+
+struct GmailMessageAttributes: Sendable {
+    var uid: UID?
+    var messageID: UInt64?
+    var threadID: UInt64?
+    var labels: [String] = []
+}
+
+final class FetchGmailAttributesHandler: BaseIMAPCommandHandler<[GmailMessageAttributes]>,
+    IMAPCommandHandler, @unchecked Sendable {
+
+    private var attributes: [GmailMessageAttributes] = []
+
+    override func handleTaggedOKResponse(_ response: TaggedResponse) {
+        super.handleTaggedOKResponse(response)
+        succeedWithResult(lock.withLock { self.attributes })
+    }
+
+    override func handleTaggedErrorResponse(_ response: TaggedResponse) {
+        failWithError(IMAPError.fetchFailed(String(describing: response.state)))
+    }
+
+    override func processResponse(_ response: Response) -> Bool {
+        let handled = super.processResponse(response)
+        if case .fetch(let fetchResponse) = response { processFetchResponse(fetchResponse) }
+        return handled
+    }
+
+    private func processFetchResponse(_ fetchResponse: FetchResponse) {
+        switch fetchResponse {
+            case .start:
+                lock.withLock { self.attributes.append(GmailMessageAttributes()) }
+            case .simpleAttribute(let attribute):
+                lock.withLock {
+                    guard let index = self.attributes.indices.last else { return }
+                    var record = self.attributes[index]
+                    Self.apply(attribute, to: &record)
+                    self.attributes[index] = record
+                }
+            default: break
+        }
+    }
+
+    private static func apply(_ attribute: MessageAttribute, to record: inout GmailMessageAttributes) {
+        switch attribute {
+            case .uid(let uid): record.uid = UID(nio: uid)
+            case .gmailMessageID(let messageID): record.messageID = messageID
+            case .gmailThreadID(let threadID): record.threadID = threadID
+            case .gmailLabels(let labels): record.labels = labels.map { $0.makeDisplayString() }
+            default: break
+        }
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAPServer+Gmail.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Gmail.swift
@@ -1,0 +1,25 @@
+import Foundation
+import NIOIMAPCore
+
+extension IMAPServer {
+    /// Fetches Gmail-native attributes for the given UIDs.
+    ///
+    /// Requires the `X-GM-EXT-1` capability; other IMAP servers answer with a
+    /// tagged BAD. Gate calls on `Capability.gmailExtensions` being advertised.
+    public func fetchGmailAttributes(
+        for identifierSet: UIDSet
+    ) async throws -> [UID: (messageID: UInt64, threadID: UInt64, labels: [String])] {
+        let command = FetchGmailAttributesCommand(identifierSet: identifierSet)
+        let records = try await executeCommand(command)
+
+        var result: [UID: (messageID: UInt64, threadID: UInt64, labels: [String])] = [:]
+        for record in records {
+            guard let uid = record.uid,
+                  let messageID = record.messageID,
+                  let threadID = record.threadID
+            else { continue }
+            result[uid] = (messageID: messageID, threadID: threadID, labels: record.labels)
+        }
+        return result
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAPServer+Gmail.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Gmail.swift
@@ -8,17 +8,17 @@ extension IMAPServer {
     /// tagged BAD. Gate calls on `Capability.gmailExtensions` being advertised.
     public func fetchGmailAttributes(
         for identifierSet: UIDSet
-    ) async throws -> [UID: (messageID: UInt64, threadID: UInt64, labels: [String])] {
+    ) async throws -> [UID: GmailMessageAttributes] {
         let command = FetchGmailAttributesCommand(identifierSet: identifierSet)
         let records = try await executeCommand(command)
 
-        var result: [UID: (messageID: UInt64, threadID: UInt64, labels: [String])] = [:]
+        var result: [UID: GmailMessageAttributes] = [:]
         for record in records {
             guard let uid = record.uid,
                   let messageID = record.messageID,
                   let threadID = record.threadID
             else { continue }
-            result[uid] = (messageID: messageID, threadID: threadID, labels: record.labels)
+            result[uid] = GmailMessageAttributes(messageID: messageID, threadID: threadID, labels: record.labels)
         }
         return result
     }

--- a/Sources/SwiftMail/IMAP/Models/GmailMessageAttributes.swift
+++ b/Sources/SwiftMail/IMAP/Models/GmailMessageAttributes.swift
@@ -1,0 +1,30 @@
+import Foundation
+
+/// Gmail-native attributes for a message, exposed via the `X-GM-EXT-1` IMAP capability.
+///
+/// Gmail's IMAP extension reports a message ID and thread ID that are stable across
+/// mailbox moves (unlike UIDs, which are only stable within a single mailbox), plus the
+/// set of Gmail labels applied to the message. See
+/// `IMAPServer.fetchGmailAttributes(for:)`.
+public struct GmailMessageAttributes: Sendable, Hashable {
+    /// Gmail's persistent message ID (`X-GM-MSGID`), stable across mailboxes.
+    public let messageID: UInt64
+
+    /// Gmail's persistent thread ID (`X-GM-THRID`), shared by every message in a thread.
+    public let threadID: UInt64
+
+    /// The Gmail labels applied to the message (`X-GM-LABELS`), including system labels
+    /// such as `\Inbox` and `\Important` alongside user-defined labels.
+    public let labels: [String]
+
+    /// Initialize a new set of Gmail message attributes.
+    /// - Parameters:
+    ///   - messageID: Gmail's persistent message ID.
+    ///   - threadID: Gmail's persistent thread ID.
+    ///   - labels: The Gmail labels applied to the message.
+    public init(messageID: UInt64, threadID: UInt64, labels: [String]) {
+        self.messageID = messageID
+        self.threadID = threadID
+        self.labels = labels
+    }
+}

--- a/Tests/SwiftIMAPTests/FetchGmailAttributesTests.swift
+++ b/Tests/SwiftIMAPTests/FetchGmailAttributesTests.swift
@@ -42,7 +42,7 @@ struct FetchGmailAttributesTests {
             [
                 "* 1 FETCH (UID 42 X-GM-MSGID 1278455344230334865 X-GM-THRID 1266894439832287888 "
                     + "X-GM-LABELS (\\Inbox \"Work\"))\r\n",
-                "A001 OK FETCH completed\r\n",
+                "A001 OK FETCH completed\r\n"
             ]
         )
 
@@ -105,10 +105,10 @@ struct FetchGmailAttributesTests {
 
     // MARK: - Helpers
 
-    private func executeFetch(_ rawResponses: [String]) async throws -> [GmailMessageAttributes] {
+    private func executeFetch(_ rawResponses: [String]) async throws -> [GmailAttributeRecord] {
         let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 
-        let promise = channel.eventLoop.makePromise(of: [GmailMessageAttributes].self)
+        let promise = channel.eventLoop.makePromise(of: [GmailAttributeRecord].self)
         let handler = FetchGmailAttributesHandler(commandTag: "A001", promise: promise)
         try await channel.pipeline.addHandler(handler)
 

--- a/Tests/SwiftIMAPTests/FetchGmailAttributesTests.swift
+++ b/Tests/SwiftIMAPTests/FetchGmailAttributesTests.swift
@@ -1,0 +1,159 @@
+import Foundation
+import NIO
+import NIOEmbedded
+@preconcurrency import NIOIMAP
+@preconcurrency import NIOIMAPCore
+import Testing
+@testable import SwiftMail
+
+@Suite(.serialized, .timeLimit(.minutes(1)))
+struct FetchGmailAttributesTests {
+
+    // MARK: - Command encoding
+
+    @Test
+    func testWireFormatRequestsUIDAndGmailAttributes() async throws {
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
+
+        let ids = UIDSet([UID(101), UID(205)])
+        let command = FetchGmailAttributesCommand(identifierSet: ids)
+        let tagged = command.toTaggedCommand(tag: "A001")
+        let wrapped = IMAPClientHandler.OutboundIn.part(CommandStreamPart.tagged(tagged))
+        try await channel.writeAndFlush(wrapped)
+
+        guard var outbound = try await channel.readOutbound(as: ByteBuffer.self) else {
+            Issue.record("Expected outbound bytes")
+            return
+        }
+        let wire = outbound.readString(length: outbound.readableBytes) ?? ""
+
+        #expect(wire.contains("UID FETCH"))
+        #expect(wire.contains("(UID X-GM-MSGID X-GM-THRID X-GM-LABELS)"))
+        #expect(wire.contains("101,205") || wire.contains("101:205"))
+    }
+
+    // MARK: - Response decoding
+
+    @Test
+    func testHandlerDecodesMessageIDThreadIDAndMixedLabelSet() async throws {
+        // Mixes a system label (\Inbox) with a user label ("Work") — system labels are
+        // written unquoted on the wire while user labels are quoted IMAP strings.
+        let attributesList = try await executeFetch(
+            [
+                "* 1 FETCH (UID 42 X-GM-MSGID 1278455344230334865 X-GM-THRID 1266894439832287888 "
+                    + "X-GM-LABELS (\\Inbox \"Work\"))\r\n",
+                "A001 OK FETCH completed\r\n",
+            ]
+        )
+
+        #expect(attributesList.count == 1)
+        #expect(attributesList[0].uid == UID(42))
+        #expect(attributesList[0].messageID == 1_278_455_344_230_334_865)
+        #expect(attributesList[0].threadID == 1_266_894_439_832_287_888)
+        #expect(attributesList[0].labels == ["\\Inbox", "Work"])
+    }
+
+    // MARK: - UID keying
+
+    @Test
+    func testResultsAreKeyedByReturnedUIDNotResponseOrder() async throws {
+        // The server answers with UID 20 before UID 10 — out of both request order and
+        // ascending order, which is how Gmail's IMAP server is free to respond. If the
+        // caller ever keyed results by position instead of the UID actually returned,
+        // this would silently swap the two messages' attributes.
+        let (server, channel) = try await makeGmailHarness()
+
+        let resultTask = Task {
+            try await server.fetchGmailAttributes(for: UIDSet([UID(10), UID(20)]))
+        }
+
+        guard let commandLine = try await nextOutboundLine(from: channel) else {
+            Issue.record("Expected outbound UID FETCH command")
+            return
+        }
+        #expect(commandLine.contains("UID FETCH"))
+
+        var response = channel.allocator.buffer(capacity: 0)
+        response.writeString(
+            "* 1 FETCH (UID 20 X-GM-MSGID 2222222222222222 X-GM-THRID 3333333333333333 "
+                + "X-GM-LABELS (\\Inbox \"Work\"))\r\n"
+                + "* 2 FETCH (UID 10 X-GM-MSGID 4444444444444444 X-GM-THRID 5555555555555555 "
+                + "X-GM-LABELS (\\Important))\r\n"
+                + "A001 OK UID FETCH completed\r\n"
+        )
+        try await channel.writeInbound(response)
+
+        let result = try await resultTask.value
+
+        #expect(result[UID(20)]?.messageID == 2_222_222_222_222_222)
+        #expect(result[UID(20)]?.threadID == 3_333_333_333_333_333)
+        #expect(result[UID(20)]?.labels == ["\\Inbox", "Work"])
+
+        #expect(result[UID(10)]?.messageID == 4_444_444_444_444_444)
+        #expect(result[UID(10)]?.threadID == 5_555_555_555_555_555)
+        #expect(result[UID(10)]?.labels == ["\\Important"])
+    }
+
+    // MARK: - Validation
+
+    @Test
+    func testValidateThrowsForEmptyIdentifierSet() {
+        #expect(throws: (any Error).self) {
+            try FetchGmailAttributesCommand(identifierSet: UIDSet()).validate()
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func executeFetch(_ rawResponses: [String]) async throws -> [GmailMessageAttributes] {
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
+
+        let promise = channel.eventLoop.makePromise(of: [GmailMessageAttributes].self)
+        let handler = FetchGmailAttributesHandler(commandTag: "A001", promise: promise)
+        try await channel.pipeline.addHandler(handler)
+
+        let command = TaggedCommand(tag: "A001", command: .noop)
+        try await channel.writeAndFlush(IMAPClientHandler.OutboundIn.part(.tagged(command)))
+        _ = try await channel.readOutbound(as: ByteBuffer.self)
+
+        for rawResponse in rawResponses {
+            var buffer = channel.allocator.buffer(capacity: rawResponse.utf8.count)
+            buffer.writeString(rawResponse)
+            try await channel.writeInbound(buffer)
+        }
+
+        return try await promise.futureResult.get()
+    }
+
+    /// Wires an `IMAPServer`'s primary connection to an embedded channel so its public
+    /// API can be driven end-to-end without a real socket, mirroring the harness used by
+    /// `IMAPIdleCancellationTests`.
+    private func makeGmailHarness() async throws -> (server: SwiftMail.IMAPServer, channel: NIOAsyncTestingChannel) {
+        let server = SwiftMail.IMAPServer(host: "localhost", port: 143, useTLS: false)
+        let connection = await server.primaryConnection
+
+        let channel = NIOAsyncTestingChannel()
+        let address = try SocketAddress(ipAddress: "127.0.0.1", port: 143)
+        try await channel.connect(to: address)
+        try await channel.addIMAPClientHandler()
+        try await channel.pipeline.addHandler(connection.duplexLogger)
+        try await channel.pipeline.addHandler(connection.responseBuffer)
+        connection.replaceChannelForTesting(channel)
+
+        return (server, channel)
+    }
+
+    private func nextOutboundLine(
+        from channel: NIOAsyncTestingChannel,
+        timeoutNanoseconds: UInt64 = 1_000_000_000
+    ) async throws -> String? {
+        let start = DispatchTime.now().uptimeNanoseconds
+        while DispatchTime.now().uptimeNanoseconds - start < timeoutNanoseconds {
+            if var line = try await channel.readOutbound(as: ByteBuffer.self) {
+                return line.readString(length: line.readableBytes)
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        return nil
+    }
+}


### PR DESCRIPTION
Adds support for Gmail's `X-GM-EXT-1` message attributes: `X-GM-MSGID`, `X-GM-THRID` and `X-GM-LABELS`.

## Motivation

Gmail exposes a message's real label set and its native thread ID over IMAP via the `X-GM-EXT-1` extension. Without these, a client has to approximate Gmail's model — inferring threads from `References`/`In-Reply-To` and treating labels as folders — which loses fidelity, since a Gmail message can carry several labels at once and folder-shaped models flatten that.

`NIOIMAPCore` already models all three attributes natively (`FetchAttribute.gmailMessageID/.gmailThreadID/.gmailLabels`, and the matching `MessageAttribute` cases with parser support). This PR only surfaces that existing capability through SwiftMail's public API — it adds no parsing of its own.

## What's added

- `FetchGmailAttributesCommand` — issues `UID FETCH <set> (UID X-GM-MSGID X-GM-THRID X-GM-LABELS)`
- `FetchGmailAttributesHandler` — accumulates the response, following the existing `FetchMessageInfoHandler` idiom
- `IMAPServer.fetchGmailAttributes(for:)` — public API, in its own extension file:

```swift
public func fetchGmailAttributes(
    for identifierSet: UIDSet
) async throws -> [UID: (messageID: UInt64, threadID: UInt64, labels: [String])]
```

Labels are returned via `GmailLabel.makeDisplayString()`, so modified-UTF-7 names decode correctly.

## Design note

`UID` is requested explicitly and results are keyed by the **returned** UID rather than by response position, because the server need not answer in the requested order. There is a test covering exactly this, since getting it wrong produces silent mis-association rather than an obvious failure.

## Compatibility

Purely additive — no existing public API is changed. The command requires the `X-GM-EXT-1` capability; other servers answer with a tagged `BAD`, so callers should gate on `Capability.gmailExtensions`. This is documented on the public method.

## Tests

Four tests in `Tests/SwiftIMAPTests/FetchGmailAttributesTests.swift`:

- wire format is `UID FETCH ... (UID X-GM-MSGID X-GM-THRID X-GM-LABELS)`
- decoding of message ID, thread ID and a mixed system/user label set (`\Inbox` + `Work`)
- results keyed by returned UID when the server answers out of order (round-trip through the public API on an embedded channel)
- `validate()` throws on an empty identifier set

Suite goes 352 → 356, all passing, nothing regressed.

Not covered: end-to-end through `IMAPTestServer`, whose FETCH stub doesn't support `X-GM-*`; extending it would have widened the diff well beyond this feature, so the embedded-channel harness is used instead — it exercises the same command/response/keying path.

## Verification

Built and tested against a real Gmail account: capabilities reported `X-GM-EXT-1: true`, and live messages returned correct thread IDs, message IDs and label sets. Replies correctly showed `msgid != thrid` while thread-starting messages showed them equal.
