### PR TITLE
Parse MIME structure at the byte level (supersedes #202)

### DIFF
--- a/Sources/SwiftMail/MIME/EMLParser+Headers.swift
+++ b/Sources/SwiftMail/MIME/EMLParser+Headers.swift
@@ -15,7 +15,7 @@ extension EMLParser {
         for separator in [Data("\r\n\r\n".utf8), Data("\n\n".utf8)] {
             guard let range = rawData.range(of: separator) else { continue }
             let headerData = rawData[..<range.lowerBound]
-            let headerBlock = String(decoding: headerData, as: UTF8.self)
+            let headerBlock = String(bytes: headerData, encoding: .utf8) ?? ""
             return (headerBlock, Data(rawData[range.upperBound...]))
         }
 

--- a/Sources/SwiftMail/MIME/EMLParser+Headers.swift
+++ b/Sources/SwiftMail/MIME/EMLParser+Headers.swift
@@ -72,11 +72,18 @@ extension EMLParser {
     /// other line breaks: Unicode "newlines" like NEL (which Latin-1 decoding
     /// can produce from raw byte 0x85), VT, FF, or U+2028 are ordinary header
     /// text, and splitting on them would truncate values or let crafted bytes
-    /// smuggle in whole headers.
+    /// smuggle in whole headers. The split works on the UTF-8 view because
+    /// String searches are grapheme-based and CRLF is a single grapheme — a
+    /// search for "\n" inside "\r\n" finds nothing on Linux.
     private static func headerLines(_ block: String) -> [String] {
-        block.components(separatedBy: "\n").map { line in
-            line.hasSuffix("\r") ? String(line.dropLast()) : line
-        }
+        let lineFeed: UInt8 = 0x0A
+        let carriageReturn: UInt8 = 0x0D
+
+        return block.utf8
+            .split(separator: lineFeed, omittingEmptySubsequences: false)
+            .map { line in
+                String(bytes: line.last == carriageReturn ? line.dropLast() : line, encoding: .utf8) ?? ""
+            }
     }
 
     // MARK: - Header Parsing

--- a/Sources/SwiftMail/MIME/EMLParser+Headers.swift
+++ b/Sources/SwiftMail/MIME/EMLParser+Headers.swift
@@ -7,25 +7,54 @@ extension EMLParser {
 
     // MARK: - Header Block Splitting
 
-    /// Split raw message bytes into a decoded header block and an opaque body.
-    static func splitHeadersAndBody(rawData: Data) throws -> (String, Data) {
-        // Find the blank-line separator in the original bytes. String indices
-        // and character distances are not byte offsets: CRLF is one Character
-        // but two bytes, and non-ASCII header text can span multiple UTF-8 bytes.
-        for separator in [Data("\r\n\r\n".utf8), Data("\n\n".utf8)] {
-            guard let range = rawData.range(of: separator) else { continue }
-            let headerData = rawData[..<range.lowerBound]
-            guard let headerBlock = String(bytes: headerData, encoding: .utf8) else {
-                throw EMLParserError.invalidData
-            }
-            return (headerBlock, Data(rawData[range.upperBound...]))
+    /// Split raw entity bytes into header bytes and opaque body bytes.
+    ///
+    /// The split happens at the first blank line, found in the original bytes:
+    /// String indices and character distances are not byte offsets (CRLF is one
+    /// `Character` but two bytes, non-ASCII text spans multiple UTF-8 bytes),
+    /// and the body need not be valid UTF-8 at all.
+    static func splitHeadersAndBody(rawData: Data) -> (headerData: Data, bodyData: Data) {
+        let data = Data(rawData)
+        let lineFeed: UInt8 = 0x0A
+        let carriageReturn: UInt8 = 0x0D
+
+        // A body part may begin with a blank line, meaning it has no headers
+        // (RFC 2046 §5.1): the leading line break separates empty headers
+        // from the body.
+        if data.first == lineFeed {
+            return (Data(), Data(data.dropFirst()))
+        }
+        if data.first == carriageReturn, data.dropFirst().first == lineFeed {
+            return (Data(), Data(data.dropFirst(2)))
         }
 
-        // No body — entire content is headers
-        guard let headerBlock = String(bytes: rawData, encoding: .utf8) else {
-            throw EMLParserError.invalidData
+        // The first blank line ends with "\n\n" or "\n\r\n"; the latter also
+        // matches "\r\n\r\n" from its first LF. Take the earliest match so a
+        // CRLF blank line later in the data cannot shadow an LF one earlier.
+        let separators = [Data([lineFeed, lineFeed]), Data([lineFeed, carriageReturn, lineFeed])]
+        let candidates = separators.compactMap { data.range(of: $0) }
+        guard let separator = candidates.min(by: { $0.lowerBound < $1.lowerBound }) else {
+            // No blank line — the entire content is headers.
+            return (data, Data())
         }
-        return (headerBlock, Data())
+
+        // Drop the CR of a CRLF-terminated final header line.
+        var headerEnd = separator.lowerBound
+        if headerEnd > data.startIndex && data[headerEnd - 1] == carriageReturn {
+            headerEnd -= 1
+        }
+        return (Data(data[data.startIndex..<headerEnd]), Data(data[separator.upperBound...]))
+    }
+
+    /// Decode header bytes into a `String`.
+    ///
+    /// Headers are ASCII by specification (RFC 5322), with UTF-8 permitted by
+    /// RFC 6532; Latin-1 maps every byte, so the decode is total and malformed
+    /// headers can never make parsing fail or lose body bytes.
+    static func decodeHeaderBlock(_ headerData: Data) -> String {
+        String(data: headerData, encoding: .utf8)
+            ?? String(data: headerData, encoding: .isoLatin1)
+            ?? ""
     }
 
     // MARK: - Header Parsing

--- a/Sources/SwiftMail/MIME/EMLParser+Headers.swift
+++ b/Sources/SwiftMail/MIME/EMLParser+Headers.swift
@@ -46,15 +46,37 @@ extension EMLParser {
         return (Data(data[data.startIndex..<headerEnd]), Data(data[separator.upperBound...]))
     }
 
-    /// Decode header bytes into a `String`.
+    /// Decode header bytes into a `String` of LF-separated lines.
     ///
     /// Headers are ASCII by specification (RFC 5322), with UTF-8 permitted by
     /// RFC 6532; Latin-1 maps every byte, so the decode is total and malformed
-    /// headers can never make parsing fail or lose body bytes.
+    /// headers can never make parsing fail or lose body bytes. Each line is
+    /// decoded independently: a single legacy 8-bit byte in one header must
+    /// not flip the whole block to Latin-1 and mangle valid UTF-8 elsewhere.
     static func decodeHeaderBlock(_ headerData: Data) -> String {
-        String(data: headerData, encoding: .utf8)
-            ?? String(data: headerData, encoding: .isoLatin1)
-            ?? ""
+        let lineFeed: UInt8 = 0x0A
+        let carriageReturn: UInt8 = 0x0D
+
+        return headerData
+            .split(separator: lineFeed, omittingEmptySubsequences: false)
+            .map { line -> String in
+                let lineData = Data(line.last == carriageReturn ? line.dropLast() : line)
+                return String(data: lineData, encoding: .utf8)
+                    ?? String(data: lineData, encoding: .isoLatin1)
+                    ?? ""
+            }
+            .joined(separator: "\n")
+    }
+
+    /// Split a header block into lines at CRLF/LF only. RFC 5322 recognizes no
+    /// other line breaks: Unicode "newlines" like NEL (which Latin-1 decoding
+    /// can produce from raw byte 0x85), VT, FF, or U+2028 are ordinary header
+    /// text, and splitting on them would truncate values or let crafted bytes
+    /// smuggle in whole headers.
+    private static func headerLines(_ block: String) -> [String] {
+        block.components(separatedBy: "\n").map { line in
+            line.hasSuffix("\r") ? String(line.dropLast()) : line
+        }
     }
 
     // MARK: - Header Parsing
@@ -67,7 +89,7 @@ extension EMLParser {
         var currentKey: String?
         var currentValue: String = ""
 
-        let lines = block.components(separatedBy: .newlines)
+        let lines = headerLines(block)
         for line in lines {
             if line.isEmpty { continue }
 
@@ -102,7 +124,7 @@ extension EMLParser {
         var currentKey: String?
         var currentValue: String = ""
 
-        let lines = block.components(separatedBy: .newlines)
+        let lines = headerLines(block)
         for line in lines {
             if line.isEmpty { continue }
 

--- a/Sources/SwiftMail/MIME/EMLParser+Headers.swift
+++ b/Sources/SwiftMail/MIME/EMLParser+Headers.swift
@@ -7,20 +7,25 @@ extension EMLParser {
 
     // MARK: - Header Block Splitting
 
-    /// Split the raw message into header block (String) and body (Data).
-    static func splitHeadersAndBody(from string: String, rawData: Data) -> (String, Data) {
+    /// Split raw message bytes into a decoded header block and an opaque body.
+    static func splitHeadersAndBody(rawData: Data) throws -> (String, Data) {
         // Find the blank-line separator in the original bytes. String indices
         // and character distances are not byte offsets: CRLF is one Character
         // but two bytes, and non-ASCII header text can span multiple UTF-8 bytes.
         for separator in [Data("\r\n\r\n".utf8), Data("\n\n".utf8)] {
             guard let range = rawData.range(of: separator) else { continue }
             let headerData = rawData[..<range.lowerBound]
-            let headerBlock = String(bytes: headerData, encoding: .utf8) ?? ""
+            guard let headerBlock = String(bytes: headerData, encoding: .utf8) else {
+                throw EMLParserError.invalidData
+            }
             return (headerBlock, Data(rawData[range.upperBound...]))
         }
 
         // No body — entire content is headers
-        return (string, Data())
+        guard let headerBlock = String(bytes: rawData, encoding: .utf8) else {
+            throw EMLParserError.invalidData
+        }
+        return (headerBlock, Data())
     }
 
     // MARK: - Header Parsing

--- a/Sources/SwiftMail/MIME/EMLParser+Headers.swift
+++ b/Sources/SwiftMail/MIME/EMLParser+Headers.swift
@@ -9,17 +9,14 @@ extension EMLParser {
 
     /// Split the raw message into header block (String) and body (Data).
     static func splitHeadersAndBody(from string: String, rawData: Data) -> (String, Data) {
-        // Find the blank line separator — try \r\n\r\n first, then \n\n
-        if let range = string.range(of: "\r\n\r\n") {
-            let headerBlock = String(string[string.startIndex..<range.lowerBound])
-            let bodyStart = string.distance(from: string.startIndex, to: range.upperBound)
-            let bodyData = rawData.dropFirst(bodyStart)
-            return (headerBlock, Data(bodyData))
-        } else if let range = string.range(of: "\n\n") {
-            let headerBlock = String(string[string.startIndex..<range.lowerBound])
-            let bodyStart = string.distance(from: string.startIndex, to: range.upperBound)
-            let bodyData = rawData.dropFirst(bodyStart)
-            return (headerBlock, Data(bodyData))
+        // Find the blank-line separator in the original bytes. String indices
+        // and character distances are not byte offsets: CRLF is one Character
+        // but two bytes, and non-ASCII header text can span multiple UTF-8 bytes.
+        for separator in [Data("\r\n\r\n".utf8), Data("\n\n".utf8)] {
+            guard let range = rawData.range(of: separator) else { continue }
+            let headerData = rawData[..<range.lowerBound]
+            let headerBlock = String(decoding: headerData, as: UTF8.self)
+            return (headerBlock, Data(rawData[range.upperBound...]))
         }
 
         // No body — entire content is headers

--- a/Sources/SwiftMail/MIME/EMLParser+Multipart.swift
+++ b/Sources/SwiftMail/MIME/EMLParser+Multipart.swift
@@ -37,10 +37,17 @@ extension EMLParser {
         }
     }
 
+    /// RFC 2046 §5.1: a boundary "must be no longer than 70 characters". The
+    /// limit also bounds the substring-search cost — an attacker-supplied
+    /// boundary of arbitrary length would make splitting quadratic in the
+    /// message size.
+    private static let maxBoundaryLength = 70
+
     /// Parse a multipart body, splitting by boundary.
     static func parseMultipart(contentType: String, bodyData: Data, sectionPath: [Int]) -> [MessagePart] {
-        guard let boundary = extractBoundary(from: contentType) else {
-            // Can't parse without boundary — treat as opaque
+        guard let boundary = extractBoundary(from: contentType),
+              !boundary.isEmpty, boundary.utf8.count <= maxBoundaryLength else {
+            // No usable boundary — treat as opaque
             let section = sectionPath.isEmpty ? [1] : sectionPath
             return [MessagePart(
                 section: Section(section),
@@ -50,6 +57,18 @@ extension EMLParser {
         }
 
         let rawParts = splitMultipartByBoundary(bodyData: bodyData, boundary: boundary)
+        guard !rawParts.isEmpty else {
+            // No recognizable delimiters (wrong or truncated boundary, or a
+            // preamble glued to the first delimiter) — keep the body as an
+            // opaque part rather than silently dropping its bytes.
+            let section = sectionPath.isEmpty ? [1] : sectionPath
+            return bodyData.isEmpty ? [] : [MessagePart(
+                section: Section(section),
+                contentType: extractMIMEType(from: contentType),
+                data: bodyData
+            )]
+        }
+
         return rawParts.enumerated().flatMap { index, rawPart -> [MessagePart] in
             buildMultipartChild(rawPart: rawPart, index: index, sectionPath: sectionPath)
         }

--- a/Sources/SwiftMail/MIME/EMLParser+Multipart.swift
+++ b/Sources/SwiftMail/MIME/EMLParser+Multipart.swift
@@ -160,7 +160,9 @@ extension EMLParser {
         let childPath = sectionPath.isEmpty ? [partNumber] : sectionPath + [partNumber]
 
         let partData = Data(rawPart.utf8)
-        let (partHeaders, partBody) = splitHeadersAndBody(from: rawPart, rawData: partData)
+        guard let (partHeaders, partBody) = try? splitHeadersAndBody(rawData: partData) else {
+            return []
+        }
         let headers = parseHeaders(partHeaders)
 
         let partContentType = headers["content-type"] ?? "text/plain"

--- a/Sources/SwiftMail/MIME/EMLParser+Multipart.swift
+++ b/Sources/SwiftMail/MIME/EMLParser+Multipart.swift
@@ -49,121 +49,136 @@ extension EMLParser {
             )]
         }
 
-        let utf8Body = String(data: bodyData, encoding: .utf8)
-        let asciiBody = String(data: bodyData, encoding: .ascii)
-        guard let bodyString = utf8Body ?? asciiBody else {
-            return []
-        }
-
-        let rawParts = splitMultipartByBoundary(bodyString: bodyString, boundary: boundary)
+        let rawParts = splitMultipartByBoundary(bodyData: bodyData, boundary: boundary)
         return rawParts.enumerated().flatMap { index, rawPart -> [MessagePart] in
             buildMultipartChild(rawPart: rawPart, index: index, sectionPath: sectionPath)
         }
     }
 
-    /// Split a multipart body string into raw part strings using the boundary
-    /// delimiter. Returns an array of raw (header+body) part strings.
-    static func splitMultipartByBoundary(bodyString: String, boundary: String) -> [String] {
-        let delimiter = "--\(boundary)"
-        var rawParts: [String] = []
-        var searchStart = bodyString.startIndex
+    /// Split a multipart body into raw (header+body) part byte blocks using the
+    /// boundary delimiter, per RFC 2046 §5.1.1.
+    ///
+    /// All matching happens on bytes: part content is not required to be valid
+    /// UTF-8, so it must never round-trip through `String`. A delimiter only
+    /// counts when it starts a line and its line contains nothing after the
+    /// boundary but optional transport padding — a part whose *content* merely
+    /// mentions "--boundary" mid-line or as a prefix of a longer token is not
+    /// split. The line break preceding a delimiter belongs to the delimiter,
+    /// not to the part. The preamble (before the first delimiter) and epilogue
+    /// (after the close delimiter) are discarded.
+    static func splitMultipartByBoundary(bodyData: Data, boundary: String) -> [Data] {
+        let data = Data(bodyData)
+        let delimiter = Data("--\(boundary)".utf8)
+        let lineFeed: UInt8 = 0x0A
+        let carriageReturn: UInt8 = 0x0D
 
-        while searchStart < bodyString.endIndex {
-            guard let delimRange = bodyString.range(of: delimiter, range: searchStart..<bodyString.endIndex) else {
-                break
+        var rawParts: [Data] = []
+        var partStart: Data.Index?
+        var searchIndex = data.startIndex
+
+        while searchIndex < data.endIndex,
+              let match = data.range(of: delimiter, in: searchIndex..<data.endIndex) {
+            // A delimiter only counts at the start of a line whose remainder
+            // is a valid delimiter-line tail; otherwise the match is ordinary
+            // part content.
+            let atLineStart = match.lowerBound == data.startIndex || data[match.lowerBound - 1] == lineFeed
+            guard atLineStart, let line = parseDelimiterLineTail(in: data, after: match.upperBound) else {
+                searchIndex = match.lowerBound + 1
+                continue
             }
 
-            // Check if this is the end delimiter
-            if isMultipartEndDelimiter(bodyString: bodyString, after: delimRange.upperBound) {
-                break
+            // Close out the running part: its content ends before the line
+            // break that precedes this delimiter.
+            if let start = partStart {
+                rawParts.append(Data(data[start..<partEnd(in: data, start: start, delimiterStart: match.lowerBound)]))
             }
 
-            // Find the start of part content (skip past delimiter + line ending)
-            let contentStart = skipPastDelimiterLineEnding(
-                bodyString: bodyString,
-                from: delimRange.upperBound
-            )
-
-            // Find the next boundary to determine the end of this part
-            if let nextDelimRange = bodyString.range(of: delimiter, range: contentStart..<bodyString.endIndex) {
-                let contentEnd = trimmedPartEnd(
-                    bodyString: bodyString,
-                    contentStart: contentStart,
-                    delimiterStart: nextDelimRange.lowerBound
-                )
-                rawParts.append(String(bodyString[contentStart..<contentEnd]))
-                searchStart = nextDelimRange.lowerBound
-            } else {
-                // No more boundaries — take the rest
-                let remainder = String(bodyString[contentStart...]).trimmingCharacters(in: .whitespacesAndNewlines)
-                rawParts.append(remainder)
-                break
+            if line.isClose {
+                return rawParts
             }
+            partStart = line.contentStart
+            searchIndex = line.contentStart
         }
 
+        // Missing close delimiter — take the remainder as the final part.
+        if let start = partStart {
+            var trimmedEnd = data.endIndex
+            while trimmedEnd > start && (data[trimmedEnd - 1] == lineFeed || data[trimmedEnd - 1] == carriageReturn) {
+                trimmedEnd -= 1
+            }
+            rawParts.append(Data(data[start..<trimmedEnd]))
+        }
         return rawParts
     }
 
-    /// Return `true` if the characters immediately after a boundary match are
-    /// `"--"`, signalling the multipart end delimiter.
-    private static func isMultipartEndDelimiter(bodyString: String, after index: String.Index) -> Bool {
-        guard index < bodyString.endIndex else { return false }
-        return bodyString[index...].hasPrefix("--")
+    /// Validate what follows a matched boundary: an optional `--` (marking the
+    /// close delimiter), optional transport padding, then CRLF, LF, or end of
+    /// data. Returns `nil` when something else follows — the boundary was a
+    /// prefix of ordinary text, not a delimiter line.
+    private static func parseDelimiterLineTail(
+        in data: Data,
+        after boundaryEnd: Data.Index
+    ) -> (contentStart: Data.Index, isClose: Bool)? {
+        let lineFeed: UInt8 = 0x0A
+        let carriageReturn: UInt8 = 0x0D
+        let dash: UInt8 = 0x2D
+        let space: UInt8 = 0x20
+        let tab: UInt8 = 0x09
+
+        var cursor = boundaryEnd
+        let isClose = cursor + 1 < data.endIndex && data[cursor] == dash && data[cursor + 1] == dash
+        if isClose {
+            cursor += 2
+        }
+
+        while cursor < data.endIndex && (data[cursor] == space || data[cursor] == tab) {
+            cursor += 1
+        }
+
+        if cursor < data.endIndex && data[cursor] == carriageReturn {
+            cursor += 1
+        }
+        if cursor < data.endIndex {
+            guard data[cursor] == lineFeed else {
+                return nil
+            }
+            cursor += 1
+        }
+        return (cursor, isClose)
     }
 
-    /// Skip past any CR/LF characters following a boundary delimiter so the
-    /// caller can read the part's header block.
-    private static func skipPastDelimiterLineEnding(
-        bodyString: String,
-        from start: String.Index
-    ) -> String.Index {
-        var contentStart = start
-        if contentStart < bodyString.endIndex && bodyString[contentStart] == "\r" {
-            contentStart = bodyString.index(after: contentStart)
+    /// The content of a part ends before the line break that precedes the next
+    /// boundary delimiter; that line break belongs to the delimiter.
+    private static func partEnd(
+        in data: Data,
+        start: Data.Index,
+        delimiterStart: Data.Index
+    ) -> Data.Index {
+        let lineFeed: UInt8 = 0x0A
+        let carriageReturn: UInt8 = 0x0D
+
+        var end = delimiterStart
+        if end > start && data[end - 1] == lineFeed {
+            end -= 1
+            if end > start && data[end - 1] == carriageReturn {
+                end -= 1
+            }
         }
-        if contentStart < bodyString.endIndex && bodyString[contentStart] == "\n" {
-            contentStart = bodyString.index(after: contentStart)
-        }
-        return contentStart
+        return end
     }
 
-    /// Trim the trailing CR/LF that precedes the next boundary delimiter so the
-    /// returned slice contains only the part body.
-    private static func trimmedPartEnd(
-        bodyString: String,
-        contentStart: String.Index,
-        delimiterStart: String.Index
-    ) -> String.Index {
-        var contentEnd = delimiterStart
-        guard contentEnd > contentStart else { return contentEnd }
-
-        let beforeEnd = bodyString.index(before: contentEnd)
-        guard bodyString[beforeEnd] == "\n" else { return contentEnd }
-        contentEnd = beforeEnd
-
-        guard contentEnd > contentStart else { return contentEnd }
-        let beforeLF = bodyString.index(before: contentEnd)
-        if bodyString[beforeLF] == "\r" {
-            contentEnd = beforeLF
-        }
-        return contentEnd
-    }
-
-    /// Build the `MessagePart` value(s) for a single raw multipart child string.
+    /// Build the `MessagePart` value(s) for a single raw multipart child.
     /// Recursively descends into nested multipart parts.
     static func buildMultipartChild(
-        rawPart: String,
+        rawPart: Data,
         index: Int,
         sectionPath: [Int]
     ) -> [MessagePart] {
         let partNumber = index + 1
         let childPath = sectionPath.isEmpty ? [partNumber] : sectionPath + [partNumber]
 
-        let partData = Data(rawPart.utf8)
-        guard let (partHeaders, partBody) = try? splitHeadersAndBody(rawData: partData) else {
-            return []
-        }
-        let headers = parseHeaders(partHeaders)
+        let (partHeaderData, partBody) = splitHeadersAndBody(rawData: rawPart)
+        let headers = parseHeaders(decodeHeaderBlock(partHeaderData))
 
         let partContentType = headers["content-type"] ?? "text/plain"
         let partEncoding = headers["content-transfer-encoding"]

--- a/Sources/SwiftMail/MIME/EMLParser.swift
+++ b/Sources/SwiftMail/MIME/EMLParser.swift
@@ -34,12 +34,9 @@ public struct EMLParser {
     /// - Parameter data: Raw RFC 822 bytes (as obtained from `fetchRawMessage` or an `.eml` file).
     /// - Returns: A fully populated ``Message``.
     public static func parse(_ data: Data) throws -> Message {
-        guard let string = String(data: data, encoding: .utf8) ?? String(data: data, encoding: .ascii) else {
-            throw EMLParserError.invalidData
-        }
-
-        // Split headers and body at the first blank line
-        let (headerBlock, bodyData) = splitHeadersAndBody(from: string, rawData: data)
+        // Decode only the RFC 822 header bytes. The body can legitimately use
+        // an arbitrary 8bit charset or contain opaque binary data.
+        let (headerBlock, bodyData) = try splitHeadersAndBody(rawData: data)
 
         guard !headerBlock.isEmpty else {
             throw EMLParserError.missingHeaders

--- a/Sources/SwiftMail/MIME/EMLParser.swift
+++ b/Sources/SwiftMail/MIME/EMLParser.swift
@@ -34,9 +34,13 @@ public struct EMLParser {
     /// - Parameter data: Raw RFC 822 bytes (as obtained from `fetchRawMessage` or an `.eml` file).
     /// - Returns: A fully populated ``Message``.
     public static func parse(_ data: Data) throws -> Message {
-        // Decode only the RFC 822 header bytes. The body can legitimately use
-        // an arbitrary 8bit charset or contain opaque binary data.
-        let (headerBlock, bodyData) = try splitHeadersAndBody(rawData: data)
+        // All structural parsing happens on raw bytes; only header blocks are
+        // decoded to String. The body can legitimately use an arbitrary 8bit
+        // charset or contain opaque binary data. A message cannot start with a
+        // blank line (RFC 5322), so stray leading line breaks are skipped.
+        let trimmed = Data(data.drop(while: { $0 == 0x0D || $0 == 0x0A }))
+        let (headerData, bodyData) = splitHeadersAndBody(rawData: trimmed)
+        let headerBlock = decodeHeaderBlock(headerData)
 
         guard !headerBlock.isEmpty else {
             throw EMLParserError.missingHeaders

--- a/Tests/SwiftIMAPTests/EMLByteLevelTests.swift
+++ b/Tests/SwiftIMAPTests/EMLByteLevelTests.swift
@@ -1,0 +1,292 @@
+// EMLByteLevelTests.swift
+// Tests for byte-level EML structure parsing: non-UTF-8 and binary part
+// content, boundary matching, and header/body split offsets.
+
+import Testing
+import Foundation
+@testable import SwiftMail
+
+@Suite("EML Byte-Level Structure Tests", .serialized, .tags(.mime), .timeLimit(.minutes(1)))
+struct EMLByteLevelTests {
+
+    @Test("Preserve non-UTF-8 8bit part inside multipart")
+    func testParseNonUTF8PartInMultipart() throws {
+        let latin1Body = Data([0x63, 0x61, 0x66, 0xE9]) // "café" in ISO-8859-1
+        var data = Data([
+            "From: sender@example.com",
+            "To: recipient@example.com",
+            "Subject: Mixed Charsets",
+            "Content-Type: multipart/mixed; boundary=\"outer\"",
+            "",
+            "--outer",
+            "Content-Type: text/plain; charset=iso-8859-1",
+            "Content-Transfer-Encoding: 8bit",
+            "",
+            ""
+        ].joined(separator: "\r\n").utf8)
+        data.append(latin1Body)
+        data.append(Data([
+            "",
+            "--outer",
+            "Content-Type: text/plain; charset=UTF-8",
+            "",
+            "ASCII part.",
+            "--outer--",
+            ""
+        ].joined(separator: "\r\n").utf8))
+
+        let message = try Message(emlData: data)
+
+        try #require(message.parts.count == 2, "Expected 2 parts, got \(message.parts.count)")
+        #expect(message.parts[0].data == latin1Body)
+        #expect(message.parts[0].textContent == "café")
+        #expect(message.parts[1].textContent?.contains("ASCII part.") == true)
+    }
+
+    @Test("Preserve opaque binary part inside multipart")
+    func testParseBinaryPartInMultipart() throws {
+        let binaryBody = Data([0x00, 0x01, 0xFF, 0xFE, 0x80, 0x0A, 0xC3, 0x28])
+        var data = Data([
+            "From: sender@example.com",
+            "To: recipient@example.com",
+            "Subject: Binary Part",
+            "Content-Type: multipart/mixed; boundary=\"outer\"",
+            "",
+            "--outer",
+            "Content-Type: application/octet-stream",
+            "Content-Transfer-Encoding: binary",
+            "Content-Disposition: attachment; filename=\"blob.bin\"",
+            "",
+            ""
+        ].joined(separator: "\r\n").utf8)
+        data.append(binaryBody)
+        data.append(Data([
+            "",
+            "--outer--",
+            ""
+        ].joined(separator: "\r\n").utf8))
+
+        let message = try Message(emlData: data)
+
+        try #require(message.parts.count == 1, "Expected 1 part, got \(message.parts.count)")
+        #expect(message.parts[0].data == binaryBody)
+        #expect(message.parts[0].decodedData() == binaryBody)
+    }
+
+    @Test("Boundary text inside part content does not split")
+    func testBoundaryTextInsideContent() throws {
+        let eml = """
+        From: sender@example.com\r
+        Subject: Boundary In Content\r
+        Content-Type: multipart/mixed; boundary="outer"\r
+        \r
+        --outer\r
+        Content-Type: text/plain\r
+        \r
+        This line mentions --outer mid-line.\r
+        --outerspace is a longer token at line start.\r
+        Both belong to the same part.\r
+        --outer--\r
+        """
+
+        let message = try Message(emlData: Data(eml.utf8))
+
+        try #require(message.parts.count == 1, "Expected 1 part, got \(message.parts.count)")
+        let text = try #require(message.parts[0].textContent)
+        #expect(text.contains("mentions --outer mid-line."))
+        #expect(text.contains("--outerspace is a longer token"))
+        #expect(text.contains("Both belong to the same part."))
+    }
+
+    @Test("Parse LF-only multipart message")
+    func testParseLFOnlyMultipart() throws {
+        let eml = """
+        From: sender@example.com
+        Subject: LF Only
+        Content-Type: multipart/alternative; boundary="b1"
+
+        --b1
+        Content-Type: text/plain
+
+        Plain version.
+        --b1
+        Content-Type: text/html
+
+        <p>HTML version.</p>
+        --b1--
+        """
+
+        let message = try Message(emlData: Data(eml.utf8))
+
+        try #require(message.parts.count == 2, "Expected 2 parts, got \(message.parts.count)")
+        #expect(message.textBody?.contains("Plain version.") == true)
+        #expect(message.htmlBody?.contains("HTML version.") == true)
+    }
+
+    @Test("Earliest blank line wins with mixed line endings")
+    func testMixedLineEndingSplit() throws {
+        // LF-terminated headers; the body itself contains a CRLF blank line.
+        // The header/body split must happen at the first blank line, not at
+        // the first CRLF-flavored one.
+        let eml = "From: sender@example.com\nSubject: Mixed EOL\nContent-Type: text/plain\n\nline one\r\n\r\nline two"
+
+        let message = try Message(emlData: Data(eml.utf8))
+
+        #expect(message.subject == "Mixed EOL")
+        try #require(message.parts.count == 1)
+        #expect(message.parts[0].textContent == "line one\r\n\r\nline two")
+    }
+
+    @Test("Headerless body part defaults to text/plain")
+    func testHeaderlessPart() throws {
+        let eml = """
+        From: sender@example.com\r
+        Subject: Headerless Part\r
+        Content-Type: multipart/mixed; boundary="outer"\r
+        \r
+        --outer\r
+        \r
+        A part with no headers at all.\r
+        --outer--\r
+        """
+
+        let message = try Message(emlData: Data(eml.utf8))
+
+        try #require(message.parts.count == 1, "Expected 1 part, got \(message.parts.count)")
+        #expect(message.parts[0].contentType == "text/plain")
+        #expect(message.parts[0].textContent == "A part with no headers at all.")
+    }
+
+    @Test("Preamble and epilogue are ignored")
+    func testPreambleAndEpilogue() throws {
+        let eml = """
+        From: sender@example.com\r
+        Subject: Preamble\r
+        Content-Type: multipart/mixed; boundary="outer"\r
+        \r
+        This is the preamble. It should be ignored.\r
+        --outer\r
+        Content-Type: text/plain\r
+        \r
+        Actual content.\r
+        --outer--\r
+        This is the epilogue. It should also be ignored.\r
+        """
+
+        let message = try Message(emlData: Data(eml.utf8))
+
+        try #require(message.parts.count == 1, "Expected 1 part, got \(message.parts.count)")
+        #expect(message.parts[0].textContent == "Actual content.")
+    }
+
+    @Test("Transport padding after boundary delimiter is tolerated")
+    func testTransportPadding() throws {
+        let eml = "From: sender@example.com\r\n"
+            + "Subject: Padding\r\n"
+            + "Content-Type: multipart/mixed; boundary=\"outer\"\r\n"
+            + "\r\n"
+            + "--outer \t \r\n"
+            + "Content-Type: text/plain\r\n"
+            + "\r\n"
+            + "Padded delimiter line.\r\n"
+            + "--outer--  \r\n"
+
+        let message = try Message(emlData: Data(eml.utf8))
+
+        try #require(message.parts.count == 1, "Expected 1 part, got \(message.parts.count)")
+        #expect(message.parts[0].textContent == "Padded delimiter line.")
+    }
+
+    @Test("Preserve 8bit bytes in nested multipart")
+    func testNestedMultipartWith8BitPart() throws {
+        let latin1Body = Data([0x47, 0x72, 0xFC, 0xDF, 0x65]) // "Grüße" in ISO-8859-1
+        var data = Data([
+            "From: sender@example.com",
+            "Subject: Nested",
+            "Content-Type: multipart/mixed; boundary=\"outer\"",
+            "",
+            "--outer",
+            "Content-Type: multipart/alternative; boundary=\"inner\"",
+            "",
+            "--inner",
+            "Content-Type: text/plain; charset=iso-8859-1",
+            "Content-Transfer-Encoding: 8bit",
+            "",
+            ""
+        ].joined(separator: "\r\n").utf8)
+        data.append(latin1Body)
+        data.append(Data([
+            "",
+            "--inner",
+            "Content-Type: text/html; charset=UTF-8",
+            "",
+            "<p>H\u{00FC}bsch</p>",
+            "--inner--",
+            "",
+            "--outer",
+            "Content-Type: application/pdf; name=\"doc.pdf\"",
+            "Content-Transfer-Encoding: base64",
+            "",
+            "SGVsbG8gV29ybGQ=",
+            "--outer--",
+            ""
+        ].joined(separator: "\r\n").utf8))
+
+        let message = try Message(emlData: data)
+
+        try #require(message.parts.count == 3, "Expected 3 parts, got \(message.parts.count)")
+        #expect(message.parts[0].section == Section([1, 1]))
+        #expect(message.parts[0].data == latin1Body)
+        #expect(message.parts[0].textContent == "Grüße")
+        #expect(message.parts[1].section == Section([1, 2]))
+        #expect(message.parts[1].textContent?.contains("Hübsch") == true)
+        #expect(message.parts[2].decodedData() == Data("Hello World".utf8))
+    }
+
+    @Test("Multi-byte UTF-8 headers do not shift body bytes")
+    func testMultiByteHeaderOffsets() throws {
+        // Raw UTF-8 header text (RFC 6532): every non-ASCII character makes
+        // character counts diverge from byte offsets.
+        let eml = """
+        From: Grüße <sender@example.com>\r
+        Subject: Übung macht den Meister — äöü\r
+        Content-Type: multipart/mixed; boundary="outer"\r
+        \r
+        --outer\r
+        Content-Type: application/pdf; name="report.pdf"\r
+        Content-Transfer-Encoding: base64\r
+        \r
+        SGVsbG8gV29ybGQ=\r
+        --outer--\r
+        """
+
+        let message = try Message(emlData: Data(eml.utf8))
+
+        #expect(message.subject == "Übung macht den Meister — äöü")
+        try #require(message.parts.count == 1)
+        #expect(message.parts[0].decodedData() == Data("Hello World".utf8))
+    }
+
+    @Test("Latin-1 header bytes fall back without losing the message")
+    func testLatin1HeaderFallback() throws {
+        var data = Data("From: sender@example.com\r\nSubject: ".utf8)
+        data.append(Data([0x47, 0x72, 0xFC, 0xDF, 0x65])) // "Grüße" in ISO-8859-1
+        data.append(Data("\r\nContent-Type: text/plain\r\n\r\nBody text.\r\n".utf8))
+
+        let message = try Message(emlData: data)
+
+        #expect(message.subject == "Grüße")
+        try #require(message.parts.count == 1)
+        #expect(message.parts[0].textContent?.contains("Body text.") == true)
+    }
+
+    @Test("Stray leading line breaks are skipped")
+    func testLeadingLineBreaks() throws {
+        let eml = "\r\n\nFrom: sender@example.com\r\nSubject: Leading\r\n\r\nBody.\r\n"
+
+        let message = try Message(emlData: Data(eml.utf8))
+
+        #expect(message.subject == "Leading")
+        #expect(message.parts.first?.textContent?.contains("Body.") == true)
+    }
+}

--- a/Tests/SwiftIMAPTests/EMLByteLevelTests.swift
+++ b/Tests/SwiftIMAPTests/EMLByteLevelTests.swift
@@ -363,4 +363,16 @@ struct EMLHeaderRobustnessTests {
         #expect(message.subject == "Grüße")
         #expect(message.header.additionalFields?["x-legacy"] == "café")
     }
+
+    @Test("CRLF header blocks split into lines on all platforms")
+    func testCRLFHeaderBlockParsing() {
+        // String searches are grapheme-based and "\r\n" is one grapheme, so a
+        // String-level split on "\n" finds nothing in CRLF text on Linux.
+        // parseHeaders is fed raw CRLF blocks by FetchMessageInfoHandler.
+        let block = "References: <root@example.com>\r\nList-Id: <list.example.com>\r\n"
+        let headers = EMLParser.parseHeaders(block)
+
+        #expect(headers["references"] == "<root@example.com>")
+        #expect(headers["list-id"] == "<list.example.com>")
+    }
 }

--- a/Tests/SwiftIMAPTests/EMLByteLevelTests.swift
+++ b/Tests/SwiftIMAPTests/EMLByteLevelTests.swift
@@ -243,6 +243,39 @@ struct EMLByteLevelTests {
         #expect(message.parts[2].decodedData() == Data("Hello World".utf8))
     }
 
+    @Test("Overlong boundary is treated as opaque content")
+    func testOverlongBoundaryFallsBackToOpaque() throws {
+        // RFC 2046 §5.1 caps boundaries at 70 characters; longer ones would
+        // also make delimiter scanning quadratic in the message size.
+        let boundary = String(repeating: "-", count: 100)
+        let body = "--\(boundary)\r\nContent-Type: text/plain\r\n\r\nhi\r\n--\(boundary)--\r\n"
+        let eml = "From: sender@example.com\r\nContent-Type: multipart/mixed; boundary=\"\(boundary)\"\r\n\r\n\(body)"
+
+        let message = try Message(emlData: Data(eml.utf8))
+
+        try #require(message.parts.count == 1)
+        #expect(message.parts[0].contentType == "multipart/mixed")
+        #expect(message.parts[0].data == Data(body.utf8))
+    }
+
+    @Test("Unrecognizable multipart body is kept as an opaque part")
+    func testUnmatchedBoundaryFallsBackToOpaque() throws {
+        // The preamble is glued to the first delimiter (no line break), so no
+        // opening delimiter is recognizable — the body bytes must survive.
+        let body = "pre--b\r\nX\r\n--b--\r\n"
+        let eml = "From: sender@example.com\r\nContent-Type: multipart/mixed; boundary=\"b\"\r\n\r\n\(body)"
+
+        let message = try Message(emlData: Data(eml.utf8))
+
+        try #require(message.parts.count == 1)
+        #expect(message.parts[0].contentType == "multipart/mixed")
+        #expect(message.parts[0].data == Data(body.utf8))
+    }
+}
+
+@Suite("EML Header Robustness Tests", .serialized, .tags(.mime), .timeLimit(.minutes(1)))
+struct EMLHeaderRobustnessTests {
+
     @Test("Multi-byte UTF-8 headers do not shift body bytes")
     func testMultiByteHeaderOffsets() throws {
         // Raw UTF-8 header text (RFC 6532): every non-ASCII character makes
@@ -288,5 +321,46 @@ struct EMLByteLevelTests {
 
         #expect(message.subject == "Leading")
         #expect(message.parts.first?.textContent?.contains("Body.") == true)
+    }
+
+    @Test("Control characters in header values stay header text")
+    func testControlCharactersInHeaders() throws {
+        // VT (0x0B) and NEL (0x85, via Latin-1 fallback) are not RFC 5322 line
+        // breaks; they must not truncate the value or end the header line.
+        var data = Data("From: sender@example.com\r\nSubject: a\u{0B}b".utf8)
+        data.append(Data([0x85])) // raw NEL byte: invalid UTF-8, Latin-1 fallback
+        data.append(Data("c\r\nContent-Type: text/plain\r\n\r\nBody.\r\n".utf8))
+
+        let message = try Message(emlData: data)
+
+        #expect(message.subject == "a\u{0B}b\u{85}c")
+        #expect(message.parts.first?.textContent?.contains("Body.") == true)
+    }
+
+    @Test("Crafted NEL byte cannot smuggle a header")
+    func testNELHeaderSmuggling() throws {
+        var data = Data("From: attacker@example.com\r\nContent-Type: text/plain\r\nSubject: Invoice".utf8)
+        data.append(Data([0x85]))
+        data.append(Data("Content-Type: multipart/mixed; boundary=X\r\n\r\nYOU OWE 1000 EUR\r\n".utf8))
+        data.append(Data("--X\r\nContent-Type: text/plain\r\n\r\nharmless\r\n--X--\r\n".utf8))
+
+        let message = try Message(emlData: data)
+
+        // The smuggled Content-Type stays inside the Subject value; the real
+        // one wins and the real body text is preserved.
+        #expect(message.parts.first?.contentType.hasPrefix("text/plain") == true)
+        #expect(message.parts.first?.textContent?.contains("YOU OWE 1000 EUR") == true)
+    }
+
+    @Test("One legacy byte does not mangle other UTF-8 headers")
+    func testPerLineHeaderDecoding() throws {
+        var data = Data("From: sender@example.com\r\nSubject: Grüße\r\nX-Legacy: caf".utf8)
+        data.append(Data([0xE9])) // "é" in ISO-8859-1: invalid UTF-8
+        data.append(Data("\r\nContent-Type: text/plain\r\n\r\nBody.\r\n".utf8))
+
+        let message = try Message(emlData: data)
+
+        #expect(message.subject == "Grüße")
+        #expect(message.header.additionalFields?["x-legacy"] == "café")
     }
 }

--- a/Tests/SwiftIMAPTests/EMLTests.swift
+++ b/Tests/SwiftIMAPTests/EMLTests.swift
@@ -38,6 +38,51 @@ struct EMLParserTests {
         #expect(message.textBody?.contains("Hello, this is a test message.") == true)
     }
 
+    @Test("Preserve non-UTF-8 8bit body bytes")
+    func testParseNonUTF8Body() throws {
+        let headers = [
+            "From: sender@example.com",
+            "To: recipient@example.com",
+            "Subject: ISO-8859-1 Body",
+            "Content-Type: text/plain; charset=iso-8859-1",
+            "Content-Transfer-Encoding: 8bit",
+            "",
+            ""
+        ].joined(separator: "\r\n")
+        let body = Data([0x63, 0x61, 0x66, 0xE9])
+        var data = Data(headers.utf8)
+        data.append(body)
+
+        let message = try Message(emlData: data)
+
+        #expect(message.parts.count == 1)
+        #expect(message.parts[0].data == body)
+        #expect(message.parts[0].decodedData() == body)
+        #expect(message.parts[0].textContent == "café")
+    }
+
+    @Test("Preserve opaque binary body bytes")
+    func testParseBinaryBody() throws {
+        let headers = [
+            "From: sender@example.com",
+            "To: recipient@example.com",
+            "Subject: Binary Body",
+            "Content-Type: application/octet-stream",
+            "Content-Transfer-Encoding: binary",
+            "",
+            ""
+        ].joined(separator: "\r\n")
+        let body = Data([0x00, 0x7F, 0x80, 0xFF])
+        var data = Data(headers.utf8)
+        data.append(body)
+
+        let message = try Message(emlData: data)
+
+        #expect(message.parts.count == 1)
+        #expect(message.parts[0].data == body)
+        #expect(message.parts[0].decodedData() == body)
+    }
+
     // MARK: - Multipart Alternative
 
     @Test("Parse multipart/alternative message")

--- a/Tests/SwiftIMAPTests/EMLTests.swift
+++ b/Tests/SwiftIMAPTests/EMLTests.swift
@@ -106,6 +106,7 @@ struct EMLParserTests {
         #expect(message.parts[1].disposition == "attachment")
         #expect(message.parts[1].encoding == "base64")
         #expect(message.attachments.count == 1)
+        #expect(message.attachments[0].decodedData() == Data("Hello World".utf8))
     }
 
     // MARK: - RFC 2047 Encoded Subject


### PR DESCRIPTION
## What changed

Rebuilds the EML/MIME parser so all structural parsing — header/body split, multipart boundary splitting, recursion into nested parts — operates on raw bytes. `String` decoding happens only at the leaves: header blocks are decoded per line with a total UTF-8 → Latin-1 fallback that cannot fail, and body bytes never round-trip through `String`.

Includes the three commits from #202 (@kolisko) unchanged, then generalizes the same insight from the top-level split to the whole parser.

## Root cause

MIME structure is defined over octets. The parser located structure in decoded `String`s:

- the top-level split used character distances as byte offsets (#201, fixed by #202), and
- `parseMultipart` decoded the entire body to `String`, split boundaries in character space, and re-encoded each part via `Data(rawPart.utf8)` — so a Latin-1 or binary part inside any multipart made the whole body silently parse to **zero parts**, and `--boundary` text inside part content wrongly split parts.

Regression tests confirm the second class: 9 of the 12 new byte-level tests fail on the #202 state of the tree.

## Behavior now

- 8bit/binary part bytes survive exactly, including in nested multiparts
- Boundary delimiters matched per RFC 2046 §5.1.1: line start only, transport padding tolerated, boundary text mid-content or as a prefix of a longer token left alone, preamble/epilogue discarded
- Header/body split at the earliest blank line (mixed CRLF/LF safe); body parts starting with a blank line are recognized as headerless (RFC 2046 §5.1)
- Parsing is total: malformed header bytes can no longer abort parsing (`EMLParserError.invalidData` is retained for API compatibility but no longer thrown)

## Hardening (from adversarial review of the rework)

- Header blocks split into lines at CRLF/LF only — previously `CharacterSet.newlines` let raw byte 0x85 (→ U+0085 via Latin-1) truncate values or smuggle a crafted `Content-Type:` into the parsed header set
- Header lines decoded independently, so one legacy 8-bit byte cannot flip the whole block to Latin-1 and mojibake valid UTF-8 headers
- RFC 2046 70-char boundary limit enforced: unbounded attacker-supplied boundaries made delimiter scanning quadratic (a crafted 187 KB message took ~15 s to parse)
- A multipart body with no recognizable delimiter is kept as an opaque part instead of dropping its bytes

## Reviewer notes

- `parseHeaders` is also used by `FetchMessageInfoHandler`; the CRLF/LF-only line splitting is strictly more correct for RFC 5322 header blocks there too
- Review surfaced a pre-existing, unrelated `EMLSerializer` infinite recursion on nested multipart sections (stack-overflow crash in `emlData()`); it predates this change and will be addressed separately

## Validation

- `swift test`: 428 tests in 56 suites pass (404 in 52 before)
- `swiftlint --strict`: clean
- New tests validated to fail against the pre-fix parser

Closes #201. Supersedes #202.

🤖 Generated with [Claude Code](https://claude.com/claude-code)