### PR TITLE
Close the post-cancellation reconnect window in IDLE teardown

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAPServer+Connection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Connection.swift
@@ -317,6 +317,12 @@ extension IMAPServer {
             try? await entry.connection.done()
             try? await entry.connection.disconnect()
             await cycleTask.value
+            // The runner may have completed a reconnect it had already started
+            // when the cancellation landed (NIO connect/auth/select are not
+            // cancellation-interruptible). Close whatever it left behind so
+            // teardown never relies on the group shutdown to reap a re-dialed
+            // socket.
+            try? await entry.connection.disconnect()
         } else {
             // The cycle task never started (the session is still connecting);
             // there is only the connection and its group to release. idle(on:)'s

--- a/Sources/SwiftMail/IMAP/IMAPServer+Idle.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Idle.swift
@@ -173,6 +173,9 @@ extension IMAPServer {
                 try? await connection.done()
                 try? await connection.disconnect()
                 await cycleTask.value
+                // Mirror teardownIdleEntry: close any connection the runner
+                // re-established while the cancellation was landing.
+                try? await connection.disconnect()
                 try? await idleGroup.shutdownGracefully()
             }
         }

--- a/Sources/SwiftMail/IMAP/IMAPServer+IdleRunner+Recovery.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+IdleRunner+Recovery.swift
@@ -84,6 +84,11 @@ extension IMAPResilientIdleRunner {
     ) async throws {
         do {
             try? await context.connection.disconnect()
+            // Teardown may have cancelled us while the disconnect above was in
+            // flight; none of the calls below are cancellation-interruptible
+            // (NIO futures), so re-check before dialing a session that is being
+            // torn down. Teardown still force-closes anything that slips past.
+            if Task.isCancelled { return }
             try await context.connection.connect()
             try await context.authentication.authenticate(on: context.connection)
             let selectCommand = SelectMailboxCommand(mailboxName: context.resolvedMailbox)
@@ -130,6 +135,10 @@ extension IMAPResilientIdleRunner {
             try? await context.connection.done(timeoutSeconds: context.configuration.doneTimeout)
             try? await context.connection.disconnect()
 
+            // Same window as attemptRoutineReconnect: the check above ran before
+            // done/disconnect, and cancellation may have landed since. Don't
+            // re-dial a session that teardown is waiting on.
+            if Task.isCancelled { return }
             try await context.connection.connect()
             try await context.authentication.authenticate(on: context.connection)
             let selectCommand = SelectMailboxCommand(mailboxName: context.resolvedMailbox)

--- a/Tests/SwiftIMAPTests/IMAPIdleGroupLifecycleTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPIdleGroupLifecycleTests.swift
@@ -134,6 +134,7 @@ import Testing
                 let session = try await server.idle(on: "INBOX", configuration: configuration)
                 #expect(try await waitForIdleCommandCount(testServer, atLeast: 1))
                 let idleCommandsBeforeDisconnect = testServer.idleCommandCount
+                let connectionsBeforeDisconnect = testServer.acceptedConnectionCount
 
                 try await server.disconnect()
 
@@ -143,9 +144,12 @@ import Testing
                 )
 
                 // Ample window for a surviving runner to re-dial (its reconnect
-                // delay is 10–50 ms).
+                // delay is 10–50 ms). Assert on connections as well as IDLE
+                // commands: a post-cancellation reconnect dials and authenticates
+                // without ever issuing another IDLE.
                 try await Task.sleep(nanoseconds: 500_000_000)
                 #expect(testServer.idleCommandCount == idleCommandsBeforeDisconnect)
+                #expect(testServer.acceptedConnectionCount == connectionsBeforeDisconnect)
 
                 // A redundant done() after disconnect must be safe and idempotent.
                 try? await session.done()
@@ -180,6 +184,7 @@ import Testing
                 let session = try await server.idle(on: "INBOX", configuration: configuration)
                 #expect(try await waitForIdleCommandCount(testServer, atLeast: 1))
                 let idleCommandsBefore = testServer.idleCommandCount
+                let connectionsBefore = testServer.acceptedConnectionCount
 
                 let doneTask = Task {
                     try? await session.done()
@@ -194,6 +199,7 @@ import Testing
 
                 try await Task.sleep(nanoseconds: 500_000_000)
                 #expect(testServer.idleCommandCount == idleCommandsBefore)
+                #expect(testServer.acceptedConnectionCount == connectionsBefore)
 
                 try? await server.disconnect()
             }

--- a/Tests/SwiftIMAPTests/IMAPTestServer.swift
+++ b/Tests/SwiftIMAPTests/IMAPTestServer.swift
@@ -76,6 +76,19 @@ final class IMAPTestServer {
         metricsQueue.sync { idleCommandCountStorage += 1 }
     }
 
+    /// Total connections ever accepted. Catches re-dials that never reach an
+    /// IDLE command (connect + LOGIN + SELECT and then exit), which
+    /// `idleCommandCount` alone cannot see.
+    var acceptedConnectionCount: Int {
+        metricsQueue.sync { acceptedConnectionCountStorage }
+    }
+
+    private var acceptedConnectionCountStorage = 0
+
+    private func recordAcceptedConnection() {
+        metricsQueue.sync { acceptedConnectionCountStorage += 1 }
+    }
+
     func start() throws {
         resetClientTrackingForStart()
 
@@ -220,6 +233,7 @@ final class IMAPTestServer {
             close(clientFd)
             return
         }
+        recordAcceptedConnection()
 
         // Handle on a background queue
         let clientGroup = clientGroup


### PR DESCRIPTION
Follow-up to #196, addressing [the Codex P2 review comment](https://github.com/Cocoanetics/SwiftMail/pull/196#discussion_r3665724570): a `disconnect()` racing a BYE-triggered `attemptRoutineReconnect` could still end with the server re-dialed and authenticated after teardown, because the runner had already passed its last cancellation check and nothing in `disconnect → connect → authenticate → select` is cancellation-interruptible (NIO futures). The re-dialed socket was reaped only by the group shutdown, and the #196 regression test could not see it — a dying runner's reconnect never issues another IDLE, so `idleCommandCount` stays flat.

Verified the claim in both recovery paths before fixing: `attemptRoutineReconnect` has no cancellation check at all, and `handleCycleError` checks only *before* its dial sequence.

## What changed

- **Runner**: both recovery paths re-check `Task.isCancelled` immediately before dialing, narrowing the window to the unavoidable check-to-connect gap.
- **Teardown** (both `teardownIdleEntry` and the post-deinit fallback): after `await cycleTask.value`, the connection is closed once more — whatever a dying runner re-established is force-closed, and teardown never relies on the `EventLoopGroup` shutdown to reap a socket.
- **Tests**: the fake server now counts accepted connections (`acceptedConnectionCount`), and both #196 regression tests assert the count stays flat across teardown — making connect-without-IDLE re-dials visible.

The order (close socket → await runner → close again) is deliberate: awaiting the runner *before* the first close could hang up to a renewal interval on futures that cancellation cannot interrupt, so the first close stays where it is to error them out fast.

## Validation

- `swift test` — 358 tests in 49 suites, 0 failures
- `swiftlint lint --strict` clean on the touched files

🤖 Generated with [Claude Code](https://claude.com/claude-code)
