### PR TITLE
Fix byte offsets when splitting EML headers

### DIFF
--- a/Sources/SwiftMail/MIME/EMLParser+Headers.swift
+++ b/Sources/SwiftMail/MIME/EMLParser+Headers.swift
@@ -15,7 +15,7 @@ extension EMLParser {
         for separator in [Data("\r\n\r\n".utf8), Data("\n\n".utf8)] {
             guard let range = rawData.range(of: separator) else { continue }
             let headerData = rawData[..<range.lowerBound]
-            let headerBlock = String(decoding: headerData, as: UTF8.self)
+            let headerBlock = String(bytes: headerData, encoding: .utf8) ?? ""
             return (headerBlock, Data(rawData[range.upperBound...]))
         }
 

--- a/Sources/SwiftMail/MIME/EMLParser+Headers.swift
+++ b/Sources/SwiftMail/MIME/EMLParser+Headers.swift
@@ -7,20 +7,25 @@ extension EMLParser {
 
     // MARK: - Header Block Splitting
 
-    /// Split the raw message into header block (String) and body (Data).
-    static func splitHeadersAndBody(from string: String, rawData: Data) -> (String, Data) {
+    /// Split raw message bytes into a decoded header block and an opaque body.
+    static func splitHeadersAndBody(rawData: Data) throws -> (String, Data) {
         // Find the blank-line separator in the original bytes. String indices
         // and character distances are not byte offsets: CRLF is one Character
         // but two bytes, and non-ASCII header text can span multiple UTF-8 bytes.
         for separator in [Data("\r\n\r\n".utf8), Data("\n\n".utf8)] {
             guard let range = rawData.range(of: separator) else { continue }
             let headerData = rawData[..<range.lowerBound]
-            let headerBlock = String(bytes: headerData, encoding: .utf8) ?? ""
+            guard let headerBlock = String(bytes: headerData, encoding: .utf8) else {
+                throw EMLParserError.invalidData
+            }
             return (headerBlock, Data(rawData[range.upperBound...]))
         }
 
         // No body — entire content is headers
-        return (string, Data())
+        guard let headerBlock = String(bytes: rawData, encoding: .utf8) else {
+            throw EMLParserError.invalidData
+        }
+        return (headerBlock, Data())
     }
 
     // MARK: - Header Parsing

--- a/Sources/SwiftMail/MIME/EMLParser+Headers.swift
+++ b/Sources/SwiftMail/MIME/EMLParser+Headers.swift
@@ -9,17 +9,14 @@ extension EMLParser {
 
     /// Split the raw message into header block (String) and body (Data).
     static func splitHeadersAndBody(from string: String, rawData: Data) -> (String, Data) {
-        // Find the blank line separator — try \r\n\r\n first, then \n\n
-        if let range = string.range(of: "\r\n\r\n") {
-            let headerBlock = String(string[string.startIndex..<range.lowerBound])
-            let bodyStart = string.distance(from: string.startIndex, to: range.upperBound)
-            let bodyData = rawData.dropFirst(bodyStart)
-            return (headerBlock, Data(bodyData))
-        } else if let range = string.range(of: "\n\n") {
-            let headerBlock = String(string[string.startIndex..<range.lowerBound])
-            let bodyStart = string.distance(from: string.startIndex, to: range.upperBound)
-            let bodyData = rawData.dropFirst(bodyStart)
-            return (headerBlock, Data(bodyData))
+        // Find the blank-line separator in the original bytes. String indices
+        // and character distances are not byte offsets: CRLF is one Character
+        // but two bytes, and non-ASCII header text can span multiple UTF-8 bytes.
+        for separator in [Data("\r\n\r\n".utf8), Data("\n\n".utf8)] {
+            guard let range = rawData.range(of: separator) else { continue }
+            let headerData = rawData[..<range.lowerBound]
+            let headerBlock = String(decoding: headerData, as: UTF8.self)
+            return (headerBlock, Data(rawData[range.upperBound...]))
         }
 
         // No body — entire content is headers

--- a/Sources/SwiftMail/MIME/EMLParser+Multipart.swift
+++ b/Sources/SwiftMail/MIME/EMLParser+Multipart.swift
@@ -160,7 +160,9 @@ extension EMLParser {
         let childPath = sectionPath.isEmpty ? [partNumber] : sectionPath + [partNumber]
 
         let partData = Data(rawPart.utf8)
-        let (partHeaders, partBody) = splitHeadersAndBody(from: rawPart, rawData: partData)
+        guard let (partHeaders, partBody) = try? splitHeadersAndBody(rawData: partData) else {
+            return []
+        }
         let headers = parseHeaders(partHeaders)
 
         let partContentType = headers["content-type"] ?? "text/plain"

--- a/Sources/SwiftMail/MIME/EMLParser+Multipart.swift
+++ b/Sources/SwiftMail/MIME/EMLParser+Multipart.swift
@@ -49,118 +49,154 @@ extension EMLParser {
             )]
         }
 
-        let utf8Body = String(data: bodyData, encoding: .utf8)
-        let asciiBody = String(data: bodyData, encoding: .ascii)
-        guard let bodyString = utf8Body ?? asciiBody else {
-            return []
-        }
-
-        let rawParts = splitMultipartByBoundary(bodyString: bodyString, boundary: boundary)
+        let rawParts = splitMultipartByBoundary(bodyData: bodyData, boundary: boundary)
         return rawParts.enumerated().flatMap { index, rawPart -> [MessagePart] in
             buildMultipartChild(rawPart: rawPart, index: index, sectionPath: sectionPath)
         }
     }
 
-    /// Split a multipart body string into raw part strings using the boundary
-    /// delimiter. Returns an array of raw (header+body) part strings.
-    static func splitMultipartByBoundary(bodyString: String, boundary: String) -> [String] {
-        let delimiter = "--\(boundary)"
-        var rawParts: [String] = []
-        var searchStart = bodyString.startIndex
+    /// Split a multipart body into opaque byte slices using valid boundary lines.
+    /// The preamble, epilogue, and CRLF framing around each part are discarded.
+    static func splitMultipartByBoundary(bodyData: Data, boundary: String) -> [Data] {
+        let marker = Data("--\(boundary)".utf8)
+        guard !marker.isEmpty else { return [] }
 
-        while searchStart < bodyString.endIndex {
-            guard let delimRange = bodyString.range(of: delimiter, range: searchStart..<bodyString.endIndex) else {
-                break
-            }
+        var rawParts: [Data] = []
+        var currentPartStart: Data.Index?
+        var searchStart = bodyData.startIndex
 
-            // Check if this is the end delimiter
-            if isMultipartEndDelimiter(bodyString: bodyString, after: delimRange.upperBound) {
-                break
-            }
-
-            // Find the start of part content (skip past delimiter + line ending)
-            let contentStart = skipPastDelimiterLineEnding(
-                bodyString: bodyString,
-                from: delimRange.upperBound
-            )
-
-            // Find the next boundary to determine the end of this part
-            if let nextDelimRange = bodyString.range(of: delimiter, range: contentStart..<bodyString.endIndex) {
-                let contentEnd = trimmedPartEnd(
-                    bodyString: bodyString,
-                    contentStart: contentStart,
-                    delimiterStart: nextDelimRange.lowerBound
+        while let delimiter = nextMultipartDelimiter(
+            in: bodyData,
+            marker: marker,
+            startingAt: searchStart
+        ) {
+            if let partStart = currentPartStart {
+                let partEnd = trimLineEnding(
+                    before: delimiter.range.lowerBound,
+                    notBefore: partStart,
+                    in: bodyData
                 )
-                rawParts.append(String(bodyString[contentStart..<contentEnd]))
-                searchStart = nextDelimRange.lowerBound
-            } else {
-                // No more boundaries — take the rest
-                let remainder = String(bodyString[contentStart...]).trimmingCharacters(in: .whitespacesAndNewlines)
-                rawParts.append(remainder)
+                rawParts.append(Data(bodyData[partStart..<partEnd]))
+            }
+
+            if delimiter.isClosing {
+                currentPartStart = nil
                 break
             }
+
+            currentPartStart = delimiter.lineEnd
+            searchStart = delimiter.lineEnd
+        }
+
+        if let partStart = currentPartStart {
+            rawParts.append(Data(bodyData[partStart...]))
         }
 
         return rawParts
     }
 
-    /// Return `true` if the characters immediately after a boundary match are
-    /// `"--"`, signalling the multipart end delimiter.
-    private static func isMultipartEndDelimiter(bodyString: String, after index: String.Index) -> Bool {
-        guard index < bodyString.endIndex else { return false }
-        return bodyString[index...].hasPrefix("--")
+    private struct MultipartDelimiter {
+        let range: Range<Data.Index>
+        let lineEnd: Data.Index
+        let isClosing: Bool
     }
 
-    /// Skip past any CR/LF characters following a boundary delimiter so the
-    /// caller can read the part's header block.
-    private static func skipPastDelimiterLineEnding(
-        bodyString: String,
-        from start: String.Index
-    ) -> String.Index {
-        var contentStart = start
-        if contentStart < bodyString.endIndex && bodyString[contentStart] == "\r" {
-            contentStart = bodyString.index(after: contentStart)
+    /// Locate the next delimiter line without decoding any MIME body bytes.
+    private static func nextMultipartDelimiter(
+        in data: Data,
+        marker: Data,
+        startingAt start: Data.Index
+    ) -> MultipartDelimiter? {
+        var searchStart = start
+
+        while searchStart < data.endIndex,
+              let range = data.range(of: marker, in: searchStart..<data.endIndex) {
+            guard isStartOfLine(range.lowerBound, in: data),
+                  let delimiter = multipartDelimiter(in: data, markerRange: range) else {
+                searchStart = data.index(after: range.lowerBound)
+                continue
+            }
+            return delimiter
         }
-        if contentStart < bodyString.endIndex && bodyString[contentStart] == "\n" {
-            contentStart = bodyString.index(after: contentStart)
-        }
-        return contentStart
+
+        return nil
     }
 
-    /// Trim the trailing CR/LF that precedes the next boundary delimiter so the
-    /// returned slice contains only the part body.
-    private static func trimmedPartEnd(
-        bodyString: String,
-        contentStart: String.Index,
-        delimiterStart: String.Index
-    ) -> String.Index {
-        var contentEnd = delimiterStart
-        guard contentEnd > contentStart else { return contentEnd }
-
-        let beforeEnd = bodyString.index(before: contentEnd)
-        guard bodyString[beforeEnd] == "\n" else { return contentEnd }
-        contentEnd = beforeEnd
-
-        guard contentEnd > contentStart else { return contentEnd }
-        let beforeLF = bodyString.index(before: contentEnd)
-        if bodyString[beforeLF] == "\r" {
-            contentEnd = beforeLF
-        }
-        return contentEnd
+    private static func isStartOfLine(_ index: Data.Index, in data: Data) -> Bool {
+        index == data.startIndex || data[data.index(before: index)] == 0x0A
     }
 
-    /// Build the `MessagePart` value(s) for a single raw multipart child string.
+    private static func multipartDelimiter(
+        in data: Data,
+        markerRange: Range<Data.Index>
+    ) -> MultipartDelimiter? {
+        var cursor = markerRange.upperBound
+        let isClosing = hasBytePair(0x2D, 0x2D, in: data, at: cursor)
+        if isClosing {
+            cursor = data.index(cursor, offsetBy: 2)
+        }
+
+        while cursor < data.endIndex && (data[cursor] == 0x20 || data[cursor] == 0x09) {
+            cursor = data.index(after: cursor)
+        }
+
+        let lineEnd: Data.Index
+        if cursor == data.endIndex {
+            lineEnd = cursor
+        } else if data[cursor] == 0x0A {
+            lineEnd = data.index(after: cursor)
+        } else if hasBytePair(0x0D, 0x0A, in: data, at: cursor) {
+            lineEnd = data.index(cursor, offsetBy: 2)
+        } else {
+            return nil
+        }
+
+        return MultipartDelimiter(range: markerRange, lineEnd: lineEnd, isClosing: isClosing)
+    }
+
+    private static func hasBytePair(
+        _ first: UInt8,
+        _ second: UInt8,
+        in data: Data,
+        at start: Data.Index
+    ) -> Bool {
+        guard start < data.endIndex else { return false }
+        let next = data.index(after: start)
+        return next < data.endIndex && data[start] == first && data[next] == second
+    }
+
+    private static func trimLineEnding(
+        before end: Data.Index,
+        notBefore start: Data.Index,
+        in data: Data
+    ) -> Data.Index {
+        var trimmedEnd = end
+        guard trimmedEnd > start else { return trimmedEnd }
+
+        let previous = data.index(before: trimmedEnd)
+        guard data[previous] == 0x0A else { return trimmedEnd }
+        trimmedEnd = previous
+
+        if trimmedEnd > start {
+            let beforeLF = data.index(before: trimmedEnd)
+            if data[beforeLF] == 0x0D {
+                trimmedEnd = beforeLF
+            }
+        }
+        return trimmedEnd
+    }
+
+    /// Build the `MessagePart` value(s) for a single raw multipart child.
     /// Recursively descends into nested multipart parts.
     static func buildMultipartChild(
-        rawPart: String,
+        rawPart: Data,
         index: Int,
         sectionPath: [Int]
     ) -> [MessagePart] {
         let partNumber = index + 1
         let childPath = sectionPath.isEmpty ? [partNumber] : sectionPath + [partNumber]
 
-        let partData = Data(rawPart.utf8)
-        guard let (partHeaders, partBody) = try? splitHeadersAndBody(rawData: partData) else {
+        guard let (partHeaders, partBody) = try? splitHeadersAndBody(rawData: rawPart) else {
             return []
         }
         let headers = parseHeaders(partHeaders)

--- a/Sources/SwiftMail/MIME/EMLParser.swift
+++ b/Sources/SwiftMail/MIME/EMLParser.swift
@@ -34,12 +34,9 @@ public struct EMLParser {
     /// - Parameter data: Raw RFC 822 bytes (as obtained from `fetchRawMessage` or an `.eml` file).
     /// - Returns: A fully populated ``Message``.
     public static func parse(_ data: Data) throws -> Message {
-        guard let string = String(data: data, encoding: .utf8) ?? String(data: data, encoding: .ascii) else {
-            throw EMLParserError.invalidData
-        }
-
-        // Split headers and body at the first blank line
-        let (headerBlock, bodyData) = splitHeadersAndBody(from: string, rawData: data)
+        // Decode only the RFC 822 header bytes. The body can legitimately use
+        // an arbitrary 8bit charset or contain opaque binary data.
+        let (headerBlock, bodyData) = try splitHeadersAndBody(rawData: data)
 
         guard !headerBlock.isEmpty else {
             throw EMLParserError.missingHeaders

--- a/Tests/SwiftIMAPTests/EMLTests.swift
+++ b/Tests/SwiftIMAPTests/EMLTests.swift
@@ -38,6 +38,51 @@ struct EMLParserTests {
         #expect(message.textBody?.contains("Hello, this is a test message.") == true)
     }
 
+    @Test("Preserve non-UTF-8 8bit body bytes")
+    func testParseNonUTF8Body() throws {
+        let headers = [
+            "From: sender@example.com",
+            "To: recipient@example.com",
+            "Subject: ISO-8859-1 Body",
+            "Content-Type: text/plain; charset=iso-8859-1",
+            "Content-Transfer-Encoding: 8bit",
+            "",
+            ""
+        ].joined(separator: "\r\n")
+        let body = Data([0x63, 0x61, 0x66, 0xE9])
+        var data = Data(headers.utf8)
+        data.append(body)
+
+        let message = try Message(emlData: data)
+
+        #expect(message.parts.count == 1)
+        #expect(message.parts[0].data == body)
+        #expect(message.parts[0].decodedData() == body)
+        #expect(message.parts[0].textContent == "café")
+    }
+
+    @Test("Preserve opaque binary body bytes")
+    func testParseBinaryBody() throws {
+        let headers = [
+            "From: sender@example.com",
+            "To: recipient@example.com",
+            "Subject: Binary Body",
+            "Content-Type: application/octet-stream",
+            "Content-Transfer-Encoding: binary",
+            "",
+            ""
+        ].joined(separator: "\r\n")
+        let body = Data([0x00, 0x7F, 0x80, 0xFF])
+        var data = Data(headers.utf8)
+        data.append(body)
+
+        let message = try Message(emlData: data)
+
+        #expect(message.parts.count == 1)
+        #expect(message.parts[0].data == body)
+        #expect(message.parts[0].decodedData() == body)
+    }
+
     // MARK: - Multipart Alternative
 
     @Test("Parse multipart/alternative message")

--- a/Tests/SwiftIMAPTests/EMLTests.swift
+++ b/Tests/SwiftIMAPTests/EMLTests.swift
@@ -106,6 +106,7 @@ struct EMLParserTests {
         #expect(message.parts[1].disposition == "attachment")
         #expect(message.parts[1].encoding == "base64")
         #expect(message.attachments.count == 1)
+        #expect(message.attachments[0].decodedData() == Data("Hello World".utf8))
     }
 
     // MARK: - RFC 2047 Encoded Subject

--- a/Tests/SwiftIMAPTests/EMLTests.swift
+++ b/Tests/SwiftIMAPTests/EMLTests.swift
@@ -116,6 +116,70 @@ struct EMLParserTests {
         #expect(message.htmlBody?.contains("HTML version.") == true)
     }
 
+    @Test("Preserve non-UTF-8 8bit multipart child bytes")
+    func testParseMultipartNonUTF8Body() throws {
+        let headers = [
+            "From: sender@example.com",
+            "To: recipient@example.com",
+            "Subject: Multipart ISO-8859-1 Body",
+            "Content-Type: multipart/mixed; boundary=byte-boundary",
+            "",
+            ""
+        ].joined(separator: "\r\n")
+        let partHeaders = [
+            "--byte-boundary",
+            "Content-Type: text/plain; charset=iso-8859-1",
+            "Content-Transfer-Encoding: 8bit",
+            "",
+            ""
+        ].joined(separator: "\r\n")
+        let body = Data([0x63, 0x61, 0x66, 0xE9])
+        var data = Data(headers.utf8)
+        data.append(Data(partHeaders.utf8))
+        data.append(body)
+        data.append(Data("\r\n--byte-boundary--\r\n".utf8))
+
+        let message = try Message(emlData: data)
+
+        try #require(message.parts.count == 1)
+        #expect(message.parts[0].data == body)
+        #expect(message.parts[0].decodedData() == body)
+        #expect(message.parts[0].textContent == "café")
+    }
+
+    @Test("Preserve opaque binary multipart child bytes")
+    func testParseMultipartBinaryBody() throws {
+        let headers = [
+            "From: sender@example.com",
+            "To: recipient@example.com",
+            "Subject: Multipart Binary Body",
+            "Content-Type: multipart/mixed; boundary=byte-boundary",
+            "",
+            ""
+        ].joined(separator: "\r\n")
+        let partHeaders = [
+            "--byte-boundary",
+            "Content-Type: application/octet-stream; name=payload.bin",
+            "Content-Disposition: attachment; filename=payload.bin",
+            "Content-Transfer-Encoding: binary",
+            "",
+            ""
+        ].joined(separator: "\r\n")
+        let body = Data([0x00, 0x7F, 0x80, 0xFF])
+        var data = Data(headers.utf8)
+        data.append(Data(partHeaders.utf8))
+        data.append(body)
+        data.append(Data("\r\n--byte-boundary--\r\n".utf8))
+
+        let message = try Message(emlData: data)
+
+        try #require(message.parts.count == 1)
+        #expect(message.parts[0].filename == "payload.bin")
+        #expect(message.parts[0].data == body)
+        #expect(message.parts[0].decodedData() == body)
+        #expect(message.attachments.count == 1)
+    }
+
     // MARK: - Multipart Mixed with Attachment
 
     @Test("Parse multipart/mixed with attachment")


### PR DESCRIPTION
## What changed

- find the EML header/body separator in the original `Data`
- decode only the header byte range
- add a regression assertion for exact Base64 attachment decoding

## Root cause

The parser used a Swift `String` character distance as a raw `Data` byte offset. CRLF and multi-byte UTF-8 content make those units diverge, so the body could start too early and corrupt MIME transfer decoding.

Fixes #201

## Validation

- `swift test`
- 404 tests in 52 suites passed
