### PR TITLE
Add read-only IMAP EXAMINE support

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Commands/ExamineMailboxCommand.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/ExamineMailboxCommand.swift
@@ -1,0 +1,29 @@
+import Foundation
+import NIO
+import NIOIMAP
+
+/// Command to select a mailbox in read-only mode.
+struct ExamineMailboxCommand: IMAPTaggedCommand {
+    typealias ResultType = Mailbox.Selection
+    typealias HandlerType = SelectHandler
+
+    let mailboxName: String
+    let timeoutSeconds: Int = 30
+
+    init(mailboxName: String) {
+        self.mailboxName = mailboxName
+    }
+
+    func validate() throws {
+        guard !mailboxName.isEmpty else {
+            throw IMAPError.invalidArgument("Mailbox name cannot be empty")
+        }
+    }
+
+    func toTaggedCommand(tag: String) -> TaggedCommand {
+        TaggedCommand(
+            tag: tag,
+            command: .examine(MailboxName(ByteBuffer(string: mailboxName)))
+        )
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/SelectHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/SelectHandler.swift
@@ -28,6 +28,12 @@ final class SelectHandler: BaseIMAPCommandHandler<Mailbox.Selection>, IMAPComman
     /// Handle a tagged OK response by succeeding the promise with the mailbox info
     /// - Parameter response: The tagged response
     override func handleTaggedOKResponse(_ response: TaggedResponse) {
+        // SELECT/EXAMINE communicate READ-WRITE or READ-ONLY in the tagged
+        // completion response. Capture it before fulfilling the result.
+        if case .ok(let responseText) = response.state, let code = responseText.code {
+            applyResponseCode(code)
+        }
+
         // Call super to handle CLIENTBUG warnings
         super.handleTaggedOKResponse(response)
 

--- a/Sources/SwiftMail/IMAP/IMAPNamedConnection+Mailbox.swift
+++ b/Sources/SwiftMail/IMAP/IMAPNamedConnection+Mailbox.swift
@@ -26,6 +26,17 @@ extension IMAPNamedConnection {
         try await select(mailbox: mailboxName)
     }
 
+    /// Select a mailbox read-only using IMAP EXAMINE.
+    ///
+    /// The server enforces the read-only selection: STORE and EXPUNGE operations
+    /// are not permitted while the mailbox remains selected this way.
+    @discardableResult
+    public func examineMailbox(_ mailboxName: String) async throws -> Mailbox.Selection {
+        try await ensureAuthenticated()
+        let command = ExamineMailboxCommand(mailboxName: resolveMailboxPath(mailboxName))
+        return try await executeCommand(command)
+    }
+
     /// Close the currently selected mailbox (expunges `\Deleted` messages).
     public func closeMailbox() async throws {
         let command = CloseCommand()

--- a/Sources/SwiftMail/IMAP/IMAPServer+Mailbox.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Mailbox.swift
@@ -44,6 +44,24 @@ extension IMAPServer {
     }
 
     /**
+     Select a mailbox in read-only mode
+
+     This method uses IMAP EXAMINE to make the mailbox current while asking the server
+     to enforce read-only access. STORE and EXPUNGE operations are not permitted while
+     the mailbox remains selected this way.
+
+     - Parameter mailboxName: The name of the mailbox to select read-only
+     - Returns: Status information about the selected mailbox
+     - Throws:
+     - `IMAPError.selectFailed` if the mailbox cannot be selected
+     - `IMAPError.connectionFailed` if not connected
+     */
+    @discardableResult public func examineMailbox(_ mailboxName: String) async throws -> Mailbox.Selection {
+        let command = ExamineMailboxCommand(mailboxName: resolveMailboxPath(mailboxName))
+        return try await executeCommand(command)
+    }
+
+    /**
      Close the currently selected mailbox
 
      This method closes the currently selected mailbox and expunges any messages

--- a/Tests/SwiftIMAPTests/ExamineMailboxCommandTests.swift
+++ b/Tests/SwiftIMAPTests/ExamineMailboxCommandTests.swift
@@ -1,0 +1,36 @@
+import NIO
+import NIOEmbedded
+@preconcurrency import NIOIMAP
+import Testing
+@testable import SwiftMail
+
+@Suite(.serialized, .timeLimit(.minutes(1)))
+struct ExamineMailboxCommandTests {
+    @Test
+    func rejectsEmptyMailboxName() {
+        let command = ExamineMailboxCommand(mailboxName: "")
+
+        #expect(throws: IMAPError.self) {
+            try command.validate()
+        }
+    }
+
+    @Test
+    func serializesExamineRatherThanSelect() async throws {
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
+        let command = ExamineMailboxCommand(mailboxName: "INBOX")
+        let tagged = command.toTaggedCommand(tag: "E001")
+        let outbound = IMAPClientHandler.OutboundIn.part(CommandStreamPart.tagged(tagged))
+
+        try await channel.writeAndFlush(outbound)
+
+        guard var buffer = try await channel.readOutbound(as: ByteBuffer.self) else {
+            Issue.record("Expected outbound bytes")
+            return
+        }
+        let wire = buffer.readString(length: buffer.readableBytes)
+
+        #expect(wire == "E001 EXAMINE \"INBOX\"\r\n")
+        #expect(wire?.contains("SELECT") == false)
+    }
+}

--- a/Tests/SwiftIMAPTests/IMAPPlaintextIntegrationTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPPlaintextIntegrationTests.swift
@@ -46,6 +46,9 @@ import Testing
                 try await server.login(username: "testuser", password: "testpass")
                 let status = try await server.selectMailbox("INBOX")
                 #expect(status.messageCount == 1)
+                let readOnlyStatus = try await server.examineMailbox("INBOX")
+                #expect(readOnlyStatus.messageCount == 1)
+                #expect(readOnlyStatus.isReadOnly)
                 try await server.disconnect()
             }
         }

--- a/Tests/SwiftIMAPTests/IMAPTestServer.swift
+++ b/Tests/SwiftIMAPTests/IMAPTestServer.swift
@@ -413,6 +413,18 @@ final class IMAPTestServer {
                     + "* OK [PERMANENTFLAGS (\\Seen \\Answered \\Flagged \\Deleted \\Draft \\*)]"
                     + " Flags permitted\r\n"
                     + "\(tag) OK [READ-WRITE] SELECT completed\r\n"
+            case "EXAMINE":
+                guard authenticated else { return "\(tag) NO Not authenticated\r\n" }
+                let mailbox = args.trimmingCharacters(in: .init(charactersIn: "\" "))
+                selectedMailbox = mailbox
+                let count = messages.count
+                let uidnext = (messages.last?.uid ?? 0) + 1
+                return "* \(count) EXISTS\r\n* 0 RECENT\r\n"
+                    + "* OK [UIDVALIDITY 1] UIDs valid\r\n"
+                    + "* OK [UIDNEXT \(uidnext)] Predicted next UID\r\n"
+                    + "* FLAGS (\\Seen \\Answered \\Flagged \\Deleted \\Draft)\r\n"
+                    + "* OK [PERMANENTFLAGS ()] No permanent flags permitted\r\n"
+                    + "\(tag) OK [READ-ONLY] EXAMINE completed\r\n"
             case "UID":
                 guard selectedMailbox != nil else { return "\(tag) NO No mailbox selected\r\n" }
                 return handleUID(tag: tag, args: args)


### PR DESCRIPTION
## Summary

- add an `ExamineMailboxCommand` that emits IMAP `EXAMINE`
- expose `examineMailbox(_:)` on `IMAPServer` and `IMAPNamedConnection`
- capture tagged `READ-ONLY` / `READ-WRITE` response codes in `SelectHandler`
- cover command serialization and a real local IMAP integration path

This allows read-only clients to have the server enforce mailbox selection semantics instead of relying on discipline after `SELECT`.

## Verification

- `swift test` — 437 tests passed
- `git diff --check`
