### PR TITLE
Replay RFC 2971 ID after every authentication when configured

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAPServer+Connection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Connection.swift
@@ -70,7 +70,11 @@ extension IMAPServer {
      */
     public func login(username: String, password: String) async throws {
         try await primaryConnection.login(username: username, password: password)
-        authentication = .login(username: username, password: password)
+        authentication = Authentication(
+            method: .login(username: username, password: password),
+            identification: clientIdentification
+        )
+        await identifyPrimaryConnectionIfNeeded()
         namespaces = primaryConnection.namespacesSnapshot
     }
 
@@ -87,7 +91,11 @@ extension IMAPServer {
     ///   or ``IMAPError.authFailed`` when authentication fails.
     public func authenticatePlain(username: String, password: String) async throws {
         try await primaryConnection.authenticatePlain(username: username, password: password)
-        authentication = .plain(username: username, password: password)
+        authentication = Authentication(
+            method: .plain(username: username, password: password),
+            identification: clientIdentification
+        )
+        await identifyPrimaryConnectionIfNeeded()
         namespaces = primaryConnection.namespacesSnapshot
     }
 
@@ -99,7 +107,11 @@ extension IMAPServer {
     ///   ``IMAPError.authFailed`` when authentication fails.
     public func authenticateXOAUTH2(email: String, accessToken: String) async throws {
         try await primaryConnection.authenticateXOAUTH2(email: email, accessToken: accessToken)
-        authentication = .xoauth2(email: email, accessTokenProvider: { accessToken })
+        authentication = Authentication(
+            method: .xoauth2(email: email, accessTokenProvider: { accessToken }),
+            identification: clientIdentification
+        )
+        await identifyPrimaryConnectionIfNeeded()
         namespaces = primaryConnection.namespacesSnapshot
     }
 
@@ -109,7 +121,32 @@ extension IMAPServer {
         email: String,
         accessTokenProvider: @escaping @Sendable () async throws -> String
     ) {
-        authentication = .xoauth2(email: email, accessTokenProvider: accessTokenProvider)
+        authentication = Authentication(
+            method: .xoauth2(email: email, accessTokenProvider: accessTokenProvider),
+            identification: clientIdentification
+        )
+    }
+
+    /// Stores the RFC 2971 client identity replayed after every successful
+    /// authentication on every connection this server opens (primary,
+    /// dedicated IDLE connections, and transparent re-authentication).
+    /// Some servers (e.g. NetEase 163/126) reject SELECT on any authenticated
+    /// connection that has not identified itself; configuring this once makes
+    /// every connection — including ones the server opens internally — send
+    /// ID right after authenticating. Call it before
+    /// `login`/`authenticatePlain`/`authenticateXOAUTH2`. Servers that do not
+    /// advertise the ID capability are never sent the command.
+    public func setClientIdentification(_ identification: Identification?) {
+        clientIdentification = identification
+        authentication?.identification = identification
+    }
+
+    /// RFC 2971 replay for the primary connection's explicit authentication.
+    /// Best-effort: a failed ID must never fail the authentication itself.
+    private func identifyPrimaryConnectionIfNeeded() async {
+        guard let clientIdentification,
+              primaryConnection.capabilitiesSnapshot.contains(.id) else { return }
+        _ = try? await primaryConnection.id(clientIdentification)
     }
 
     /// Identify the client to the server using the `ID` command.

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -71,6 +71,12 @@ public actor IMAPServer {
     /// Authentication configuration for spawning new connections.
     var authentication: Authentication?
 
+    /// RFC 2971 client identity replayed after every successful
+    /// authentication on every connection this server opens (primary,
+    /// dedicated IDLE connections, and transparent re-authentication).
+    /// Set it before calling `login`/`authenticatePlain`/`authenticateXOAUTH2`.
+    var clientIdentification: Identification?
+
     /** The list of all mailboxes with their attributes */
     public private(set) var mailboxes: [Mailbox.Info] = []
 
@@ -113,13 +119,18 @@ public actor IMAPServer {
         let handle: IMAPNamedConnection
     }
 
-    enum Authentication {
-        case login(username: String, password: String)
-        case plain(username: String, password: String)
-        case xoauth2(email: String, accessTokenProvider: @Sendable () async throws -> String)
+    struct Authentication {
+        enum Method {
+            case login(username: String, password: String)
+            case plain(username: String, password: String)
+            case xoauth2(email: String, accessTokenProvider: @Sendable () async throws -> String)
+        }
+
+        let method: Method
+        var identification: Identification?
 
         func authenticate(on connection: IMAPConnection) async throws {
-            switch self {
+            switch method {
                 case .login(let username, let password):
                     try await connection.login(username: username, password: password)
                 case .plain(let username, let password):
@@ -127,6 +138,14 @@ public actor IMAPServer {
                 case .xoauth2(let email, let accessTokenProvider):
                     let accessToken = try await accessTokenProvider()
                     try await connection.authenticateXOAUTH2(email: email, accessToken: accessToken)
+            }
+            // RFC 2971: some servers (e.g. NetEase 163/126) reject SELECT on any
+            // authenticated connection that has not identified itself, so the
+            // stored identity is replayed after every authentication. Servers
+            // that do not advertise the ID capability are skipped, and a
+            // failed ID must never fail the authentication itself.
+            if let identification, connection.capabilitiesSnapshot.contains(.id) {
+                _ = try? await connection.id(identification)
             }
         }
     }


### PR DESCRIPTION
## Motivation

Some IMAP servers — notably NetEase (163.com / 126.com / yeah.net), one of the largest mail providers in China — reject every `SELECT` on an authenticated connection that has not identified itself via the RFC 2971 `ID` command, answering `NO Unsafe Login. Please contact kefu@188.com for help`.

Callers can already send `ID` manually on the primary connection via `IMAPServer.id(_:)`. But connections the server opens internally authenticate **without** `ID` and are permanently rejected by such servers:

- the dedicated IDLE connection (`idle(on:)` → `makeIdleConnection` → authenticate → `SELECT`), so mailbox IDLE never establishes;
- IDLE recovery reconnects;
- transparent re-authentication in `executeCommand` after the primary connection is dropped, so a recycled connection stalls until the caller reconnects explicitly.

## Change

- `IMAPServer.setClientIdentification(_:)` (new public API) stores an optional `Identification`.
- The internal `Authentication` enum becomes a struct carrying the identification alongside the auth method; `authenticate(on:)` replays `ID` right after every successful authentication on whichever connection it authenticated — all internal call sites are covered without modification.
- The three public auth methods replay on the primary connection as well, so one configuration call covers every connection for the server's lifetime.
- Guards: the replay is skipped when the connection does not advertise the `ID` capability (checked against the post-auth capability snapshot), and it is best-effort — a failed `ID` never fails the authentication itself. **Behavior is unchanged unless the new API is used.**

## Verification

- `swift build` clean on this branch.
- Verified downstream (Orvia mail client, which vendors this patch on 1.5.2 and 1.6.4) against a real NetEase 163 account: with the identification configured, mailbox IDLE establishes and pushes arrive in seconds; without it, the dedicated IDLE connection's `SELECT` is rejected as described.

🤖 Generated with [Claude Code](https://claude.com/claude-code)