### PR TITLE
Replay RFC 2971 ID after every authentication when configured (supersedes #193)

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAPConnection+Authentication.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+Authentication.swift
@@ -278,7 +278,15 @@ extension IMAPConnection {
             await handleConnectionTerminationInResponses(handler.untaggedResponses)
             duplexLogger.flushInboundBuffer()
 
-            applyXOAUTH2Capabilities(refreshedCapabilities)
+            isSessionAuthenticated = true
+            // AUTHENTICATE often returns an OK without CAPABILITY data, and RFC 3501
+            // invalidates the pre-authentication capability set once authentication
+            // succeeds. Refresh from the server instead of retaining the stale
+            // snapshot — capability-gated features (like the RFC 2971 ID replay)
+            // would otherwise miss capabilities the server only advertises after
+            // authentication. useCommandBody avoids re-entering the command queue
+            // this method already holds, like the namespace fetch below.
+            try await refreshCapabilities(using: refreshedCapabilities, useCommandBody: true)
             await fetchNamespacesIfSupported(useCommandBody: true)
         } catch {
             await handleXOAUTH2Failure(
@@ -317,18 +325,6 @@ extension IMAPConnection {
         )
         let wrapped = IMAPClientHandler.OutboundIn.part(CommandStreamPart.tagged(command))
         try await channel.writeAndFlush(wrapped).get()
-    }
-
-    private func applyXOAUTH2Capabilities(_ refreshedCapabilities: [Capability]) {
-        isSessionAuthenticated = true
-        if !refreshedCapabilities.isEmpty {
-            self.capabilities = Set(refreshedCapabilities)
-        } else {
-            // AUTHENTICATE often returns an OK without CAPABILITY data.
-            // Avoid issuing a follow-up CAPABILITY command here because we're already
-            // inside commandQueue.run, and a nested executeCommand would deadlock.
-            logger.debug("XOAUTH2 completed without capability data; retaining existing capability snapshot")
-        }
     }
 
     private func handleXOAUTH2Failure(

--- a/Sources/SwiftMail/IMAP/IMAPConnection+CommandExecution.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+CommandExecution.swift
@@ -11,13 +11,22 @@ extension IMAPConnection {
         return serverCapabilities
     }
 
-    func refreshCapabilities(using reportedCapabilities: [Capability]) async throws {
+    /// Replaces the capability snapshot with `reportedCapabilities`, or — when the
+    /// server reported none — with the result of an explicit CAPABILITY command.
+    /// Pass `useCommandBody: true` from call sites that already hold the command
+    /// queue (mirrors `fetchNamespacesIfSupported(useCommandBody:)`).
+    func refreshCapabilities(using reportedCapabilities: [Capability], useCommandBody: Bool = false) async throws {
         if !reportedCapabilities.isEmpty {
             self.capabilities = Set(reportedCapabilities)
             return
         }
 
-        try await fetchCapabilities()
+        if useCommandBody {
+            let refreshedCapabilities = try await executeCommandBody(CapabilityCommand())
+            self.capabilities = Set(refreshedCapabilities)
+        } else {
+            try await fetchCapabilities()
+        }
     }
 
     func fetchNamespaces() async throws -> NamespaceResponse {

--- a/Sources/SwiftMail/IMAP/IMAPServer+Connection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Connection.swift
@@ -74,7 +74,7 @@ extension IMAPServer {
             method: .login(username: username, password: password),
             identification: clientIdentification
         )
-        await identifyPrimaryConnectionIfNeeded()
+        try await identifyPrimaryConnectionIfNeeded()
         namespaces = primaryConnection.namespacesSnapshot
     }
 
@@ -95,7 +95,7 @@ extension IMAPServer {
             method: .plain(username: username, password: password),
             identification: clientIdentification
         )
-        await identifyPrimaryConnectionIfNeeded()
+        try await identifyPrimaryConnectionIfNeeded()
         namespaces = primaryConnection.namespacesSnapshot
     }
 
@@ -111,7 +111,7 @@ extension IMAPServer {
             method: .xoauth2(email: email, accessTokenProvider: { accessToken }),
             identification: clientIdentification
         )
-        await identifyPrimaryConnectionIfNeeded()
+        try await identifyPrimaryConnectionIfNeeded()
         namespaces = primaryConnection.namespacesSnapshot
     }
 
@@ -135,18 +135,21 @@ extension IMAPServer {
     /// every connection — including ones the server opens internally — send
     /// ID right after authenticating. Call it before
     /// `login`/`authenticatePlain`/`authenticateXOAUTH2`. Servers that do not
-    /// advertise the ID capability are never sent the command.
+    /// advertise the ID capability are never sent the command, and a server
+    /// refusing ID (NO/BAD) never fails the authentication — but an ID
+    /// failure that kills the connection surfaces as an authentication error
+    /// instead of handing back a dead session.
     public func setClientIdentification(_ identification: Identification?) {
         clientIdentification = identification
         authentication?.identification = identification
     }
 
-    /// RFC 2971 replay for the primary connection's explicit authentication.
-    /// Best-effort: a failed ID must never fail the authentication itself.
-    private func identifyPrimaryConnectionIfNeeded() async {
-        guard let clientIdentification,
-              primaryConnection.capabilitiesSnapshot.contains(.id) else { return }
-        _ = try? await primaryConnection.id(clientIdentification)
+    /// RFC 2971 replay for the primary connection's explicit authentication
+    /// paths, with the same failure semantics as the internal replay in
+    /// ``Authentication/identify(_:with:)``.
+    private func identifyPrimaryConnectionIfNeeded() async throws {
+        guard let clientIdentification else { return }
+        try await Authentication.identify(primaryConnection, with: clientIdentification)
     }
 
     /// Identify the client to the server using the `ID` command.

--- a/Sources/SwiftMail/IMAP/IMAPServer+Connection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Connection.swift
@@ -70,7 +70,11 @@ extension IMAPServer {
      */
     public func login(username: String, password: String) async throws {
         try await primaryConnection.login(username: username, password: password)
-        authentication = .login(username: username, password: password)
+        authentication = Authentication(
+            method: .login(username: username, password: password),
+            identification: clientIdentification
+        )
+        await identifyPrimaryConnectionIfNeeded()
         namespaces = primaryConnection.namespacesSnapshot
     }
 
@@ -87,7 +91,11 @@ extension IMAPServer {
     ///   or ``IMAPError.authFailed`` when authentication fails.
     public func authenticatePlain(username: String, password: String) async throws {
         try await primaryConnection.authenticatePlain(username: username, password: password)
-        authentication = .plain(username: username, password: password)
+        authentication = Authentication(
+            method: .plain(username: username, password: password),
+            identification: clientIdentification
+        )
+        await identifyPrimaryConnectionIfNeeded()
         namespaces = primaryConnection.namespacesSnapshot
     }
 
@@ -99,7 +107,11 @@ extension IMAPServer {
     ///   ``IMAPError.authFailed`` when authentication fails.
     public func authenticateXOAUTH2(email: String, accessToken: String) async throws {
         try await primaryConnection.authenticateXOAUTH2(email: email, accessToken: accessToken)
-        authentication = .xoauth2(email: email, accessTokenProvider: { accessToken })
+        authentication = Authentication(
+            method: .xoauth2(email: email, accessTokenProvider: { accessToken }),
+            identification: clientIdentification
+        )
+        await identifyPrimaryConnectionIfNeeded()
         namespaces = primaryConnection.namespacesSnapshot
     }
 
@@ -109,7 +121,32 @@ extension IMAPServer {
         email: String,
         accessTokenProvider: @escaping @Sendable () async throws -> String
     ) {
-        authentication = .xoauth2(email: email, accessTokenProvider: accessTokenProvider)
+        authentication = Authentication(
+            method: .xoauth2(email: email, accessTokenProvider: accessTokenProvider),
+            identification: clientIdentification
+        )
+    }
+
+    /// Stores the RFC 2971 client identity replayed after every successful
+    /// authentication on every connection this server opens (primary,
+    /// dedicated IDLE connections, and transparent re-authentication).
+    /// Some servers (e.g. NetEase 163/126) reject SELECT on any authenticated
+    /// connection that has not identified itself; configuring this once makes
+    /// every connection — including ones the server opens internally — send
+    /// ID right after authenticating. Call it before
+    /// `login`/`authenticatePlain`/`authenticateXOAUTH2`. Servers that do not
+    /// advertise the ID capability are never sent the command.
+    public func setClientIdentification(_ identification: Identification?) {
+        clientIdentification = identification
+        authentication?.identification = identification
+    }
+
+    /// RFC 2971 replay for the primary connection's explicit authentication.
+    /// Best-effort: a failed ID must never fail the authentication itself.
+    private func identifyPrimaryConnectionIfNeeded() async {
+        guard let clientIdentification,
+              primaryConnection.capabilitiesSnapshot.contains(.id) else { return }
+        _ = try? await primaryConnection.id(clientIdentification)
     }
 
     /// Identify the client to the server using the `ID` command.

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -71,6 +71,12 @@ public actor IMAPServer {
     /// Authentication configuration for spawning new connections.
     var authentication: Authentication?
 
+    /// RFC 2971 client identity replayed after every successful
+    /// authentication on every connection this server opens (primary,
+    /// dedicated IDLE connections, and transparent re-authentication).
+    /// Set it before calling `login`/`authenticatePlain`/`authenticateXOAUTH2`.
+    var clientIdentification: Identification?
+
     /** The list of all mailboxes with their attributes */
     public private(set) var mailboxes: [Mailbox.Info] = []
 
@@ -121,13 +127,18 @@ public actor IMAPServer {
         let handle: IMAPNamedConnection
     }
 
-    enum Authentication {
-        case login(username: String, password: String)
-        case plain(username: String, password: String)
-        case xoauth2(email: String, accessTokenProvider: @Sendable () async throws -> String)
+    struct Authentication {
+        enum Method {
+            case login(username: String, password: String)
+            case plain(username: String, password: String)
+            case xoauth2(email: String, accessTokenProvider: @Sendable () async throws -> String)
+        }
+
+        let method: Method
+        var identification: Identification?
 
         func authenticate(on connection: IMAPConnection) async throws {
-            switch self {
+            switch method {
                 case .login(let username, let password):
                     try await connection.login(username: username, password: password)
                 case .plain(let username, let password):
@@ -135,6 +146,14 @@ public actor IMAPServer {
                 case .xoauth2(let email, let accessTokenProvider):
                     let accessToken = try await accessTokenProvider()
                     try await connection.authenticateXOAUTH2(email: email, accessToken: accessToken)
+            }
+            // RFC 2971: some servers (e.g. NetEase 163/126) reject SELECT on any
+            // authenticated connection that has not identified itself, so the
+            // stored identity is replayed after every authentication. Servers
+            // that do not advertise the ID capability are skipped, and a
+            // failed ID must never fail the authentication itself.
+            if let identification, connection.capabilitiesSnapshot.contains(.id) {
+                _ = try? await connection.id(identification)
             }
         }
     }

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -127,14 +127,14 @@ public actor IMAPServer {
         let handle: IMAPNamedConnection
     }
 
-    struct Authentication {
-        enum Method {
-            case login(username: String, password: String)
-            case plain(username: String, password: String)
-            case xoauth2(email: String, accessTokenProvider: @Sendable () async throws -> String)
-        }
+    enum AuthenticationMethod {
+        case login(username: String, password: String)
+        case plain(username: String, password: String)
+        case xoauth2(email: String, accessTokenProvider: @Sendable () async throws -> String)
+    }
 
-        let method: Method
+    struct Authentication {
+        let method: AuthenticationMethod
         var identification: Identification?
 
         func authenticate(on connection: IMAPConnection) async throws {
@@ -149,11 +149,34 @@ public actor IMAPServer {
             }
             // RFC 2971: some servers (e.g. NetEase 163/126) reject SELECT on any
             // authenticated connection that has not identified itself, so the
-            // stored identity is replayed after every authentication. Servers
-            // that do not advertise the ID capability are skipped, and a
-            // failed ID must never fail the authentication itself.
-            if let identification, connection.capabilitiesSnapshot.contains(.id) {
-                _ = try? await connection.id(identification)
+            // stored identity is replayed after every authentication.
+            guard let identification else { return }
+            try await Self.identify(connection, with: identification)
+        }
+
+        /// Replays the stored RFC 2971 identity on a freshly authenticated
+        /// connection. Servers that do not advertise the ID capability are
+        /// never sent the command — the snapshot is authoritative here because
+        /// every authentication path refreshes it before returning. A server
+        /// refusing ID (NO/BAD) is tolerated: the session stays authenticated
+        /// and usable. But an ID failure that recycles the connection (socket
+        /// closed, timeout) must propagate — swallowing it would report
+        /// authentication success for a connection that is no longer
+        /// connected or authenticated.
+        static func identify(
+            _ connection: IMAPConnection,
+            with identification: Identification
+        ) async throws {
+            guard connection.capabilitiesSnapshot.contains(.id) else { return }
+
+            do {
+                _ = try await connection.id(identification)
+            } catch let error as CancellationError {
+                throw error
+            } catch {
+                guard connection.isConnected, connection.isAuthenticated else {
+                    throw error
+                }
             }
         }
     }

--- a/Tests/SwiftIMAPTests/ClientIdentificationReplayTests.swift
+++ b/Tests/SwiftIMAPTests/ClientIdentificationReplayTests.swift
@@ -1,0 +1,312 @@
+import Foundation
+import NIO
+import NIOEmbedded
+import NIOIMAP
+import NIOIMAPCore
+import Testing
+@testable import SwiftMail
+
+/// Coverage for the RFC 2971 ID replay that runs after every successful
+/// authentication when a client identification is configured (PR #193):
+/// the replay itself, the post-auth capability refresh that makes the
+/// ID-capability guard reliable for XOAUTH2, and the failure semantics —
+/// a server refusing ID is tolerated, a connection-killing ID failure is not.
+@Suite(.serialized, .timeLimit(.minutes(1)))
+struct ClientIdentificationReplayTests {
+    private struct Harness {
+        let connection: IMAPConnection
+        let channel: NIOAsyncTestingChannel
+    }
+
+    private static let identification = Identification(name: "SwiftMailTests", version: "1.0")
+
+    @Test
+    func serverRefusingIDDoesNotFailAuthentication() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+
+        do {
+            let harness = try await makeHarness(group: group, capabilities: [])
+            let authentication = IMAPServer.Authentication(
+                method: .login(username: "testuser", password: "testpass"),
+                identification: Self.identification
+            )
+            let authTask = Task {
+                try await authentication.authenticate(on: harness.connection)
+            }
+
+            try await respondToLogin(
+                harness: harness,
+                okLine: "A001 OK [CAPABILITY IMAP4rev1 ID] LOGIN completed\r\n"
+            )
+
+            guard let idLine = try await nextOutboundLine(from: harness.channel) else {
+                Issue.record("Expected outbound ID command after authentication")
+                authTask.cancel()
+                try await group.shutdownGracefully()
+                return
+            }
+            #expect(idLine.hasPrefix("A002 ID ("))
+
+            try await writeInboundLines(harness.channel, "A002 NO ID not permitted\r\n")
+
+            try await authTask.value
+            #expect(harness.connection.isAuthenticated)
+            #expect(harness.connection.isConnected)
+
+            try await group.shutdownGracefully()
+        } catch {
+            try? await group.shutdownGracefully()
+            throw error
+        }
+    }
+
+    /// Regression for review finding 1 on PR #193: a server that advertises ID
+    /// only after authentication and answers AUTHENTICATE with a plain OK
+    /// (no CAPABILITY response code) must still get the ID replay. The stale
+    /// pre-authentication snapshot used to short-circuit the guard.
+    @Test
+    func xoauth2WithoutCapabilityDataRefreshesCapabilitiesBeforeReplay() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+
+        do {
+            let xoauth2 = Capability.authenticate(AuthenticationMechanism("XOAUTH2"))
+            let harness = try await makeHarness(group: group, capabilities: [xoauth2, .saslIR])
+            let authentication = IMAPServer.Authentication(
+                method: .xoauth2(email: "user@example.com", accessTokenProvider: { "token123" }),
+                identification: Self.identification
+            )
+            let authTask = Task {
+                try await authentication.authenticate(on: harness.connection)
+            }
+
+            guard let authLine = try await nextOutboundLine(from: harness.channel) else {
+                Issue.record("Expected outbound AUTHENTICATE command")
+                authTask.cancel()
+                try await group.shutdownGracefully()
+                return
+            }
+            #expect(authLine.hasPrefix("A001 AUTHENTICATE XOAUTH2 "))
+            try await writeInboundLines(harness.channel, "A001 OK authenticated\r\n")
+
+            guard let capabilityLine = try await nextOutboundLine(from: harness.channel) else {
+                Issue.record("Expected capability refresh after AUTHENTICATE without capability data")
+                authTask.cancel()
+                try await group.shutdownGracefully()
+                return
+            }
+            #expect(capabilityLine == "A002 CAPABILITY\r\n")
+            try await writeInboundLines(
+                harness.channel,
+                "* CAPABILITY IMAP4rev1 AUTH=XOAUTH2 ID\r\nA002 OK CAPABILITY completed\r\n"
+            )
+
+            guard let idLine = try await nextOutboundLine(from: harness.channel) else {
+                Issue.record("Expected outbound ID command after capability refresh")
+                authTask.cancel()
+                try await group.shutdownGracefully()
+                return
+            }
+            #expect(idLine.hasPrefix("A003 ID ("))
+            try await writeInboundLines(harness.channel, "* ID NIL\r\nA003 OK ID completed\r\n")
+
+            try await authTask.value
+            #expect(harness.connection.capabilitiesSnapshot.contains(.id))
+            #expect(harness.connection.isAuthenticated)
+
+            try await group.shutdownGracefully()
+        } catch {
+            try? await group.shutdownGracefully()
+            throw error
+        }
+    }
+
+    /// Regression for review finding 2 on PR #193: when the server closes the
+    /// socket during the ID replay, the connection is recycled and left
+    /// unauthenticated — reporting authentication success anyway would hand
+    /// callers a dead connection. The failure must propagate.
+    @Test
+    func connectionDeathDuringIDFailsAuthentication() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+
+        do {
+            let harness = try await makeHarness(group: group, capabilities: [])
+            let authentication = IMAPServer.Authentication(
+                method: .login(username: "testuser", password: "testpass"),
+                identification: Self.identification
+            )
+            let authTask = Task {
+                try await authentication.authenticate(on: harness.connection)
+            }
+
+            try await respondToLogin(
+                harness: harness,
+                okLine: "A001 OK [CAPABILITY IMAP4rev1 ID] LOGIN completed\r\n"
+            )
+
+            guard let idLine = try await nextOutboundLine(from: harness.channel) else {
+                Issue.record("Expected outbound ID command after authentication")
+                authTask.cancel()
+                try await group.shutdownGracefully()
+                return
+            }
+            #expect(idLine.hasPrefix("A002 ID ("))
+
+            try await harness.channel.close().get()
+
+            do {
+                try await authTask.value
+                Issue.record("Expected authentication to fail when the connection dies during ID")
+            } catch is CancellationError {
+                Issue.record("Expected a connection failure, got CancellationError")
+            } catch {
+                // Expected: the ID failure recycled the connection, so the
+                // authentication as a whole must report failure.
+            }
+
+            #expect(!harness.connection.isAuthenticated)
+            #expect(!harness.connection.isConnected)
+
+            try await group.shutdownGracefully()
+        } catch {
+            try? await group.shutdownGracefully()
+            throw error
+        }
+    }
+
+    @Test
+    func skipsIDWhenServerDoesNotAdvertiseIt() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+
+        do {
+            let harness = try await makeHarness(group: group, capabilities: [])
+            let authentication = IMAPServer.Authentication(
+                method: .login(username: "testuser", password: "testpass"),
+                identification: Self.identification
+            )
+            let authTask = Task {
+                try await authentication.authenticate(on: harness.connection)
+            }
+
+            try await respondToLogin(
+                harness: harness,
+                okLine: "A001 OK [CAPABILITY IMAP4rev1] LOGIN completed\r\n"
+            )
+
+            try await authTask.value
+            #expect(harness.connection.isAuthenticated)
+
+            let unexpected = try await nextOutboundLine(
+                from: harness.channel,
+                timeoutNanoseconds: 200_000_000
+            )
+            #expect(unexpected == nil, "No ID command may be sent when the server does not advertise it")
+
+            try await group.shutdownGracefully()
+        } catch {
+            try? await group.shutdownGracefully()
+            throw error
+        }
+    }
+
+    // MARK: - Harness
+
+    private func makeHarness(
+        group: MultiThreadedEventLoopGroup,
+        capabilities: Set<NIOIMAPCore.Capability>
+    ) async throws -> Harness {
+        let connection = IMAPConnection(
+            host: "localhost",
+            port: 143,
+            transportSecurity: .plainText,
+            // Explicit since the designated initializer dropped its defaults: forgetting the
+            // security policy is now a build error rather than a silently lax connection.
+            minimumTLSVersion: .tlsv12,
+            group: group,
+            loggerLabel: "test.imap",
+            outboundLabel: "test.imap.out",
+            inboundLabel: "test.imap.in",
+            connectionID: "test-id-replay",
+            connectionRole: "test",
+            parserLimits: .default
+        )
+        let channel = NIOAsyncTestingChannel()
+        let address = try SocketAddress(ipAddress: "127.0.0.1", port: 143)
+        try await channel.connect(to: address)
+        try await channel.addIMAPClientHandler()
+        try await channel.pipeline.addHandler(connection.duplexLogger)
+        try await channel.pipeline.addHandler(connection.responseBuffer)
+        connection.replaceChannelForTesting(channel)
+        connection.replaceCapabilitiesForTesting(capabilities)
+
+        return Harness(connection: connection, channel: channel)
+    }
+
+    /// Consumes the outbound LOGIN command and answers it with `okLine`.
+    private func respondToLogin(harness: Harness, okLine: String) async throws {
+        guard let loginLine = try await nextOutboundLine(from: harness.channel) else {
+            Issue.record("Expected outbound LOGIN command")
+            return
+        }
+        #expect(loginLine.hasPrefix("A001 LOGIN "))
+        try await writeInboundLines(harness.channel, okLine)
+    }
+
+    private func writeInboundLines(_ channel: NIOAsyncTestingChannel, _ text: String) async throws {
+        var buffer = channel.allocator.buffer(capacity: text.utf8.count)
+        buffer.writeString(text)
+        try await channel.writeInbound(buffer)
+    }
+
+    private func nextOutboundLine(
+        from channel: NIOAsyncTestingChannel,
+        timeoutNanoseconds: UInt64 = 1_000_000_000
+    ) async throws -> String? {
+        let start = DispatchTime.now().uptimeNanoseconds
+        while DispatchTime.now().uptimeNanoseconds - start < timeoutNanoseconds {
+            if var line = try await channel.readOutbound(as: ByteBuffer.self) {
+                return line.readString(length: line.readableBytes)
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        return nil
+    }
+}
+
+#if os(macOS)
+    /// End-to-end coverage of the public path: `setClientIdentification` followed
+    /// by `login` must send ID on the primary connection before the caller's
+    /// first SELECT.
+    @Suite(.serialized, .timeLimit(.minutes(1)))
+    struct ClientIdentificationIntegrationTests {
+        @Test(.timeLimit(.minutes(1)))
+        func loginReplaysConfiguredIdentification() async throws {
+            let tempRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            let maildir = tempRoot.appendingPathComponent("Maildir")
+            try FileManager.default.createDirectory(at: maildir, withIntermediateDirectories: true, attributes: nil)
+            defer {
+                try? FileManager.default.removeItem(at: tempRoot)
+            }
+
+            let testServer = try IMAPTestServer(
+                host: "localhost",
+                port: 0,
+                username: "testuser",
+                password: "testpass",
+                maildirURL: maildir
+            )
+            try testServer.start()
+
+            try await testServer.run {
+                let server = IMAPServer(host: "127.0.0.1", port: testServer.port, useTLS: false)
+                try await server.connect()
+                await server.setClientIdentification(Identification(name: "SwiftMailTests", version: "1.0"))
+                try await server.login(username: "testuser", password: "testpass")
+                #expect(testServer.idCommandCount == 1)
+
+                let status = try await server.selectMailbox("INBOX")
+                #expect(status.messageCount == 0)
+                try await server.disconnect()
+            }
+        }
+    }
+#endif

--- a/Tests/SwiftIMAPTests/IMAPTestServer.swift
+++ b/Tests/SwiftIMAPTests/IMAPTestServer.swift
@@ -76,6 +76,18 @@ final class IMAPTestServer {
         metricsQueue.sync { idleCommandCountStorage += 1 }
     }
 
+    /// Number of ID commands received across all connections. Lets tests verify
+    /// the RFC 2971 replay actually reached the wire after authentication.
+    var idCommandCount: Int {
+        metricsQueue.sync { idCommandCountStorage }
+    }
+
+    private var idCommandCountStorage = 0
+
+    private func recordIDCommand() {
+        metricsQueue.sync { idCommandCountStorage += 1 }
+    }
+
     /// Total connections ever accepted. Catches re-dials that never reach an
     /// IDLE command (connect + LOGIN + SELECT and then exit), which
     /// `idleCommandCount` alone cannot see.
@@ -412,6 +424,7 @@ final class IMAPTestServer {
             case "LIST":
                 return "* LIST (\\HasNoChildren) \"/\" \"INBOX\"\r\n\(tag) OK LIST completed\r\n"
             case "ID":
+                recordIDCommand()
                 return "* ID NIL\r\n\(tag) OK ID completed\r\n"
             case "NOOP":
                 return "\(tag) OK NOOP completed\r\n"


### PR DESCRIPTION
Supersedes #193 by @heymi, keeping the original commit (and authorship credit) intact and adding the changes requested in review. Closes #193.

## Motivation (from #193)

Some IMAP servers — notably NetEase (163.com / 126.com / yeah.net) — reject every `SELECT` on an authenticated connection that has not identified itself via the RFC 2971 `ID` command (`NO Unsafe Login…`). Callers can send `ID` manually on the primary connection, but connections the server opens internally (dedicated IDLE connection, IDLE recovery reconnects, transparent re-authentication) authenticate without `ID` and are permanently rejected by such servers.

`IMAPServer.setClientIdentification(_:)` stores an optional `Identification` that is replayed right after every successful authentication on every connection the server opens. Behavior is unchanged unless the new API is used.

## Review findings addressed

**1. Stale capability snapshot could skip the replay (MEDIUM).** A server that advertises `ID` only after authentication and answers `AUTHENTICATE` with a plain `OK` (no `CAPABILITY` response code) left XOAUTH2 holding the pre-authentication snapshot, so the replay guard saw no `ID` and skipped the command. Fixed at the root: XOAUTH2 now refreshes capabilities with an explicit `CAPABILITY` command when the `OK` carries none — through `executeCommandBody`, the same in-queue route the STARTTLS upgrade uses — matching what `LOGIN` and `AUTHENTICATE PLAIN` already did. The post-auth snapshot is now authoritative on every authentication path, so the guard (and every other capability-gated feature) can trust it.

**2. Blanket `try?` masked dead connections (MEDIUM).** If the server accepted authentication and then the socket died during `ID` (close or timeout), the connection was recycled — disconnected and unauthenticated — yet authentication still reported success, handing out unusable connections (`connection(named:)`, IDLE setup/recovery, and the public login/authenticate methods alike). The replay logic is now shared (`Authentication.identify`) between the internal path and the primary connection: a server refusing `ID` (`NO`/`BAD`) with the session intact stays best-effort and never fails authentication, but a failure that leaves the connection disconnected or unauthenticated propagates, and cancellation rethrows.

**CI fix:** `Authentication.Method` is hoisted to `IMAPServer.AuthenticationMethod` — the two-level nesting in the original commit fails `swiftlint --strict`.

## Automated coverage (new)

Scripted-connection tests (`NIOAsyncTestingChannel`) plus one end-to-end test against the in-repo fake IMAP server:

- replay after `LOGIN` when `ID` is advertised, with a server `NO` tolerated and the session left intact;
- XOAUTH2 with a bare `OK` triggers the capability refresh and then the replay — **fails without fix 1**;
- socket death during `ID` fails the authentication and leaves the connection unauthenticated — **fails without fix 2**;
- no `ID` capability → no `ID` command sent;
- `setClientIdentification` + `login` sends exactly one `ID` on the primary connection before `SELECT` (fake server now counts `ID` commands).

Both regression tests were verified to fail against the pre-fix sources and pass with the fixes.

## Verification

- `swift build` and `swift test` clean: 409 tests in 54 suites pass.
- `swiftlint lint --strict` clean on all touched files.
- The original change was verified by @heymi against a real NetEase 163 account (see #193): with the identification configured, mailbox IDLE establishes and pushes arrive in seconds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)