### PR TITLE
Add configurable MOVE fallback and preserve COPYUID evidence

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Commands/MoveCommand.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/MoveCommand.swift
@@ -23,6 +23,28 @@ struct MoveCommand<T: MessageIdentifier>: IMAPTaggedCommand {
         }
     }
 
+    /// RFC 4315 forbids COPYUID from naming source UIDs outside the UID command's set.
+    func validate(copyUID: CopyUID?) throws -> CopyUID? {
+        guard let copyUID,
+              let reason = copyUID.sourceValidationFailure(for: identifierSet)
+        else {
+            return copyUID
+        }
+        throw IMAPError.malformedCopyUIDAfterTaggedOK(reason)
+    }
+
+    /// Never expose untrusted partial-failure evidence as a verified mapping.
+    func validate(error: IMAPError) -> IMAPError {
+        guard case .moveFailedAfterPartialCompletion(let copyUID, let reason) = error,
+              let validationFailure = copyUID.sourceValidationFailure(for: identifierSet)
+        else {
+            return error
+        }
+        return .moveFailedAfterPossiblePartialCompletion(
+            "MOVE returned unverified COPYUID evidence (\(validationFailure)): \(reason)"
+        )
+    }
+
     /// Convert to an IMAP tagged command
     /// - Parameter tag: The command tag
     /// - Returns: A TaggedCommand ready to be sent to the server

--- a/Sources/SwiftMail/IMAP/IMAP/Commands/ServerCommands.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/ServerCommands.swift
@@ -36,6 +36,16 @@ struct CopyCommand<T: MessageIdentifier>: IMAPTaggedCommand {
         }
     }
 
+    /// RFC 4315 forbids COPYUID from naming source UIDs outside the UID command's set.
+    func validate(copyUID: CopyUID?) throws -> CopyUID? {
+        guard let copyUID,
+              let reason = copyUID.sourceValidationFailure(for: identifierSet)
+        else {
+            return copyUID
+        }
+        throw IMAPError.malformedCopyUIDAfterTaggedOK(reason)
+    }
+
     /// Convert to an IMAP tagged command
     /// - Parameter tag: The command tag
     /// - Returns: A TaggedCommand ready to be sent to the server

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/MoveHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/MoveHandler.swift
@@ -20,12 +20,16 @@ final class MoveHandler: BaseIMAPCommandHandler<CopyUID?>, IMAPCommandHandler, @
         do {
             succeedWithResult(try extractCopyUID(from: response))
         } catch {
-            failWithError(error)
+            // The tagged OK is authority that MOVE completed. A malformed
+            // optional COPYUID makes only the address mapping unusable; turning
+            // it into command failure would make a durable caller retry an
+            // already-committed move.
+            succeedWithResult(nil)
         }
     }
 
     override func handleTaggedErrorResponse(_ response: TaggedResponse) {
-        failWithError(IMAPError.commandFailed("Move failed: \(String(describing: response.state))"))
+        failWithError(IMAPError.moveFailed(String(describing: response.state)))
     }
 }
 

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/MoveHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/MoveHandler.swift
@@ -64,7 +64,20 @@ final class MoveHandler: BaseIMAPCommandHandler<CopyUID?>, IMAPCommandHandler, @
     }
 
     override func handleTaggedErrorResponse(_ response: TaggedResponse) {
-        failWithError(IMAPError.moveFailed(String(describing: response.state)))
+        let reason = String(describing: response.state)
+        let partialCopyUID = lock.withLock {
+            malformedCopyUIDReason == nil ? retainedCopyUID : nil
+        }
+        if let partialCopyUID {
+            failWithError(
+                IMAPError.moveFailedAfterPartialCompletion(
+                    copyUID: partialCopyUID,
+                    reason: reason
+                )
+            )
+        } else {
+            failWithError(IMAPError.moveFailed(reason))
+        }
     }
 }
 

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/MoveHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/MoveHandler.swift
@@ -9,22 +9,57 @@ import NIOConcurrencyHelpers
 
 /// Handler for IMAP MOVE command.
 ///
-/// Extracts the `COPYUID` response code from the tagged OK when the server includes one
-/// (RFC 6851 §3.3). Returns `nil` when the server omits `COPYUID`.
+/// Retains a valid `COPYUID` from either the untagged `OK` recommended before EXPUNGE
+/// responses or the final tagged `OK` (RFC 6851 §§3.3, 4.3). Returns `nil` only when
+/// the successful response contains no `COPYUID` evidence.
 final class MoveHandler: BaseIMAPCommandHandler<CopyUID?>, IMAPCommandHandler, @unchecked Sendable {
     typealias ResultType = CopyUID?
+
+    private var retainedCopyUID: CopyUID?
+    private var malformedCopyUIDReason: String?
+
+    override func handleUntaggedResponse(_ response: Response) -> Bool {
+        if super.handleUntaggedResponse(response) {
+            return true
+        }
+
+        guard case .untagged(.conditionalState(.ok(let text))) = response,
+              let code = text.code,
+              case .uidCopy(let data) = code
+        else {
+            return false
+        }
+
+        recordUntaggedCopyUID(data)
+        return false
+    }
 
     override func handleTaggedOKResponse(_ response: TaggedResponse) {
         super.handleTaggedOKResponse(response)
 
+        var taggedCopyUID: CopyUID?
+        var taggedMalformedReason: String?
         do {
-            succeedWithResult(try extractCopyUID(from: response))
+            taggedCopyUID = try extractCopyUID(from: response)
         } catch {
-            // The tagged OK is authority that MOVE completed. A malformed
-            // optional COPYUID makes only the address mapping unusable; turning
-            // it into command failure would make a durable caller retry an
-            // already-committed move.
-            succeedWithResult(nil)
+            taggedMalformedReason = String(describing: error)
+        }
+
+        let resolution = lock.withLock { () -> (copyUID: CopyUID?, malformedReason: String?) in
+            if let reason = malformedCopyUIDReason ?? taggedMalformedReason {
+                return (nil, reason)
+            }
+            if let retainedCopyUID, let taggedCopyUID,
+               !retainedCopyUID.isEquivalent(to: taggedCopyUID) {
+                return (nil, "Conflicting COPYUID mappings in untagged and tagged OK responses")
+            }
+            return (taggedCopyUID ?? retainedCopyUID, nil)
+        }
+
+        if let reason = resolution.malformedReason {
+            failWithError(IMAPError.malformedCopyUIDAfterTaggedOK(reason))
+        } else {
+            succeedWithResult(resolution.copyUID)
         }
     }
 
@@ -34,6 +69,26 @@ final class MoveHandler: BaseIMAPCommandHandler<CopyUID?>, IMAPCommandHandler, @
 }
 
 private extension MoveHandler {
+    func recordUntaggedCopyUID(_ data: NIOIMAPCore.ResponseCodeCopy) {
+        do {
+            let copyUID = try CopyUID(nio: data)
+            lock.withLock {
+                if let retainedCopyUID, !retainedCopyUID.isEquivalent(to: copyUID) {
+                    malformedCopyUIDReason =
+                        "Conflicting COPYUID mappings in multiple untagged OK responses"
+                } else if retainedCopyUID == nil {
+                    retainedCopyUID = copyUID
+                }
+            }
+        } catch {
+            lock.withLock {
+                if malformedCopyUIDReason == nil {
+                    malformedCopyUIDReason = String(describing: error)
+                }
+            }
+        }
+    }
+
     func extractCopyUID(from response: TaggedResponse) throws -> CopyUID? {
         guard case .ok(let text) = response.state,
               let code = text.code,

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/MoveHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/MoveHandler.swift
@@ -12,7 +12,10 @@ import NIOConcurrencyHelpers
 /// Retains a valid `COPYUID` from either the untagged `OK` recommended before EXPUNGE
 /// responses or the final tagged `OK` (RFC 6851 §§3.3, 4.3). Returns `nil` only when
 /// the successful response contains no `COPYUID` evidence.
-final class MoveHandler: BaseIMAPCommandHandler<CopyUID?>, IMAPCommandHandler, @unchecked Sendable {
+final class MoveHandler:
+    BaseIMAPCommandHandler<CopyUID?>,
+    IMAPCommandHandler,
+    @unchecked Sendable {
     typealias ResultType = CopyUID?
 
     private var retainedCopyUID: CopyUID?
@@ -76,9 +79,10 @@ final class MoveHandler: BaseIMAPCommandHandler<CopyUID?>, IMAPCommandHandler, @
                 )
             )
         } else {
-            failWithError(IMAPError.moveFailed(reason))
+            failWithError(IMAPError.moveFailedAfterPossiblePartialCompletion(reason))
         }
     }
+
 }
 
 private extension MoveHandler {

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/ServerHandlers.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/ServerHandlers.swift
@@ -58,7 +58,11 @@ final class CopyHandler: BaseIMAPCommandHandler<CopyUID?>, IMAPCommandHandler, @
         do {
             succeedWithResult(try extractCopyUID(from: response))
         } catch {
-            failWithError(error)
+            // COPY itself succeeded; only its optional destination mapping was
+            // malformed. Returning nil prevents a durable caller from copying
+            // the same messages again while keeping tagged NO/BAD failures on
+            // the typed error path below.
+            succeedWithResult(nil)
         }
     }
 

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/ServerHandlers.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/ServerHandlers.swift
@@ -58,11 +58,7 @@ final class CopyHandler: BaseIMAPCommandHandler<CopyUID?>, IMAPCommandHandler, @
         do {
             succeedWithResult(try extractCopyUID(from: response))
         } catch {
-            // COPY itself succeeded; only its optional destination mapping was
-            // malformed. Returning nil prevents a durable caller from copying
-            // the same messages again while keeping tagged NO/BAD failures on
-            // the typed error path below.
-            succeedWithResult(nil)
+            failWithError(IMAPError.malformedCopyUIDAfterTaggedOK(String(describing: error)))
         }
     }
 

--- a/Sources/SwiftMail/IMAP/IMAPError.swift
+++ b/Sources/SwiftMail/IMAP/IMAPError.swift
@@ -22,11 +22,17 @@ public enum IMAPError: Error {
     case storeFailed(String)
     case expungeFailed(String)
     case moveFailed(String)
+    /// MOVE may have changed server state before failing, but no trustworthy mapping is available.
+    /// Callers must refresh both mailboxes and must not retry the original identifiers.
+    case moveFailedAfterPossiblePartialCompletion(String)
     /// MOVE completed for the verified subset in `copyUID` before ending with tagged NO/BAD.
     /// Callers should reconcile both mailboxes from this mapping and must not retry blindly.
     case moveFailedAfterPartialCompletion(copyUID: CopyUID, reason: String)
-    /// The command completed with tagged OK, but its present COPYUID evidence was malformed
-    /// or internally conflicting. The provider operation completed; callers must not resend it.
+    /// Fallback COPY completed and created the verified destinations in `copyUID`, but a later
+    /// STORE or EXPUNGE failed. Source flags/removal are unknown and must be refreshed.
+    case moveFallbackFailedAfterCopy(copyUID: CopyUID, reason: String)
+    /// The command completed with tagged OK, but its present COPYUID evidence was malformed,
+    /// conflicting, or unverifiable. The provider operation completed; callers must not resend it.
     case malformedCopyUIDAfterTaggedOK(String)
     case commandNotSupported(String)
     case authFailed(String)
@@ -75,10 +81,14 @@ extension IMAPError: CustomStringConvertible {
                 return "Expunge failed: \(reason)"
             case .moveFailed(let reason):
                 return "Move failed: \(reason)"
+            case .moveFailedAfterPossiblePartialCompletion(let reason):
+                return "Move may have partially completed before failing: \(reason)"
             case .moveFailedAfterPartialCompletion(_, let reason):
                 return "Move partially completed before failing: \(reason)"
+            case .moveFallbackFailedAfterCopy(_, let reason):
+                return "Move fallback copied messages before failing: \(reason)"
             case .malformedCopyUIDAfterTaggedOK(let reason):
-                return "Command completed but returned malformed COPYUID data: \(reason)"
+                return "Command completed but returned untrusted COPYUID data: \(reason)"
             case .commandNotSupported(let reason):
                 return "Command not supported: \(reason)"
             case .authFailed(let reason):
@@ -133,10 +143,14 @@ extension IMAPError: LocalizedError {
                 return "Failed to expunge deleted messages: \(reason)"
             case .moveFailed(let reason):
                 return "Failed to move messages: \(reason)"
+            case .moveFailedAfterPossiblePartialCompletion(let reason):
+                return "The server may have moved or copied messages before failing: \(reason)"
             case .moveFailedAfterPartialCompletion(_, let reason):
                 return "The server moved a verified subset of messages before failing: \(reason)"
+            case .moveFallbackFailedAfterCopy(_, let reason):
+                return "The fallback created verified destination copies, but source state is unknown: \(reason)"
             case .malformedCopyUIDAfterTaggedOK(let reason):
-                return "The command completed, but its COPYUID mapping was invalid: \(reason)"
+                return "The command completed, but its COPYUID mapping could not be trusted: \(reason)"
             case .commandNotSupported(let reason):
                 return "The requested command is not supported by the server: \(reason)"
             case .authFailed(let reason):
@@ -170,10 +184,24 @@ extension IMAPError: LocalizedError {
                 return "Check that your email provider supports XOAUTH2 for IMAP connections."
             case .moveFailedAfterPartialCompletion:
                 return "Do not retry blindly. Reconcile both mailboxes using the verified COPYUID mapping."
+            case .moveFallbackFailedAfterCopy:
+                return "Do not retry. Reconcile the destination copies using COPYUID and refresh the source mailbox."
+            case .moveFailed, .moveFailedAfterPossiblePartialCompletion:
+                return "Do not retry. Refresh both mailboxes and reconcile their current state first."
             case .malformedCopyUIDAfterTaggedOK:
                 return "Do not retry. The command completed; refresh the affected mailboxes before continuing."
             default:
                 return "Check the error details and try again."
         }
+    }
+}
+
+extension IMAPError {
+    static func moveFallbackFailed(after copyUID: CopyUID?, underlying error: Error) -> IMAPError {
+        let reason = "COPY completed before fallback failed: \(error)"
+        if let copyUID {
+            return .moveFallbackFailedAfterCopy(copyUID: copyUID, reason: reason)
+        }
+        return .moveFailedAfterPossiblePartialCompletion(reason)
     }
 }

--- a/Sources/SwiftMail/IMAP/IMAPError.swift
+++ b/Sources/SwiftMail/IMAP/IMAPError.swift
@@ -22,6 +22,9 @@ public enum IMAPError: Error {
     case storeFailed(String)
     case expungeFailed(String)
     case moveFailed(String)
+    /// MOVE completed for the verified subset in `copyUID` before ending with tagged NO/BAD.
+    /// Callers should reconcile both mailboxes from this mapping and must not retry blindly.
+    case moveFailedAfterPartialCompletion(copyUID: CopyUID, reason: String)
     /// The command completed with tagged OK, but its present COPYUID evidence was malformed
     /// or internally conflicting. The provider operation completed; callers must not resend it.
     case malformedCopyUIDAfterTaggedOK(String)
@@ -72,6 +75,8 @@ extension IMAPError: CustomStringConvertible {
                 return "Expunge failed: \(reason)"
             case .moveFailed(let reason):
                 return "Move failed: \(reason)"
+            case .moveFailedAfterPartialCompletion(_, let reason):
+                return "Move partially completed before failing: \(reason)"
             case .malformedCopyUIDAfterTaggedOK(let reason):
                 return "Command completed but returned malformed COPYUID data: \(reason)"
             case .commandNotSupported(let reason):
@@ -128,6 +133,8 @@ extension IMAPError: LocalizedError {
                 return "Failed to expunge deleted messages: \(reason)"
             case .moveFailed(let reason):
                 return "Failed to move messages: \(reason)"
+            case .moveFailedAfterPartialCompletion(_, let reason):
+                return "The server moved a verified subset of messages before failing: \(reason)"
             case .malformedCopyUIDAfterTaggedOK(let reason):
                 return "The command completed, but its COPYUID mapping was invalid: \(reason)"
             case .commandNotSupported(let reason):
@@ -161,6 +168,10 @@ extension IMAPError: LocalizedError {
                 return "Verify your OAuth credentials or request a fresh access token."
             case .unsupportedAuthMechanism:
                 return "Check that your email provider supports XOAUTH2 for IMAP connections."
+            case .moveFailedAfterPartialCompletion:
+                return "Do not retry blindly. Reconcile both mailboxes using the verified COPYUID mapping."
+            case .malformedCopyUIDAfterTaggedOK:
+                return "Do not retry. The command completed; refresh the affected mailboxes before continuing."
             default:
                 return "Check the error details and try again."
         }

--- a/Sources/SwiftMail/IMAP/IMAPError.swift
+++ b/Sources/SwiftMail/IMAP/IMAPError.swift
@@ -22,6 +22,9 @@ public enum IMAPError: Error {
     case storeFailed(String)
     case expungeFailed(String)
     case moveFailed(String)
+    /// The command completed with tagged OK, but its present COPYUID evidence was malformed
+    /// or internally conflicting. The provider operation completed; callers must not resend it.
+    case malformedCopyUIDAfterTaggedOK(String)
     case commandNotSupported(String)
     case authFailed(String)
     case unsupportedAuthMechanism(String)
@@ -69,6 +72,8 @@ extension IMAPError: CustomStringConvertible {
                 return "Expunge failed: \(reason)"
             case .moveFailed(let reason):
                 return "Move failed: \(reason)"
+            case .malformedCopyUIDAfterTaggedOK(let reason):
+                return "Command completed but returned malformed COPYUID data: \(reason)"
             case .commandNotSupported(let reason):
                 return "Command not supported: \(reason)"
             case .authFailed(let reason):
@@ -123,6 +128,8 @@ extension IMAPError: LocalizedError {
                 return "Failed to expunge deleted messages: \(reason)"
             case .moveFailed(let reason):
                 return "Failed to move messages: \(reason)"
+            case .malformedCopyUIDAfterTaggedOK(let reason):
+                return "The command completed, but its COPYUID mapping was invalid: \(reason)"
             case .commandNotSupported(let reason):
                 return "The requested command is not supported by the server: \(reason)"
             case .authFailed(let reason):

--- a/Sources/SwiftMail/IMAP/IMAPNamedConnection+Manipulation.swift
+++ b/Sources/SwiftMail/IMAP/IMAPNamedConnection+Manipulation.swift
@@ -1,6 +1,26 @@
 import Foundation
 
 extension IMAPNamedConnection {
+    /// Move UIDs with the server's atomic MOVE extension and never fall back.
+    ///
+    /// Unlike ``move(messages:to:)``, this entry point either emits one `UID MOVE`
+    /// or throws before issuing a manipulation command. UIDPLUS is deliberately
+    /// not required: RFC 6851 defines `UID MOVE` under the MOVE capability and
+    /// makes `COPYUID` evidence an optional UIDPLUS interaction.
+    ///
+    /// - Throws: ``IMAPError/commandNotSupported(_:)`` when MOVE is not currently
+    ///   advertised, before any COPY, STORE, MOVE, or EXPUNGE command is emitted.
+    @discardableResult
+    public func moveAtomically(
+        messages identifierSet: UIDSet,
+        to destinationMailbox: String
+    ) async throws -> CopyUID? {
+        guard supportsMove else {
+            throw IMAPError.commandNotSupported("MOVE command not supported by server")
+        }
+        return try await executeMove(messages: identifierSet, to: destinationMailbox)
+    }
+
     /// Copy messages to another mailbox.
     ///
     /// - Returns: A ``CopyUID`` with the server-verified source-to-destination UID mapping,

--- a/Sources/SwiftMail/IMAP/IMAPNamedConnection+Manipulation.swift
+++ b/Sources/SwiftMail/IMAP/IMAPNamedConnection+Manipulation.swift
@@ -7,8 +7,8 @@ extension IMAPNamedConnection {
     ///   or `nil` when the server omits `COPYUID` (e.g. the server does not advertise UIDPLUS,
     ///   or a sequence-number-based copy was issued).
     /// - Throws: ``IMAPError/malformedCopyUIDAfterTaggedOK(_:)`` when the server completes
-    ///   the command but supplies malformed COPYUID evidence. The COPY completed and must
-    ///   not be resent.
+    ///   the command but supplies malformed or unverifiable COPYUID evidence. The COPY
+    ///   completed and must not be resent.
     @discardableResult
     public func copy<T: MessageIdentifier>(
         messages identifierSet: MessageIdentifierSet<T>,
@@ -18,7 +18,8 @@ extension IMAPNamedConnection {
             identifierSet: identifierSet,
             destinationMailbox: resolveMailboxPath(destinationMailbox)
         )
-        return try await executeCommand(command)
+        let copyUID = try await executeCommand(command)
+        return try command.validate(copyUID: copyUID)
     }
 
     /// Update flags for messages.
@@ -69,11 +70,15 @@ extension IMAPNamedConnection {
     ///   or `nil` when the server omits `COPYUID`.
     /// - Throws: ``IMAPError/commandNotSupported(_:)`` before a manipulation command when
     ///   `fallback` is ``MoveFallbackPolicy/disabled`` and MOVE is not advertised; or
+    ///   ``IMAPError/moveFailedAfterPossiblePartialCompletion(_:)`` when server state may
+    ///   have changed but no trustworthy mapping is available; or
     ///   ``IMAPError/moveFailedAfterPartialCompletion(copyUID:reason:)`` when a tagged failure
     ///   follows a verified partial mapping, which callers must use to reconcile both mailboxes; or
+    ///   ``IMAPError/moveFallbackFailedAfterCopy(copyUID:reason:)`` when fallback COPY succeeds
+    ///   but source STORE or EXPUNGE does not complete; or
     ///   ``IMAPError/malformedCopyUIDAfterTaggedOK(_:)`` after a successful command with
-    ///   malformed or conflicting COPYUID evidence. A command that throws the latter error
-    ///   completed and must not be resent.
+    ///   malformed, conflicting, or unverifiable COPYUID evidence. A command that throws
+    ///   the latter error completed and must not be resent.
     @discardableResult
     public func move<T: MessageIdentifier>(
         messages identifierSet: MessageIdentifierSet<T>,
@@ -82,6 +87,8 @@ extension IMAPNamedConnection {
     ) async throws -> CopyUID? {
         try await ensureAuthenticated()
         let capabilities = self.capabilities
+        let useTargetedUIDExpunge = T.self == UID.self
+            && capabilities.containsUIDPlusCapability
 
         if case .disabled = fallback {
             guard capabilities.containsMoveCapability else {
@@ -91,14 +98,21 @@ extension IMAPNamedConnection {
         }
 
         if capabilities.containsMoveCapability
-            && (T.self != UID.self || capabilities.contains(.uidPlus)) {
+            && (T.self != UID.self || useTargetedUIDExpunge) {
             return try await executeMove(messages: identifierSet, to: destinationMailbox)
         }
 
         let copyUID = try await copy(messages: identifierSet, to: destinationMailbox)
-        try await store(flags: [.deleted], on: identifierSet, operation: .add)
-        try await expungeMoveFallback(messages: identifierSet)
-        return copyUID
+        do {
+            try await store(flags: [.deleted], on: identifierSet, operation: .add)
+            try await expungeMoveFallback(
+                messages: identifierSet,
+                useTargetedUIDExpunge: useTargetedUIDExpunge
+            )
+            return copyUID
+        } catch {
+            throw IMAPError.moveFallbackFailed(after: copyUID, underlying: error)
+        }
     }
 
     /// Move one message using the established MOVE-or-COPY+STORE+EXPUNGE policy.
@@ -136,13 +150,19 @@ extension IMAPNamedConnection {
             identifierSet: identifierSet,
             destinationMailbox: resolveMailboxPath(destinationMailbox)
         )
-        return try await executeCommand(command)
+        do {
+            let copyUID = try await executeCommand(command)
+            return try command.validate(copyUID: copyUID)
+        } catch let error as IMAPError {
+            throw command.validate(error: error)
+        }
     }
 
     private func expungeMoveFallback<T: MessageIdentifier>(
-        messages identifierSet: MessageIdentifierSet<T>
+        messages identifierSet: MessageIdentifierSet<T>,
+        useTargetedUIDExpunge: Bool
     ) async throws {
-        if T.self == UID.self && capabilities.contains(.uidPlus) {
+        if useTargetedUIDExpunge {
             let uidSet = UIDSet(identifierSet.toArray().map { UID($0.value) })
             try await expunge(messages: uidSet)
         } else {

--- a/Sources/SwiftMail/IMAP/IMAPNamedConnection+Manipulation.swift
+++ b/Sources/SwiftMail/IMAP/IMAPNamedConnection+Manipulation.swift
@@ -1,31 +1,14 @@
 import Foundation
 
 extension IMAPNamedConnection {
-    /// Move UIDs with the server's atomic MOVE extension and never fall back.
-    ///
-    /// Unlike ``move(messages:to:)``, this entry point either emits one `UID MOVE`
-    /// or throws before issuing a manipulation command. UIDPLUS is deliberately
-    /// not required: RFC 6851 defines `UID MOVE` under the MOVE capability and
-    /// makes `COPYUID` evidence an optional UIDPLUS interaction.
-    ///
-    /// - Throws: ``IMAPError/commandNotSupported(_:)`` when MOVE is not currently
-    ///   advertised, before any COPY, STORE, MOVE, or EXPUNGE command is emitted.
-    @discardableResult
-    public func moveAtomically(
-        messages identifierSet: UIDSet,
-        to destinationMailbox: String
-    ) async throws -> CopyUID? {
-        guard supportsMove else {
-            throw IMAPError.commandNotSupported("MOVE command not supported by server")
-        }
-        return try await executeMove(messages: identifierSet, to: destinationMailbox)
-    }
-
     /// Copy messages to another mailbox.
     ///
     /// - Returns: A ``CopyUID`` with the server-verified source-to-destination UID mapping,
     ///   or `nil` when the server omits `COPYUID` (e.g. the server does not advertise UIDPLUS,
     ///   or a sequence-number-based copy was issued).
+    /// - Throws: ``IMAPError/malformedCopyUIDAfterTaggedOK(_:)`` when the server completes
+    ///   the command but supplies malformed COPYUID evidence. The COPY completed and must
+    ///   not be resent.
     @discardableResult
     public func copy<T: MessageIdentifier>(
         messages identifierSet: MessageIdentifierSet<T>,
@@ -65,23 +48,40 @@ extension IMAPNamedConnection {
         try await executeCommand(command)
     }
 
-    /// Move messages to another mailbox (uses MOVE if supported, otherwise COPY+STORE+EXPUNGE).
+    /// Move messages to another mailbox.
+    ///
+    /// The default retains the existing MOVE-or-COPY+STORE+EXPUNGE behavior. Pass
+    /// ``MoveFallbackPolicy/disabled`` to require MOVE without requiring UIDPLUS.
     ///
     /// - Returns: A ``CopyUID`` with the server-verified source-to-destination UID mapping,
     ///   or `nil` when the server omits `COPYUID`.
+    /// - Throws: ``IMAPError/commandNotSupported(_:)`` before a manipulation command when
+    ///   `fallback` is ``MoveFallbackPolicy/disabled`` and MOVE is not advertised; or
+    ///   ``IMAPError/malformedCopyUIDAfterTaggedOK(_:)`` after a successful command with
+    ///   malformed or conflicting COPYUID evidence. A command that throws the latter error
+    ///   completed and must not be resent.
     @discardableResult
     public func move<T: MessageIdentifier>(
         messages identifierSet: MessageIdentifierSet<T>,
-        to destinationMailbox: String
+        to destinationMailbox: String,
+        fallback: MoveFallbackPolicy = .copyStoreExpunge
     ) async throws -> CopyUID? {
-        if capabilities.contains(.move) && (T.self != UID.self || capabilities.contains(.uidPlus)) {
+        if case .disabled = fallback {
+            guard capabilities.containsMoveCapability else {
+                throw IMAPError.commandNotSupported("MOVE command not supported by server")
+            }
             return try await executeMove(messages: identifierSet, to: destinationMailbox)
-        } else {
-            let copyUID = try await copy(messages: identifierSet, to: destinationMailbox)
-            try await store(flags: [.deleted], on: identifierSet, operation: .add)
-            try await expungeMoveFallback(messages: identifierSet)
-            return copyUID
         }
+
+        if capabilities.containsMoveCapability
+            && (T.self != UID.self || capabilities.contains(.uidPlus)) {
+            return try await executeMove(messages: identifierSet, to: destinationMailbox)
+        }
+
+        let copyUID = try await copy(messages: identifierSet, to: destinationMailbox)
+        try await store(flags: [.deleted], on: identifierSet, operation: .add)
+        try await expungeMoveFallback(messages: identifierSet)
+        return copyUID
     }
 
     /// Move a single message to another mailbox.
@@ -90,10 +90,12 @@ extension IMAPNamedConnection {
     ///   or `nil` when the server omits `COPYUID`.
     @discardableResult
     public func move<T: MessageIdentifier>(
-        message identifier: T, to destinationMailbox: String
+        message identifier: T,
+        to destinationMailbox: String,
+        fallback: MoveFallbackPolicy = .copyStoreExpunge
     ) async throws -> CopyUID? {
         let set = MessageIdentifierSet<T>(identifier)
-        return try await move(messages: set, to: destinationMailbox)
+        return try await move(messages: set, to: destinationMailbox, fallback: fallback)
     }
 
     private func executeMove<T: MessageIdentifier>(

--- a/Sources/SwiftMail/IMAP/IMAPNamedConnection+Manipulation.swift
+++ b/Sources/SwiftMail/IMAP/IMAPNamedConnection+Manipulation.swift
@@ -48,15 +48,29 @@ extension IMAPNamedConnection {
         try await executeCommand(command)
     }
 
-    /// Move messages to another mailbox.
+    /// Move messages using the established MOVE-or-COPY+STORE+EXPUNGE policy.
+    @discardableResult
+    public func move<T: MessageIdentifier>(
+        messages identifierSet: MessageIdentifierSet<T>,
+        to destinationMailbox: String
+    ) async throws -> CopyUID? {
+        try await move(
+            messages: identifierSet,
+            to: destinationMailbox,
+            fallback: .copyStoreExpunge
+        )
+    }
+
+    /// Move messages to another mailbox with an explicit fallback policy.
     ///
-    /// The default retains the existing MOVE-or-COPY+STORE+EXPUNGE behavior. Pass
-    /// ``MoveFallbackPolicy/disabled`` to require MOVE without requiring UIDPLUS.
+    /// Pass ``MoveFallbackPolicy/disabled`` to require MOVE without requiring UIDPLUS.
     ///
     /// - Returns: A ``CopyUID`` with the server-verified source-to-destination UID mapping,
     ///   or `nil` when the server omits `COPYUID`.
     /// - Throws: ``IMAPError/commandNotSupported(_:)`` before a manipulation command when
     ///   `fallback` is ``MoveFallbackPolicy/disabled`` and MOVE is not advertised; or
+    ///   ``IMAPError/moveFailedAfterPartialCompletion(copyUID:reason:)`` when a tagged failure
+    ///   follows a verified partial mapping, which callers must use to reconcile both mailboxes; or
     ///   ``IMAPError/malformedCopyUIDAfterTaggedOK(_:)`` after a successful command with
     ///   malformed or conflicting COPYUID evidence. A command that throws the latter error
     ///   completed and must not be resent.
@@ -64,8 +78,11 @@ extension IMAPNamedConnection {
     public func move<T: MessageIdentifier>(
         messages identifierSet: MessageIdentifierSet<T>,
         to destinationMailbox: String,
-        fallback: MoveFallbackPolicy = .copyStoreExpunge
+        fallback: MoveFallbackPolicy
     ) async throws -> CopyUID? {
+        try await ensureAuthenticated()
+        let capabilities = self.capabilities
+
         if case .disabled = fallback {
             guard capabilities.containsMoveCapability else {
                 throw IMAPError.commandNotSupported("MOVE command not supported by server")
@@ -84,7 +101,20 @@ extension IMAPNamedConnection {
         return copyUID
     }
 
-    /// Move a single message to another mailbox.
+    /// Move one message using the established MOVE-or-COPY+STORE+EXPUNGE policy.
+    @discardableResult
+    public func move<T: MessageIdentifier>(
+        message identifier: T,
+        to destinationMailbox: String
+    ) async throws -> CopyUID? {
+        try await move(
+            message: identifier,
+            to: destinationMailbox,
+            fallback: .copyStoreExpunge
+        )
+    }
+
+    /// Move a single message to another mailbox with an explicit fallback policy.
     ///
     /// - Returns: A ``CopyUID`` with the server-verified source-to-destination UID mapping,
     ///   or `nil` when the server omits `COPYUID`.
@@ -92,7 +122,7 @@ extension IMAPNamedConnection {
     public func move<T: MessageIdentifier>(
         message identifier: T,
         to destinationMailbox: String,
-        fallback: MoveFallbackPolicy = .copyStoreExpunge
+        fallback: MoveFallbackPolicy
     ) async throws -> CopyUID? {
         let set = MessageIdentifierSet<T>(identifier)
         return try await move(messages: set, to: destinationMailbox, fallback: fallback)

--- a/Sources/SwiftMail/IMAP/IMAPNamedConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPNamedConnection.swift
@@ -61,6 +61,15 @@ public actor IMAPNamedConnection {
         capabilities.contains(.uidPlus)
     }
 
+    /// Whether the server advertised MOVE (RFC 6851) for this connection.
+    ///
+    /// This reports the advertised capability only. ``move(messages:to:)`` issues a real `MOVE`
+    /// for a UID-based set only when the server also advertises UIDPLUS, and otherwise falls back
+    /// to COPY + STORE `\Deleted` + EXPUNGE.
+    public var supportsMove: Bool {
+        capabilities.contains(.move)
+    }
+
     // MARK: - Internal Helpers
 
     /// Capabilities snapshot reused by the split extensions when deciding

--- a/Sources/SwiftMail/IMAP/IMAPNamedConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPNamedConnection.swift
@@ -63,11 +63,11 @@ public actor IMAPNamedConnection {
 
     /// Whether the server advertised MOVE (RFC 6851) for this connection.
     ///
-    /// This reports the advertised capability only. ``move(messages:to:)`` issues a real `MOVE`
-    /// for a UID-based set only when the server also advertises UIDPLUS, and otherwise falls back
-    /// to COPY + STORE `\Deleted` + EXPUNGE.
+    /// This reports the advertised capability only. The default
+    /// ``move(messages:to:fallback:)`` policy retains the existing UIDPLUS-dependent fallback,
+    /// while ``MoveFallbackPolicy/disabled`` requires MOVE directly.
     public var supportsMove: Bool {
-        capabilities.contains(.move)
+        capabilities.containsMoveCapability
     }
 
     // MARK: - Internal Helpers

--- a/Sources/SwiftMail/IMAP/IMAPNamedConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPNamedConnection.swift
@@ -58,7 +58,7 @@ public actor IMAPNamedConnection {
 
     /// Whether the server advertised UIDPLUS for this connection.
     public var supportsUIDPlus: Bool {
-        capabilities.contains(.uidPlus)
+        capabilities.containsUIDPlusCapability
     }
 
     /// Whether the server advertised MOVE (RFC 6851) for this connection.

--- a/Sources/SwiftMail/IMAP/IMAPServer+Helpers.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Helpers.swift
@@ -14,13 +14,18 @@ extension IMAPServer {
     func executeCommand<CommandType: IMAPCommand>(
         _ command: CommandType
     ) async throws -> CommandType.ResultType {
+        try await ensurePrimaryConnectionAuthenticated()
+
+        return try await primaryConnection.executeCommand(command)
+    }
+
+    /// Refreshes session-scoped state before a capability-dependent command decision.
+    func ensurePrimaryConnectionAuthenticated() async throws {
         if let authentication, !primaryConnection.isAuthenticated {
             logger.info("Primary connection not authenticated; re-authenticating before command")
             try await authentication.authenticate(on: primaryConnection)
             namespaces = primaryConnection.namespacesSnapshot
         }
-
-        return try await primaryConnection.executeCommand(command)
     }
 
     func resolveMailboxPath(_ mailbox: String) -> String {

--- a/Sources/SwiftMail/IMAP/IMAPServer+Manipulation.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Manipulation.swift
@@ -6,6 +6,28 @@ import NIOIMAPCore
 
 extension IMAPServer {
     /**
+     Moves UIDs with the server's atomic MOVE extension and never falls back.
+
+     Unlike ``move(messages:to:)``, this entry point either emits one `UID MOVE`
+     or throws before issuing a manipulation command. UIDPLUS is deliberately
+     not required: RFC 6851 defines `UID MOVE` under the MOVE capability and
+     makes `COPYUID` evidence an optional UIDPLUS interaction.
+
+     - Throws: ``IMAPError/commandNotSupported(_:)`` when MOVE is not currently
+       advertised, before any COPY, STORE, MOVE, or EXPUNGE command is emitted.
+     */
+    @discardableResult
+    public func moveAtomically(
+        messages identifierSet: UIDSet,
+        to destinationMailbox: String
+    ) async throws -> CopyUID? {
+        guard capabilities.contains(.move) else {
+            throw IMAPError.commandNotSupported("MOVE command not supported by server")
+        }
+        return try await executeMove(messages: identifierSet, to: destinationMailbox)
+    }
+
+    /**
      Moves messages to another mailbox.
 
      This method attempts to use the MOVE extension if available, falling back to

--- a/Sources/SwiftMail/IMAP/IMAPServer+Manipulation.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Manipulation.swift
@@ -5,13 +5,25 @@ import NIOIMAPCore
 // MARK: - Message Manipulation Commands
 
 extension IMAPServer {
+    /// Moves messages using the established MOVE-or-COPY+STORE+EXPUNGE policy.
+    @discardableResult
+    public func move<T: MessageIdentifier>(
+        messages identifierSet: MessageIdentifierSet<T>,
+        to destinationMailbox: String
+    ) async throws -> CopyUID? {
+        try await move(
+            messages: identifierSet,
+            to: destinationMailbox,
+            fallback: .copyStoreExpunge
+        )
+    }
+
     /**
      Moves messages to another mailbox.
 
-     By default this method attempts to use the MOVE extension and retains its
-     existing COPY+STORE+EXPUNGE fallback. Pass ``MoveFallbackPolicy/disabled``
-     to require MOVE and refuse before emitting a manipulation command when the
-     extension is unavailable. The disabled policy does not require UIDPLUS.
+     Pass ``MoveFallbackPolicy/disabled`` to require MOVE and refuse before emitting
+     a manipulation command when the extension is unavailable. The disabled policy
+     does not require UIDPLUS.
 
      The generic type T determines the identifier type:
      - Use `SequenceNumber` for temporary message numbers that may change
@@ -25,6 +37,8 @@ extension IMAPServer {
        or `nil` when the server omits `COPYUID` (e.g. the server does not advertise UIDPLUS).
      - Throws:
      - `IMAPError.moveFailed` if the move operation fails
+     - ``IMAPError/moveFailedAfterPartialCompletion(copyUID:reason:)`` when a tagged failure
+       follows a verified partial mapping; reconcile both mailboxes before deciding whether to retry
      - `IMAPError.emptyIdentifierSet` if the identifier set is empty
      - ``IMAPError/commandNotSupported(_:)`` before a manipulation command when `fallback`
        is ``MoveFallbackPolicy/disabled`` and MOVE is not advertised
@@ -36,8 +50,11 @@ extension IMAPServer {
     public func move<T: MessageIdentifier>(
         messages identifierSet: MessageIdentifierSet<T>,
         to destinationMailbox: String,
-        fallback: MoveFallbackPolicy = .copyStoreExpunge
+        fallback: MoveFallbackPolicy
     ) async throws -> CopyUID? {
+        try await ensurePrimaryConnectionAuthenticated()
+        let capabilities = self.capabilities
+
         if case .disabled = fallback {
             guard capabilities.containsMoveCapability else {
                 throw IMAPError.commandNotSupported("MOVE command not supported by server")
@@ -57,6 +74,19 @@ extension IMAPServer {
         return copyUID
     }
 
+    /// Moves one message using the established MOVE-or-COPY+STORE+EXPUNGE policy.
+    @discardableResult
+    public func move<T: MessageIdentifier>(
+        message identifier: T,
+        to destinationMailbox: String
+    ) async throws -> CopyUID? {
+        try await move(
+            message: identifier,
+            to: destinationMailbox,
+            fallback: .copyStoreExpunge
+        )
+    }
+
     /**
      Move a single message from the current mailbox to another mailbox
      - Parameters:
@@ -71,10 +101,23 @@ extension IMAPServer {
     public func move<T: MessageIdentifier>(
         message identifier: T,
         to destinationMailbox: String,
-        fallback: MoveFallbackPolicy = .copyStoreExpunge
+        fallback: MoveFallbackPolicy
     ) async throws -> CopyUID? {
         let set = MessageIdentifierSet<T>(identifier)
         return try await move(messages: set, to: destinationMailbox, fallback: fallback)
+    }
+
+    /// Moves the message identified by `header` using the established fallback policy.
+    @discardableResult
+    public func move(
+        header: MessageInfo,
+        to destinationMailbox: String
+    ) async throws -> CopyUID? {
+        try await move(
+            header: header,
+            to: destinationMailbox,
+            fallback: .copyStoreExpunge
+        )
     }
 
     /**
@@ -91,7 +134,7 @@ extension IMAPServer {
     public func move(
         header: MessageInfo,
         to destinationMailbox: String,
-        fallback: MoveFallbackPolicy = .copyStoreExpunge
+        fallback: MoveFallbackPolicy
     ) async throws -> CopyUID? {
         if let uid = header.uid {
             return try await move(message: uid, to: destinationMailbox, fallback: fallback)

--- a/Sources/SwiftMail/IMAP/IMAPServer+Manipulation.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Manipulation.swift
@@ -36,14 +36,18 @@ extension IMAPServer {
      - Returns: A ``CopyUID`` with the server-verified source-to-destination UID mapping,
        or `nil` when the server omits `COPYUID` (e.g. the server does not advertise UIDPLUS).
      - Throws:
-     - `IMAPError.moveFailed` if the move operation fails
+     - ``IMAPError/moveFailedAfterPossiblePartialCompletion(_:)`` when MOVE or a fallback
+       may have changed server state but no trustworthy mapping is available; do not retry
      - ``IMAPError/moveFailedAfterPartialCompletion(copyUID:reason:)`` when a tagged failure
        follows a verified partial mapping; reconcile both mailboxes before deciding whether to retry
+     - ``IMAPError/moveFallbackFailedAfterCopy(copyUID:reason:)`` when fallback COPY succeeds
+       but a later STORE or EXPUNGE fails; destination copies are verified, source state is unknown
      - `IMAPError.emptyIdentifierSet` if the identifier set is empty
      - ``IMAPError/commandNotSupported(_:)`` before a manipulation command when `fallback`
        is ``MoveFallbackPolicy/disabled`` and MOVE is not advertised
      - ``IMAPError/malformedCopyUIDAfterTaggedOK(_:)`` after a successful command with
-       malformed or conflicting COPYUID evidence; the command completed and must not be resent
+       malformed, conflicting, or unverifiable COPYUID evidence; the command completed and
+       must not be resent
      - Note: Logs move operations at info level with message count and destination
      */
     @discardableResult
@@ -54,6 +58,8 @@ extension IMAPServer {
     ) async throws -> CopyUID? {
         try await ensurePrimaryConnectionAuthenticated()
         let capabilities = self.capabilities
+        let useTargetedUIDExpunge = T.self == UID.self
+            && capabilities.containsUIDPlusCapability
 
         if case .disabled = fallback {
             guard capabilities.containsMoveCapability else {
@@ -63,15 +69,22 @@ extension IMAPServer {
         }
 
         if capabilities.containsMoveCapability
-            && (T.self != UID.self || capabilities.contains(.uidPlus)) {
+            && (T.self != UID.self || useTargetedUIDExpunge) {
             return try await executeMove(messages: identifierSet, to: destinationMailbox)
         }
 
         // Preserve the existing fallback, including targeted UID EXPUNGE when UIDPLUS is available.
         let copyUID = try await copy(messages: identifierSet, to: destinationMailbox)
-        try await store(flags: [.deleted], on: identifierSet, operation: .add)
-        try await expungeMoveFallback(messages: identifierSet)
-        return copyUID
+        do {
+            try await store(flags: [.deleted], on: identifierSet, operation: .add)
+            try await expungeMoveFallback(
+                messages: identifierSet,
+                useTargetedUIDExpunge: useTargetedUIDExpunge
+            )
+            return copyUID
+        } catch {
+            throw IMAPError.moveFallbackFailed(after: copyUID, underlying: error)
+        }
     }
 
     /// Moves one message using the established MOVE-or-COPY+STORE+EXPUNGE policy.
@@ -157,7 +170,7 @@ extension IMAPServer {
      - `IMAPError.copyFailed` if the copy operation fails
      - `IMAPError.emptyIdentifierSet` if the identifier set is empty
      - ``IMAPError/malformedCopyUIDAfterTaggedOK(_:)`` after a successful COPY with
-       malformed COPYUID evidence; the COPY completed and must not be resent
+       malformed or unverifiable COPYUID evidence; the COPY completed and must not be resent
      */
     @discardableResult
     public func copy<T: MessageIdentifier>(
@@ -168,7 +181,8 @@ extension IMAPServer {
             identifierSet: identifierSet,
             destinationMailbox: resolveMailboxPath(destinationMailbox)
         )
-        return try await executeCommand(command)
+        let copyUID = try await executeCommand(command)
+        return try command.validate(copyUID: copyUID)
     }
 
     /**
@@ -229,9 +243,10 @@ extension IMAPServer {
     }
 
     func expungeMoveFallback<T: MessageIdentifier>(
-        messages identifierSet: MessageIdentifierSet<T>
+        messages identifierSet: MessageIdentifierSet<T>,
+        useTargetedUIDExpunge: Bool
     ) async throws {
-        if T.self == UID.self && capabilities.contains(.uidPlus) {
+        if useTargetedUIDExpunge {
             let uidSet = UIDSet(identifierSet.toArray().map { UID($0.value) })
             try await expunge(messages: uidSet)
         } else {
@@ -252,7 +267,8 @@ extension IMAPServer {
      - identifierSet: The set of messages to move
      - destinationMailbox: The name of the destination mailbox
      - Throws:
-     - `IMAPError.moveFailed` if the move operation fails
+     - ``IMAPError/moveFailedAfterPossiblePartialCompletion(_:)`` when the move may have
+       changed server state without a trustworthy mapping
      - `IMAPError.emptyIdentifierSet` if the identifier set is empty
      - Note: Logs move operations at debug level
      */
@@ -264,6 +280,11 @@ extension IMAPServer {
             identifierSet: identifierSet,
             destinationMailbox: resolveMailboxPath(destinationMailbox)
         )
-        return try await executeCommand(command)
+        do {
+            let copyUID = try await executeCommand(command)
+            return try command.validate(copyUID: copyUID)
+        } catch let error as IMAPError {
+            throw command.validate(error: error)
+        }
     }
 }

--- a/Sources/SwiftMail/IMAP/IMAPServer+Manipulation.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Manipulation.swift
@@ -6,32 +6,12 @@ import NIOIMAPCore
 
 extension IMAPServer {
     /**
-     Moves UIDs with the server's atomic MOVE extension and never falls back.
-
-     Unlike ``move(messages:to:)``, this entry point either emits one `UID MOVE`
-     or throws before issuing a manipulation command. UIDPLUS is deliberately
-     not required: RFC 6851 defines `UID MOVE` under the MOVE capability and
-     makes `COPYUID` evidence an optional UIDPLUS interaction.
-
-     - Throws: ``IMAPError/commandNotSupported(_:)`` when MOVE is not currently
-       advertised, before any COPY, STORE, MOVE, or EXPUNGE command is emitted.
-     */
-    @discardableResult
-    public func moveAtomically(
-        messages identifierSet: UIDSet,
-        to destinationMailbox: String
-    ) async throws -> CopyUID? {
-        guard capabilities.contains(.move) else {
-            throw IMAPError.commandNotSupported("MOVE command not supported by server")
-        }
-        return try await executeMove(messages: identifierSet, to: destinationMailbox)
-    }
-
-    /**
      Moves messages to another mailbox.
 
-     This method attempts to use the MOVE extension if available, falling back to
-     COPY+EXPUNGE if necessary.
+     By default this method attempts to use the MOVE extension and retains its
+     existing COPY+STORE+EXPUNGE fallback. Pass ``MoveFallbackPolicy/disabled``
+     to require MOVE and refuse before emitting a manipulation command when the
+     extension is unavailable. The disabled policy does not require UIDPLUS.
 
      The generic type T determines the identifier type:
      - Use `SequenceNumber` for temporary message numbers that may change
@@ -40,27 +20,41 @@ extension IMAPServer {
      - Parameters:
      - identifierSet: The set of messages to move
      - destinationMailbox: The name of the destination mailbox
+     - fallback: Whether COPY+STORE+EXPUNGE fallback is allowed.
      - Returns: A ``CopyUID`` with the server-verified source-to-destination UID mapping,
        or `nil` when the server omits `COPYUID` (e.g. the server does not advertise UIDPLUS).
      - Throws:
      - `IMAPError.moveFailed` if the move operation fails
      - `IMAPError.emptyIdentifierSet` if the identifier set is empty
+     - ``IMAPError/commandNotSupported(_:)`` before a manipulation command when `fallback`
+       is ``MoveFallbackPolicy/disabled`` and MOVE is not advertised
+     - ``IMAPError/malformedCopyUIDAfterTaggedOK(_:)`` after a successful command with
+       malformed or conflicting COPYUID evidence; the command completed and must not be resent
      - Note: Logs move operations at info level with message count and destination
      */
     @discardableResult
     public func move<T: MessageIdentifier>(
         messages identifierSet: MessageIdentifierSet<T>,
-        to destinationMailbox: String
+        to destinationMailbox: String,
+        fallback: MoveFallbackPolicy = .copyStoreExpunge
     ) async throws -> CopyUID? {
-        if capabilities.contains(.move) && (T.self != UID.self || capabilities.contains(.uidPlus)) {
+        if case .disabled = fallback {
+            guard capabilities.containsMoveCapability else {
+                throw IMAPError.commandNotSupported("MOVE command not supported by server")
+            }
             return try await executeMove(messages: identifierSet, to: destinationMailbox)
-        } else {
-            // Fall back to COPY + DELETE + targeted expunge when UIDPLUS is available.
-            let copyUID = try await copy(messages: identifierSet, to: destinationMailbox)
-            try await store(flags: [.deleted], on: identifierSet, operation: .add)
-            try await expungeMoveFallback(messages: identifierSet)
-            return copyUID
         }
+
+        if capabilities.containsMoveCapability
+            && (T.self != UID.self || capabilities.contains(.uidPlus)) {
+            return try await executeMove(messages: identifierSet, to: destinationMailbox)
+        }
+
+        // Preserve the existing fallback, including targeted UID EXPUNGE when UIDPLUS is available.
+        let copyUID = try await copy(messages: identifierSet, to: destinationMailbox)
+        try await store(flags: [.deleted], on: identifierSet, operation: .add)
+        try await expungeMoveFallback(messages: identifierSet)
+        return copyUID
     }
 
     /**
@@ -68,16 +62,19 @@ extension IMAPServer {
      - Parameters:
      - message: The message identifier to move
      - destinationMailbox: The name of the destination mailbox
+     - fallback: Whether COPY+STORE+EXPUNGE fallback is allowed.
      - Returns: A ``CopyUID`` with the server-verified source-to-destination UID mapping,
        or `nil` when the server omits `COPYUID`.
      - Throws: An error if the move operation fails
      */
     @discardableResult
     public func move<T: MessageIdentifier>(
-        message identifier: T, to destinationMailbox: String
+        message identifier: T,
+        to destinationMailbox: String,
+        fallback: MoveFallbackPolicy = .copyStoreExpunge
     ) async throws -> CopyUID? {
         let set = MessageIdentifierSet<T>(identifier)
-        return try await move(messages: set, to: destinationMailbox)
+        return try await move(messages: set, to: destinationMailbox, fallback: fallback)
     }
 
     /**
@@ -85,17 +82,22 @@ extension IMAPServer {
      - Parameters:
      - header: The email header of the message to move
      - destinationMailbox: The name of the destination mailbox
+     - fallback: Whether COPY+STORE+EXPUNGE fallback is allowed.
      - Returns: A ``CopyUID`` with the server-verified source-to-destination UID mapping,
        or `nil` when the server omits `COPYUID`.
      - Throws: An error if the move operation fails
      */
     @discardableResult
-    public func move(header: MessageInfo, to destinationMailbox: String) async throws -> CopyUID? {
+    public func move(
+        header: MessageInfo,
+        to destinationMailbox: String,
+        fallback: MoveFallbackPolicy = .copyStoreExpunge
+    ) async throws -> CopyUID? {
         if let uid = header.uid {
-            return try await move(message: uid, to: destinationMailbox)
+            return try await move(message: uid, to: destinationMailbox, fallback: fallback)
         } else {
             let sequenceNumber = header.sequenceNumber
-            return try await move(message: sequenceNumber, to: destinationMailbox)
+            return try await move(message: sequenceNumber, to: destinationMailbox, fallback: fallback)
         }
     }
 
@@ -111,6 +113,8 @@ extension IMAPServer {
      - Throws:
      - `IMAPError.copyFailed` if the copy operation fails
      - `IMAPError.emptyIdentifierSet` if the identifier set is empty
+     - ``IMAPError/malformedCopyUIDAfterTaggedOK(_:)`` after a successful COPY with
+       malformed COPYUID evidence; the COPY completed and must not be resent
      */
     @discardableResult
     public func copy<T: MessageIdentifier>(

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -96,6 +96,15 @@ public actor IMAPServer {
         capabilities.contains(.uidPlus)
     }
 
+    /// Whether the primary connection advertised MOVE (RFC 6851).
+    ///
+    /// This reports the advertised capability only. ``move(messages:to:)`` issues a real `MOVE`
+    /// for a UID-based set only when the server also advertises UIDPLUS, and otherwise falls back
+    /// to COPY + STORE `\Deleted` + EXPUNGE.
+    public var supportsMove: Bool {
+        capabilities.contains(.move)
+    }
+
     var certificatePolicyForTesting: MailCertificateVerificationPolicy {
         primaryConnection.certificateVerificationPolicyForTesting
     }

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -98,11 +98,11 @@ public actor IMAPServer {
 
     /// Whether the primary connection advertised MOVE (RFC 6851).
     ///
-    /// This reports the advertised capability only. ``move(messages:to:)`` issues a real `MOVE`
-    /// for a UID-based set only when the server also advertises UIDPLUS, and otherwise falls back
-    /// to COPY + STORE `\Deleted` + EXPUNGE.
+    /// This reports the advertised capability only. The default
+    /// ``move(messages:to:fallback:)`` policy retains the existing UIDPLUS-dependent fallback,
+    /// while ``MoveFallbackPolicy/disabled`` requires MOVE directly.
     public var supportsMove: Bool {
-        capabilities.contains(.move)
+        capabilities.containsMoveCapability
     }
 
     var certificatePolicyForTesting: MailCertificateVerificationPolicy {

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -93,7 +93,7 @@ public actor IMAPServer {
 
     /// Whether the primary connection advertised UIDPLUS.
     public var supportsUIDPlus: Bool {
-        capabilities.contains(.uidPlus)
+        capabilities.containsUIDPlusCapability
     }
 
     /// Whether the primary connection advertised MOVE (RFC 6851).

--- a/Sources/SwiftMail/IMAP/Models/Capability+Move.swift
+++ b/Sources/SwiftMail/IMAP/Models/Capability+Move.swift
@@ -1,0 +1,14 @@
+import NIOIMAPCore
+
+extension Set where Element == NIOIMAPCore.Capability {
+    /// RFC 3501 capability names are ASCII case-insensitive, while
+    /// NIOIMAPCore preserves their spelling and synthesizes case-sensitive equality.
+    var containsMoveCapability: Bool {
+        contains { capability in
+            guard capability.value == nil else { return false }
+            return capability.name.utf8.elementsEqual("move".utf8) { candidate, expected in
+                (candidate | 0x20) == expected
+            }
+        }
+    }
+}

--- a/Sources/SwiftMail/IMAP/Models/Capability+Move.swift
+++ b/Sources/SwiftMail/IMAP/Models/Capability+Move.swift
@@ -4,9 +4,18 @@ extension Set where Element == NIOIMAPCore.Capability {
     /// RFC 3501 capability names are ASCII case-insensitive, while
     /// NIOIMAPCore preserves their spelling and synthesizes case-sensitive equality.
     var containsMoveCapability: Bool {
+        containsBareCapability(named: "move")
+    }
+
+    /// RFC 4315's UIDPLUS capability follows the same case-insensitive token rules.
+    var containsUIDPlusCapability: Bool {
+        containsBareCapability(named: "uidplus")
+    }
+
+    private func containsBareCapability(named expectedName: String) -> Bool {
         contains { capability in
             guard capability.value == nil else { return false }
-            return capability.name.utf8.elementsEqual("move".utf8) { candidate, expected in
+            return capability.name.utf8.elementsEqual(expectedName.utf8) { candidate, expected in
                 (candidate | 0x20) == expected
             }
         }

--- a/Sources/SwiftMail/IMAP/Models/CopyUID.swift
+++ b/Sources/SwiftMail/IMAP/Models/CopyUID.swift
@@ -36,8 +36,8 @@ extension CopyUID {
     internal init(nio data: NIOIMAPCore.ResponseCodeCopy) throws {
         let validity = UIDValidity(nio: data.destinationUIDValidity)
 
-        let sourceUIDs = try Self.expand(data.sourceUIDs)
-        let destinationUIDs = try Self.expand(data.destinationUIDs)
+        let sourceUIDs = try Self.expand(data.sourceUIDs, role: "source")
+        let destinationUIDs = try Self.expand(data.destinationUIDs, role: "destination")
 
         guard sourceUIDs.count == destinationUIDs.count else {
             throw IMAPError.commandFailed(
@@ -51,8 +51,12 @@ extension CopyUID {
 
     private static let maxExpandedUIDs = 1_000_000
 
-    private static func expand(_ ranges: [NIOIMAPCore.UIDRange]) throws -> [UID] {
+    private static func expand(
+        _ ranges: [NIOIMAPCore.UIDRange],
+        role: String
+    ) throws -> [UID] {
         var result: [UID] = []
+        var seen: Set<UInt32> = []
         for nioRange in ranges {
             let lower = nioRange.range.lowerBound.rawValue
             let upper = nioRange.range.upperBound.rawValue
@@ -66,6 +70,9 @@ extension CopyUID {
                 throw IMAPError.commandFailed("COPYUID expansion exceeds \(maxExpandedUIDs) UIDs")
             }
             for raw in lower...upper {
+                guard seen.insert(raw).inserted else {
+                    throw IMAPError.commandFailed("COPYUID contains duplicate \(role) UID \(raw)")
+                }
                 result.append(UID(raw))
             }
         }

--- a/Sources/SwiftMail/IMAP/Models/CopyUID.swift
+++ b/Sources/SwiftMail/IMAP/Models/CopyUID.swift
@@ -7,7 +7,7 @@ import NIOIMAPCore
 /// successful `OK` response, this value carries the exact source-to-destination UID mapping
 /// in the order the server provided it. When `COPYUID` is absent — either because the server
 /// doesn't advertise UIDPLUS or chose not to include the code — the corresponding method
-/// returns `nil` instead. Malformed or conflicting evidence throws
+/// returns `nil` instead. Malformed, conflicting, or unverifiable evidence throws
 /// ``IMAPError/malformedCopyUIDAfterTaggedOK(_:)`` rather than being collapsed into absence.
 public struct CopyUID: Sendable {
     /// The UIDVALIDITY of the destination mailbox.
@@ -60,6 +60,15 @@ extension CopyUID {
         for nioRange in ranges {
             let lower = nioRange.range.lowerBound.rawValue
             let upper = nioRange.range.upperBound.rawValue
+            // NIOIMAPCore normalizes both wire `*` and numeric 4294967295 to `.max`.
+            // RFC 4315 forbids `*` in COPYUID, so fail closed on the ambiguous value rather
+            // than expose wildcard evidence as verified. This conservatively rejects the
+            // standards-valid numeric maximum until the parser preserves lexical provenance.
+            guard lower != UInt32.max, upper != UInt32.max else {
+                throw IMAPError.commandFailed(
+                    "COPYUID contains an indistinguishable wildcard or maximum \(role) UID"
+                )
+            }
             guard lower <= upper else {
                 throw IMAPError.commandFailed("COPYUID contains an invalid UID range")
             }
@@ -77,6 +86,21 @@ extension CopyUID {
             }
         }
         return result
+    }
+
+    func sourceValidationFailure<T: MessageIdentifier>(
+        for identifierSet: MessageIdentifierSet<T>
+    ) -> String? {
+        guard T.self == UID.self else { return nil }
+        // `UID.latest` encodes as unresolved `*`. Without the selected mailbox's highest UID,
+        // membership cannot be proven, so fail closed rather than expose unverified evidence.
+        guard !identifierSet.contains(T.latest) else {
+            return "COPYUID source UIDs cannot be verified against a wildcard request"
+        }
+        guard let unexpected = mapping.lazy.map(\.source).first(where: { source in
+            !identifierSet.contains(T(source.value))
+        }) else { return nil }
+        return "COPYUID contains unrequested source UID \(unexpected.value)"
     }
 
     func isEquivalent(to other: CopyUID) -> Bool {

--- a/Sources/SwiftMail/IMAP/Models/CopyUID.swift
+++ b/Sources/SwiftMail/IMAP/Models/CopyUID.swift
@@ -4,10 +4,11 @@ import NIOIMAPCore
 /// The verified COPYUID mapping returned by the server after a UID-based COPY or MOVE operation.
 ///
 /// When the server supports UIDPLUS (RFC 4315) and returns a `COPYUID` response code in the
-/// tagged `OK`, this value carries the exact source-to-destination UID mapping in the order
-/// the server provided it. When `COPYUID` is absent — either because the server doesn't
-/// advertise UIDPLUS or chose not to include the code — the corresponding method returns
-/// `nil` instead.
+/// successful `OK` response, this value carries the exact source-to-destination UID mapping
+/// in the order the server provided it. When `COPYUID` is absent — either because the server
+/// doesn't advertise UIDPLUS or chose not to include the code — the corresponding method
+/// returns `nil` instead. Malformed or conflicting evidence throws
+/// ``IMAPError/malformedCopyUIDAfterTaggedOK(_:)`` rather than being collapsed into absence.
 public struct CopyUID: Sendable {
     /// The UIDVALIDITY of the destination mailbox.
     ///
@@ -69,5 +70,17 @@ extension CopyUID {
             }
         }
         return result
+    }
+
+    func isEquivalent(to other: CopyUID) -> Bool {
+        guard destinationUIDValidity == other.destinationUIDValidity,
+              mapping.count == other.mapping.count
+        else {
+            return false
+        }
+
+        return zip(mapping, other.mapping).allSatisfy { lhs, rhs in
+            lhs.source == rhs.source && lhs.destination == rhs.destination
+        }
     }
 }

--- a/Sources/SwiftMail/IMAP/Models/MoveFallbackPolicy.swift
+++ b/Sources/SwiftMail/IMAP/Models/MoveFallbackPolicy.swift
@@ -1,0 +1,9 @@
+/// Controls whether the public `move` APIs may emulate MOVE.
+public enum MoveFallbackPolicy: Sendable {
+    /// Preserve the traditional behavior: use MOVE when eligible, otherwise
+    /// fall back to COPY, STORE `\Deleted`, and EXPUNGE.
+    case copyStoreExpunge
+
+    /// Require the server's MOVE extension and never emit fallback commands.
+    case disabled
+}

--- a/Tests/SwiftIMAPTests/AtomicMoveTests.swift
+++ b/Tests/SwiftIMAPTests/AtomicMoveTests.swift
@@ -1,0 +1,109 @@
+import Foundation
+import NIOIMAPCore
+import Testing
+@testable import SwiftMail
+
+#if os(macOS)
+    @Suite("Atomic-only UID MOVE", .serialized, .timeLimit(.minutes(1)))
+    struct AtomicMoveTests {
+        @Test("MOVE with UIDPLUS emits one UID MOVE and returns COPYUID")
+        func moveWithUIDPlus() async throws {
+            try await withServer(capabilities: ["IMAP4rev1", "AUTH=PLAIN", "MOVE", "UIDPLUS"]) { server, testServer in
+                let result = try await server.moveAtomically(
+                    messages: UIDSet(UID(1)), to: "Archive")
+                let copyUID = try #require(result)
+                #expect(copyUID.destinationUIDValidity == UIDValidity(2))
+                #expect(copyUID.mapping.map(\.source.value) == [1])
+                #expect(copyUID.mapping.map(\.destination.value) == [101])
+                assertOnlyAtomicMoveWasEmitted(testServer.commandLog)
+            }
+        }
+
+        @Test("MOVE without UIDPLUS still emits UID MOVE and returns no mapping")
+        func moveWithoutUIDPlus() async throws {
+            try await withServer(capabilities: ["IMAP4rev1", "AUTH=PLAIN", "MOVE"]) { server, testServer in
+                let result = try await server.moveAtomically(
+                    messages: UIDSet(UID(1)), to: "Archive")
+                #expect(result == nil)
+                assertOnlyAtomicMoveWasEmitted(testServer.commandLog)
+            }
+        }
+
+        @Test("Named connection exposes the same atomic-only UID MOVE contract")
+        func namedConnectionMoveWithoutUIDPlus() async throws {
+            try await withServer(capabilities: ["IMAP4rev1", "AUTH=PLAIN", "MOVE"]) { server, testServer in
+                let named = try await server.connection(named: "atomic-move")
+                _ = try await named.selectMailbox("INBOX")
+
+                let result = try await named.moveAtomically(
+                    messages: UIDSet(UID(1)), to: "Archive")
+
+                #expect(result == nil)
+                assertOnlyAtomicMoveWasEmitted(testServer.commandLog)
+            }
+        }
+
+        @Test("No MOVE capability refuses before any transport command")
+        func noMoveRefusesBeforeTransport() async {
+            let server = SwiftMail.IMAPServer(host: "127.0.0.1", port: 1, useTLS: false)
+            await server.primaryConnection.replaceCapabilitiesForTesting([])
+            do {
+                _ = try await server.moveAtomically(messages: UIDSet(UID(1)), to: "Archive")
+                Issue.record("Expected commandNotSupported")
+            } catch let error as IMAPError {
+                guard case .commandNotSupported = error else {
+                    Issue.record("Expected commandNotSupported, got \(error)")
+                    return
+                }
+            } catch {
+                Issue.record("Expected IMAPError.commandNotSupported, got \(error)")
+            }
+        }
+
+        private func withServer(
+            capabilities: [String],
+            body: (SwiftMail.IMAPServer, IMAPTestServer) async throws -> Void
+        ) async throws {
+            let tempRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            let maildir = tempRoot.appendingPathComponent("Maildir")
+            let curDir = maildir.appendingPathComponent("cur")
+            try FileManager.default.createDirectory(at: curDir, withIntermediateDirectories: true)
+            defer { try? FileManager.default.removeItem(at: tempRoot) }
+
+            let sample = """
+            From: Sender <sender@example.com>\r
+            To: Recipient <recipient@example.com>\r
+            Subject: Atomic move\r
+            Date: Thu, 01 Jan 2026 00:00:00 +0000\r
+            Message-ID: <atomic@example.com>\r
+            Content-Type: text/plain; charset=utf-8\r
+            \r
+            Body.\r
+            """
+            try #require(sample.data(using: .utf8)).write(to: curDir.appendingPathComponent("1.eml"))
+
+            let testServer = try IMAPTestServer(
+                username: "u", password: "p", advertisedCapabilities: capabilities,
+                maildirURL: maildir)
+            try testServer.start()
+            try await testServer.run {
+                let server = SwiftMail.IMAPServer(
+                    host: "127.0.0.1", port: testServer.port, useTLS: false)
+                try await server.connect()
+                try await server.login(username: "u", password: "p")
+                _ = try await server.selectMailbox("INBOX")
+                try await body(server, testServer)
+                try await server.disconnect()
+            }
+        }
+
+        private func assertOnlyAtomicMoveWasEmitted(_ commands: [String]) {
+            let upper = commands.map { $0.uppercased() }
+            #expect(upper.filter { $0.contains(" UID MOVE ") }.count == 1)
+            #expect(upper.allSatisfy { !$0.contains(" UID COPY ") })
+            #expect(upper.allSatisfy { !$0.contains(" UID STORE ") })
+            #expect(upper.allSatisfy { !$0.contains("UID EXPUNGE") })
+            #expect(upper.allSatisfy { !$0.contains(" EXPUNGE") })
+        }
+    }
+#endif

--- a/Tests/SwiftIMAPTests/AtomicMoveTests.swift
+++ b/Tests/SwiftIMAPTests/AtomicMoveTests.swift
@@ -159,6 +159,8 @@ import Testing
 
         private func withServer(
             capabilities: [String],
+            rejectedUIDSubcommand: String? = nil,
+            copyUIDSourceOverride: String? = nil,
             body: (SwiftMail.IMAPServer, IMAPTestServer) async throws -> Void
         ) async throws {
             let tempRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
@@ -180,7 +182,10 @@ import Testing
             try #require(sample.data(using: .utf8)).write(to: curDir.appendingPathComponent("1.eml"))
 
             let testServer = try IMAPTestServer(
-                username: "u", password: "p", advertisedCapabilities: capabilities,
+                username: "u", password: "p",
+                rejectedUIDSubcommand: rejectedUIDSubcommand,
+                copyUIDSourceOverride: copyUIDSourceOverride,
+                advertisedCapabilities: capabilities,
                 maildirURL: maildir)
             try testServer.start()
             try await testServer.run {
@@ -203,14 +208,14 @@ import Testing
         ) async {
             do {
                 _ = try await operation()
-                Issue.record("Expected MOVE to fail because reconnect does not restore SELECT")
+                Issue.record("Expected MOVE to report possible partial completion")
             } catch let error as IMAPError {
-                guard case .moveFailed = error else {
-                    Issue.record("Expected moveFailed after authenticated MOVE, got \(error)")
+                guard case .moveFailedAfterPossiblePartialCompletion = error else {
+                    Issue.record("Expected possible partial completion after authenticated MOVE, got \(error)")
                     return
                 }
             } catch {
-                Issue.record("Expected IMAPError.moveFailed, got \(error)")
+                Issue.record("Expected IMAPError.moveFailedAfterPossiblePartialCompletion, got \(error)")
             }
         }
 
@@ -229,6 +234,148 @@ import Testing
             #expect(upper.filter { $0.contains(" UID COPY ") }.count == 1)
             #expect(upper.filter { $0.contains(" UID STORE ") }.count == 1)
             #expect(upper.filter { $0.contains(" EXPUNGE") }.count == 1)
+        }
+    }
+
+    extension AtomicMoveTests {
+        @Test("Lowercase UIDPLUS keeps UID MOVE atomic on both connection surfaces")
+        func lowercaseUIDPlusUsesMove() async throws {
+            try await withServer(
+                capabilities: ["IMAP4rev1", "AUTH=PLAIN", "move", "uidplus"]
+            ) { server, testServer in
+                #expect(await server.supportsUIDPlus)
+                _ = try await server.move(messages: UIDSet(UID(1)), to: "Archive")
+
+                let named = try await server.connection(named: "lowercase-uidplus-move")
+                #expect(await named.supportsUIDPlus)
+                _ = try await named.selectMailbox("INBOX")
+                _ = try await named.move(messages: UIDSet(UID(1)), to: "Archive")
+
+                assertOnlyMovesWereEmitted(testServer.commandLog, count: 2)
+            }
+        }
+
+        @Test("Lowercase UIDPLUS fallback uses targeted UID EXPUNGE")
+        func lowercaseUIDPlusUsesTargetedFallbackExpunge() async throws {
+            try await withServer(
+                capabilities: ["IMAP4rev1", "AUTH=PLAIN", "uidplus"]
+            ) { server, testServer in
+                _ = try await server.move(messages: UIDSet(UID(1)), to: "Archive")
+
+                let named = try await server.connection(named: "lowercase-uidplus-fallback")
+                _ = try await named.selectMailbox("INBOX")
+                _ = try await named.move(messages: UIDSet(UID(1)), to: "Archive")
+
+                let upper = testServer.commandLog.map { $0.uppercased() }
+                #expect(upper.filter { $0.contains(" UID COPY ") }.count == 2)
+                #expect(upper.filter { $0.contains(" UID STORE ") }.count == 2)
+                #expect(upper.filter { $0.contains(" UID EXPUNGE ") }.count == 2)
+                #expect(upper.allSatisfy { !$0.contains(" EXPUNGE") || $0.contains(" UID EXPUNGE ") })
+            }
+        }
+
+        @Test("Fallback failure preserves COPYUID on server and named connection")
+        func fallbackFailurePreservesCopyUID() async throws {
+            try await withServer(
+                capabilities: ["IMAP4rev1", "AUTH=PLAIN", "UIDPLUS"],
+                rejectedUIDSubcommand: "STORE"
+            ) { server, _ in
+                await expectVerifiedPartialFailure {
+                    try await server.move(messages: UIDSet(UID(1)), to: "Archive")
+                }
+
+                let named = try await server.connection(named: "partial-fallback")
+                _ = try await named.selectMailbox("INBOX")
+                await expectVerifiedPartialFailure {
+                    try await named.move(messages: UIDSet(UID(1)), to: "Archive")
+                }
+            }
+        }
+
+        @Test("Fallback failure without COPYUID is non-retryable")
+        func fallbackFailureWithoutCopyUIDIsNonRetryable() async throws {
+            try await withServer(
+                capabilities: ["IMAP4rev1", "AUTH=PLAIN"],
+                rejectedUIDSubcommand: "STORE"
+            ) { server, _ in
+                await expectPossiblePartialFailure {
+                    try await server.move(messages: UIDSet(UID(1)), to: "Archive")
+                }
+            }
+        }
+
+        @Test("COPYUID rejects source UIDs outside the requested command set")
+        func copyUIDRejectsUnrequestedSourceUIDs() async throws {
+            try await withServer(
+                capabilities: ["IMAP4rev1", "AUTH=PLAIN", "MOVE", "UIDPLUS"],
+                copyUIDSourceOverride: "2"
+            ) { server, _ in
+                await expectMalformedCompletion {
+                    try await server.copy(messages: UIDSet(UID(1)), to: "Archive")
+                }
+
+                let named = try await server.connection(named: "unrequested-copyuid")
+                _ = try await named.selectMailbox("INBOX")
+                await expectMalformedCompletion {
+                    try await named.move(
+                        messages: UIDSet(UID(1)),
+                        to: "Archive",
+                        fallback: .disabled
+                    )
+                }
+            }
+        }
+
+        private func expectVerifiedPartialFailure(
+            _ operation: () async throws -> CopyUID?
+        ) async {
+            do {
+                _ = try await operation()
+                Issue.record("Expected moveFallbackFailedAfterCopy")
+            } catch let error as IMAPError {
+                guard case .moveFallbackFailedAfterCopy(let copyUID, let reason) = error else {
+                    Issue.record("Expected verified fallback copy, got \(error)")
+                    return
+                }
+                #expect(copyUID.mapping.map(\.source.value) == [1])
+                #expect(copyUID.mapping.map(\.destination.value) == [101])
+                #expect(reason.contains("COPY completed before fallback failed"))
+            } catch {
+                Issue.record("Expected IMAPError.moveFallbackFailedAfterCopy, got \(error)")
+            }
+        }
+
+        private func expectPossiblePartialFailure(
+            _ operation: () async throws -> CopyUID?
+        ) async {
+            do {
+                _ = try await operation()
+                Issue.record("Expected moveFailedAfterPossiblePartialCompletion")
+            } catch let error as IMAPError {
+                guard case .moveFailedAfterPossiblePartialCompletion = error else {
+                    Issue.record("Expected possible partial completion, got \(error)")
+                    return
+                }
+                #expect(error.recoverySuggestion?.contains("Do not retry") == true)
+            } catch {
+                Issue.record("Expected possible-partial IMAPError, got \(error)")
+            }
+        }
+
+        private func expectMalformedCompletion(
+            _ operation: () async throws -> CopyUID?
+        ) async {
+            do {
+                _ = try await operation()
+                Issue.record("Expected malformedCopyUIDAfterTaggedOK")
+            } catch let error as IMAPError {
+                guard case .malformedCopyUIDAfterTaggedOK = error else {
+                    Issue.record("Expected malformed completion, got \(error)")
+                    return
+                }
+            } catch {
+                Issue.record("Expected malformed COPYUID IMAPError, got \(error)")
+            }
         }
     }
 #endif

--- a/Tests/SwiftIMAPTests/AtomicMoveTests.swift
+++ b/Tests/SwiftIMAPTests/AtomicMoveTests.swift
@@ -102,6 +102,61 @@ import Testing
             }
         }
 
+        @Test("Original MOVE overloads remain usable as function values")
+        func originalMoveOverloadsRemainFunctionValues() async throws {
+            try await withServer(
+                capabilities: ["IMAP4rev1", "AUTH=PLAIN", "MOVE", "UIDPLUS"]
+            ) { server, _ in
+                let named = try await server.connection(named: "function-values")
+
+                let serverMessages: (SwiftMail.UIDSet, String) async throws -> CopyUID? =
+                    server.move(messages:to:)
+                let serverMessage: (SwiftMail.UID, String) async throws -> CopyUID? =
+                    server.move(message:to:)
+                let serverHeader: (MessageInfo, String) async throws -> CopyUID? =
+                    server.move(header:to:)
+                let namedMessages: (SwiftMail.UIDSet, String) async throws -> CopyUID? =
+                    named.move(messages:to:)
+                let namedMessage: (SwiftMail.UID, String) async throws -> CopyUID? =
+                    named.move(message:to:)
+
+                _ = (serverMessages, serverMessage, serverHeader, namedMessages, namedMessage)
+            }
+        }
+
+        @Test("MOVE capability is checked after server and named reauthentication")
+        func moveCapabilityIsCheckedAfterReauthentication() async throws {
+            try await withServer(
+                capabilities: ["IMAP4rev1", "AUTH=PLAIN", "MOVE"]
+            ) { server, testServer in
+                let named = try await server.connection(named: "reauthenticated-move")
+                _ = try await named.selectMailbox("INBOX")
+
+                try await server.primaryConnection.disconnect()
+                try await named.disconnect()
+
+                await expectMoveAttemptAfterReauthentication {
+                    try await server.move(
+                        messages: UIDSet(UID(1)),
+                        to: "Archive",
+                        fallback: .disabled
+                    )
+                }
+                await expectMoveAttemptAfterReauthentication {
+                    try await named.move(
+                        messages: UIDSet(UID(1)),
+                        to: "Archive",
+                        fallback: .disabled
+                    )
+                }
+
+                let moveCommands = testServer.commandLog
+                    .map { $0.uppercased() }
+                    .filter { $0.contains(" UID MOVE ") }
+                #expect(moveCommands.count == 2)
+            }
+        }
+
         private func withServer(
             capabilities: [String],
             body: (SwiftMail.IMAPServer, IMAPTestServer) async throws -> Void
@@ -141,6 +196,22 @@ import Testing
 
         private func assertOnlyAtomicMoveWasEmitted(_ commands: [String]) {
             assertOnlyMovesWereEmitted(commands, count: 1)
+        }
+
+        private func expectMoveAttemptAfterReauthentication(
+            _ operation: () async throws -> CopyUID?
+        ) async {
+            do {
+                _ = try await operation()
+                Issue.record("Expected MOVE to fail because reconnect does not restore SELECT")
+            } catch let error as IMAPError {
+                guard case .moveFailed = error else {
+                    Issue.record("Expected moveFailed after authenticated MOVE, got \(error)")
+                    return
+                }
+            } catch {
+                Issue.record("Expected IMAPError.moveFailed, got \(error)")
+            }
         }
 
         private func assertOnlyMovesWereEmitted(_ commands: [String], count: Int) {

--- a/Tests/SwiftIMAPTests/AtomicMoveTests.swift
+++ b/Tests/SwiftIMAPTests/AtomicMoveTests.swift
@@ -4,13 +4,12 @@ import Testing
 @testable import SwiftMail
 
 #if os(macOS)
-    @Suite("Atomic-only UID MOVE", .serialized, .timeLimit(.minutes(1)))
+    @Suite("MOVE fallback policy", .serialized, .timeLimit(.minutes(1)))
     struct AtomicMoveTests {
-        @Test("MOVE with UIDPLUS emits one UID MOVE and returns COPYUID")
-        func moveWithUIDPlus() async throws {
+        @Test("Default policy uses MOVE with UIDPLUS")
+        func defaultPolicyUsesMoveWithUIDPlus() async throws {
             try await withServer(capabilities: ["IMAP4rev1", "AUTH=PLAIN", "MOVE", "UIDPLUS"]) { server, testServer in
-                let result = try await server.moveAtomically(
-                    messages: UIDSet(UID(1)), to: "Archive")
+                let result = try await server.move(messages: UIDSet(UID(1)), to: "Archive")
                 let copyUID = try #require(result)
                 #expect(copyUID.destinationUIDValidity == UIDValidity(2))
                 #expect(copyUID.mapping.map(\.source.value) == [1])
@@ -19,36 +18,59 @@ import Testing
             }
         }
 
-        @Test("MOVE without UIDPLUS still emits UID MOVE and returns no mapping")
-        func moveWithoutUIDPlus() async throws {
+        @Test("Disabled fallback uses MOVE without UIDPLUS")
+        func disabledFallbackUsesMoveWithoutUIDPlus() async throws {
             try await withServer(capabilities: ["IMAP4rev1", "AUTH=PLAIN", "MOVE"]) { server, testServer in
-                let result = try await server.moveAtomically(
-                    messages: UIDSet(UID(1)), to: "Archive")
+                let result = try await server.move(
+                    messages: UIDSet(UID(1)), to: "Archive", fallback: .disabled)
                 #expect(result == nil)
                 assertOnlyAtomicMoveWasEmitted(testServer.commandLog)
             }
         }
 
-        @Test("Named connection exposes the same atomic-only UID MOVE contract")
-        func namedConnectionMoveWithoutUIDPlus() async throws {
+        @Test("Default policy preserves COPY STORE EXPUNGE fallback")
+        func defaultPolicyPreservesExistingFallback() async throws {
+            try await withServer(capabilities: ["IMAP4rev1", "AUTH=PLAIN", "MOVE"]) { server, testServer in
+                let result = try await server.move(messages: UIDSet(UID(1)), to: "Archive")
+
+                #expect(result == nil)
+                assertOnlyFallbackWasEmitted(testServer.commandLog)
+            }
+        }
+
+        @Test("Named single-message convenience forwards disabled fallback")
+        func namedConnectionForwardsDisabledFallback() async throws {
             try await withServer(capabilities: ["IMAP4rev1", "AUTH=PLAIN", "MOVE"]) { server, testServer in
                 let named = try await server.connection(named: "atomic-move")
                 _ = try await named.selectMailbox("INBOX")
 
-                let result = try await named.moveAtomically(
-                    messages: UIDSet(UID(1)), to: "Archive")
+                let result = try await named.move(
+                    message: UID(1), to: "Archive", fallback: .disabled)
 
                 #expect(result == nil)
                 assertOnlyAtomicMoveWasEmitted(testServer.commandLog)
             }
         }
 
-        @Test("No MOVE capability refuses before any transport command")
+        @Test("Header convenience forwards disabled fallback")
+        func headerConvenienceForwardsDisabledFallback() async throws {
+            try await withServer(capabilities: ["IMAP4rev1", "AUTH=PLAIN", "MOVE"]) { server, testServer in
+                let header = MessageInfo(sequenceNumber: SequenceNumber(1), uid: UID(1))
+                let result = try await server.move(
+                    header: header, to: "Archive", fallback: .disabled)
+
+                #expect(result == nil)
+                assertOnlyAtomicMoveWasEmitted(testServer.commandLog)
+            }
+        }
+
+        @Test("Disabled fallback without MOVE refuses before any transport command")
         func noMoveRefusesBeforeTransport() async {
             let server = SwiftMail.IMAPServer(host: "127.0.0.1", port: 1, useTLS: false)
             await server.primaryConnection.replaceCapabilitiesForTesting([])
             do {
-                _ = try await server.moveAtomically(messages: UIDSet(UID(1)), to: "Archive")
+                _ = try await server.move(
+                    messages: UIDSet(UID(1)), to: "Archive", fallback: .disabled)
                 Issue.record("Expected commandNotSupported")
             } catch let error as IMAPError {
                 guard case .commandNotSupported = error else {
@@ -57,6 +79,26 @@ import Testing
                 }
             } catch {
                 Issue.record("Expected IMAPError.commandNotSupported, got \(error)")
+            }
+        }
+
+        @Test(
+            "Parser-produced MOVE spellings work on server and named connection",
+            arguments: ["MOVE", "move", "MoVe"]
+        )
+        func parserProducedMoveSpelling(_ spelling: String) async throws {
+            try await withServer(capabilities: ["IMAP4rev1", "AUTH=PLAIN", spelling]) { server, testServer in
+                #expect(await server.supportsMove)
+                _ = try await server.move(
+                    messages: UIDSet(UID(1)), to: "Archive", fallback: .disabled)
+
+                let named = try await server.connection(named: "case-insensitive-move")
+                #expect(await named.supportsMove)
+                _ = try await named.selectMailbox("INBOX")
+                _ = try await named.move(
+                    messages: UIDSet(UID(1)), to: "Archive", fallback: .disabled)
+
+                assertOnlyMovesWereEmitted(testServer.commandLog, count: 2)
             }
         }
 
@@ -74,7 +116,7 @@ import Testing
             From: Sender <sender@example.com>\r
             To: Recipient <recipient@example.com>\r
             Subject: Atomic move\r
-            Date: Thu, 01 Jan 2026 00:00:00 +0000\r
+            Date: Wed, 01 Jan 2020 00:00:00 +0000\r
             Message-ID: <atomic@example.com>\r
             Content-Type: text/plain; charset=utf-8\r
             \r
@@ -98,12 +140,24 @@ import Testing
         }
 
         private func assertOnlyAtomicMoveWasEmitted(_ commands: [String]) {
+            assertOnlyMovesWereEmitted(commands, count: 1)
+        }
+
+        private func assertOnlyMovesWereEmitted(_ commands: [String], count: Int) {
             let upper = commands.map { $0.uppercased() }
-            #expect(upper.filter { $0.contains(" UID MOVE ") }.count == 1)
+            #expect(upper.filter { $0.contains(" UID MOVE ") }.count == count)
             #expect(upper.allSatisfy { !$0.contains(" UID COPY ") })
             #expect(upper.allSatisfy { !$0.contains(" UID STORE ") })
             #expect(upper.allSatisfy { !$0.contains("UID EXPUNGE") })
             #expect(upper.allSatisfy { !$0.contains(" EXPUNGE") })
+        }
+
+        private func assertOnlyFallbackWasEmitted(_ commands: [String]) {
+            let upper = commands.map { $0.uppercased() }
+            #expect(upper.allSatisfy { !$0.contains(" UID MOVE ") })
+            #expect(upper.filter { $0.contains(" UID COPY ") }.count == 1)
+            #expect(upper.filter { $0.contains(" UID STORE ") }.count == 1)
+            #expect(upper.filter { $0.contains(" EXPUNGE") }.count == 1)
         }
     }
 #endif

--- a/Tests/SwiftIMAPTests/CopyUIDCommandValidationTests.swift
+++ b/Tests/SwiftIMAPTests/CopyUIDCommandValidationTests.swift
@@ -1,0 +1,66 @@
+import Testing
+@testable import SwiftMail
+
+@Suite("COPYUID command validation")
+struct CopyUIDCommandValidationTests {
+    @Test
+    func unrequestedPartialMappingIsNotExposedAsVerified() {
+        let command = MoveCommand(
+            identifierSet: UIDSet(UID(1)),
+            destinationMailbox: "Archive"
+        )
+        let invalid = CopyUID(
+            destinationUIDValidity: UIDValidity(10),
+            mapping: [(source: UID(2), destination: UID(300))]
+        )
+        let error = command.validate(
+            error: .moveFailedAfterPartialCompletion(copyUID: invalid, reason: "MOVE denied")
+        )
+
+        guard case .moveFailedAfterPossiblePartialCompletion = error else {
+            Issue.record("Expected invalid mapping to become possible partial completion")
+            return
+        }
+    }
+
+    @Test
+    func requestedWildcardMappingIsNotExposedAsVerified() {
+        let copyUID = CopyUID(
+            destinationUIDValidity: UIDValidity(10),
+            mapping: [(source: UID(42), destination: UID(300))]
+        )
+        let singleton = CopyCommand(
+            identifierSet: UIDSet(UID.latest),
+            destinationMailbox: "Archive"
+        )
+        let reversedRange = MoveCommand(
+            identifierSet: UIDSet(UID(559)...UID.latest),
+            destinationMailbox: "Archive"
+        )
+
+        expectUnverifiableWildcard { try singleton.validate(copyUID: copyUID) }
+        expectUnverifiableWildcard { try reversedRange.validate(copyUID: copyUID) }
+        let partial = reversedRange.validate(
+            error: .moveFailedAfterPartialCompletion(copyUID: copyUID, reason: "MOVE denied")
+        )
+        guard case .moveFailedAfterPossiblePartialCompletion = partial else {
+            Issue.record("Expected wildcard mapping to remain unverified")
+            return
+        }
+    }
+
+    private func expectUnverifiableWildcard(_ operation: () throws -> CopyUID?) {
+        do {
+            _ = try operation()
+            Issue.record("Expected wildcard COPYUID evidence to be rejected")
+        } catch let error as IMAPError {
+            guard case .malformedCopyUIDAfterTaggedOK(let reason) = error else {
+                Issue.record("Expected malformedCopyUIDAfterTaggedOK, got \(error)")
+                return
+            }
+            #expect(reason.contains("cannot be verified against a wildcard request"))
+        } catch {
+            Issue.record("Expected IMAPError.malformedCopyUIDAfterTaggedOK, got \(error)")
+        }
+    }
+}

--- a/Tests/SwiftIMAPTests/CopyUIDTests.swift
+++ b/Tests/SwiftIMAPTests/CopyUIDTests.swift
@@ -85,13 +85,12 @@ struct CopyUIDTests {
     // MARK: - CopyHandler — cardinality mismatch
 
     @Test
-    func testCardinalityMismatchThrows() async throws {
+    func testCardinalityMismatchOnTaggedOKReturnsNil() async throws {
         // Source has 2 UIDs, destination has 1 — malformed.
-        await #expect(throws: (any Error).self) {
-            try await executeCopy(
-                responses: ["A001 OK [COPYUID 1 1:2 200] COPY completed\r\n"]
-            )
-        }
+        let result = try await executeCopy(
+            responses: ["A001 OK [COPYUID 1 1:2 200] COPY completed\r\n"]
+        )
+        #expect(result == nil)
     }
 
     // MARK: - MoveHandler — COPYUID present
@@ -116,6 +115,44 @@ struct CopyUIDTests {
             responses: ["A001 OK MOVE completed\r\n"]
         )
         #expect(result == nil)
+    }
+
+    @Test
+    func testMoveCardinalityMismatchOnTaggedOKReturnsNil() async throws {
+        let result = try await executeMove(
+            responses: ["A001 OK [COPYUID 1 1:2 200] MOVE completed\r\n"]
+        )
+        #expect(result == nil)
+    }
+
+    @Test
+    func testMoveTaggedNOThrowsMoveFailed() async {
+        do {
+            _ = try await executeMove(responses: ["A001 NO MOVE denied\r\n"])
+            Issue.record("Expected tagged NO to throw moveFailed")
+        } catch let error as IMAPError {
+            guard case .moveFailed = error else {
+                Issue.record("Expected moveFailed, got \(error)")
+                return
+            }
+        } catch {
+            Issue.record("Expected IMAPError.moveFailed, got \(error)")
+        }
+    }
+
+    @Test
+    func testCopyTaggedNOThrowsCopyFailed() async {
+        do {
+            _ = try await executeCopy(responses: ["A001 NO COPY denied\r\n"])
+            Issue.record("Expected tagged NO to throw copyFailed")
+        } catch let error as IMAPError {
+            guard case .copyFailed = error else {
+                Issue.record("Expected copyFailed, got \(error)")
+                return
+            }
+        } catch {
+            Issue.record("Expected IMAPError.copyFailed, got \(error)")
+        }
     }
 
     // MARK: - CopyUID model — maximum uidValidity

--- a/Tests/SwiftIMAPTests/CopyUIDTests.swift
+++ b/Tests/SwiftIMAPTests/CopyUIDTests.swift
@@ -6,7 +6,7 @@ import NIOEmbedded
 import Testing
 @testable import SwiftMail
 
-/// Tests for COPYUID extraction from UID COPY and UID MOVE tagged responses.
+/// Tests COPYUID extraction and malformed-evidence handling for UID COPY and UID MOVE.
 @Suite(.serialized, .timeLimit(.minutes(1)))
 struct CopyUIDTests {
 
@@ -85,12 +85,13 @@ struct CopyUIDTests {
     // MARK: - CopyHandler — cardinality mismatch
 
     @Test
-    func testCardinalityMismatchOnTaggedOKReturnsNil() async throws {
+    func testCopyCardinalityMismatchOnTaggedOKThrowsTypedCompletionError() async {
         // Source has 2 UIDs, destination has 1 — malformed.
-        let result = try await executeCopy(
-            responses: ["A001 OK [COPYUID 1 1:2 200] COPY completed\r\n"]
-        )
-        #expect(result == nil)
+        await expectMalformedCopyUID {
+            try await executeCopy(
+                responses: ["A001 OK [COPYUID 1 1:2 200] COPY completed\r\n"]
+            )
+        }
     }
 
     // MARK: - MoveHandler — COPYUID present
@@ -118,11 +119,87 @@ struct CopyUIDTests {
     }
 
     @Test
-    func testMoveCardinalityMismatchOnTaggedOKReturnsNil() async throws {
+    func testMoveCardinalityMismatchOnTaggedOKThrowsTypedCompletionError() async {
+        await expectMalformedCopyUID {
+            try await executeMove(
+                responses: ["A001 OK [COPYUID 1 1:2 200] MOVE completed\r\n"]
+            )
+        }
+    }
+
+    @Test
+    func testMoveRetainsUntaggedOKCopyUIDAcrossExpungeResponses() async throws {
         let result = try await executeMove(
-            responses: ["A001 OK [COPYUID 1 1:2 200] MOVE completed\r\n"]
+            responses: [
+                "* OK [COPYUID 10 3 300] Moved\r\n",
+                "* 1 EXPUNGE\r\n",
+                "* 2 EXPUNGE\r\n",
+                "A001 OK MOVE completed\r\n"
+            ]
         )
-        #expect(result == nil)
+
+        let copyUID = try #require(result)
+        #expect(copyUID.destinationUIDValidity == UIDValidity(10))
+        #expect(copyUID.mapping.map(\.source.value) == [3])
+        #expect(copyUID.mapping.map(\.destination.value) == [300])
+    }
+
+    @Test
+    func testMoveAcceptsMatchingUntaggedAndTaggedCopyUID() async throws {
+        let result = try await executeMove(
+            responses: [
+                "* OK [COPYUID 10 3 300] Moved\r\n",
+                "A001 OK [COPYUID 10 3 300] MOVE completed\r\n"
+            ]
+        )
+
+        let copyUID = try #require(result)
+        #expect(copyUID.mapping.map(\.destination.value) == [300])
+    }
+
+    @Test
+    func testMoveRejectsConflictingUntaggedAndTaggedCopyUID() async {
+        await expectMalformedCopyUID {
+            try await executeMove(
+                responses: [
+                    "* OK [COPYUID 10 3 300] Moved\r\n",
+                    "A001 OK [COPYUID 10 3 301] MOVE completed\r\n"
+                ]
+            )
+        }
+    }
+
+    @Test
+    func testMoveMalformedUntaggedCopyUIDThrowsOnlyAfterTaggedOK() async {
+        await expectMalformedCopyUID {
+            try await executeMove(
+                responses: [
+                    "* OK [COPYUID 1 1:2 200] Moved\r\n",
+                    "* 1 EXPUNGE\r\n",
+                    "A001 OK MOVE completed\r\n"
+                ]
+            )
+        }
+    }
+
+    @Test
+    func testMoveTaggedFailureWinsOverMalformedUntaggedCopyUID() async {
+        do {
+            _ = try await executeMove(
+                responses: [
+                    "* OK [COPYUID 1 1:2 200] Moved\r\n",
+                    "A001 NO MOVE denied\r\n"
+                ]
+            )
+            Issue.record("Expected tagged NO to throw moveFailed")
+        } catch let error as IMAPError {
+            guard case .moveFailed = error else {
+                Issue.record("Expected moveFailed, got \(error)")
+                return
+            }
+        } catch {
+            Issue.record("Expected IMAPError.moveFailed, got \(error)")
+        }
     }
 
     @Test
@@ -209,5 +286,21 @@ struct CopyUIDTests {
         }
 
         return try await promise.futureResult.get()
+    }
+
+    private func expectMalformedCopyUID(
+        _ operation: () async throws -> CopyUID?
+    ) async {
+        do {
+            _ = try await operation()
+            Issue.record("Expected malformedCopyUIDAfterTaggedOK")
+        } catch let error as IMAPError {
+            guard case .malformedCopyUIDAfterTaggedOK = error else {
+                Issue.record("Expected malformedCopyUIDAfterTaggedOK, got \(error)")
+                return
+            }
+        } catch {
+            Issue.record("Expected IMAPError.malformedCopyUIDAfterTaggedOK, got \(error)")
+        }
     }
 }

--- a/Tests/SwiftIMAPTests/CopyUIDTests.swift
+++ b/Tests/SwiftIMAPTests/CopyUIDTests.swift
@@ -304,3 +304,54 @@ struct CopyUIDTests {
         }
     }
 }
+
+extension CopyUIDTests {
+    @Test(
+        "COPY and MOVE reject repeated COPYUID members",
+        arguments: [
+            "A001 OK [COPYUID 42 1,1 101,102] completed\r\n",
+            "A001 OK [COPYUID 42 1:2,2 101:103] completed\r\n",
+            "A001 OK [COPYUID 42 1,2 101,101] completed\r\n",
+            "A001 OK [COPYUID 42 1:3 101:102,102] completed\r\n"
+        ]
+    )
+    func testRepeatedCopyUIDMembersAreRejected(_ response: String) async {
+        await expectMalformedCopyUID {
+            try await executeCopy(responses: [response])
+        }
+        await expectMalformedCopyUID {
+            try await executeMove(responses: [response])
+        }
+    }
+
+    @Test
+    func testMoveTaggedFailurePreservesVerifiedPartialMapping() async {
+        do {
+            _ = try await executeMove(
+                responses: [
+                    "* OK [COPYUID 10 3:4 300:301] Partially moved\r\n",
+                    "A001 NO MOVE failed after partial completion\r\n"
+                ]
+            )
+            Issue.record("Expected moveFailedAfterPartialCompletion")
+        } catch let error as IMAPError {
+            guard case .moveFailedAfterPartialCompletion(let copyUID, let reason) = error else {
+                Issue.record("Expected moveFailedAfterPartialCompletion, got \(error)")
+                return
+            }
+            #expect(copyUID.destinationUIDValidity == UIDValidity(10))
+            #expect(copyUID.mapping.map(\.source.value) == [3, 4])
+            #expect(copyUID.mapping.map(\.destination.value) == [300, 301])
+            #expect(reason.contains("MOVE failed after partial completion"))
+            #expect(error.recoverySuggestion?.contains("Do not retry blindly") == true)
+        } catch {
+            Issue.record("Expected IMAPError.moveFailedAfterPartialCompletion, got \(error)")
+        }
+    }
+
+    @Test
+    func testMalformedCopyUIDRecoveryDoesNotSuggestRetry() {
+        let error = IMAPError.malformedCopyUIDAfterTaggedOK("duplicate source UID")
+        #expect(error.recoverySuggestion?.contains("Do not retry") == true)
+    }
+}

--- a/Tests/SwiftIMAPTests/CopyUIDTests.swift
+++ b/Tests/SwiftIMAPTests/CopyUIDTests.swift
@@ -191,29 +191,30 @@ struct CopyUIDTests {
                     "A001 NO MOVE denied\r\n"
                 ]
             )
-            Issue.record("Expected tagged NO to throw moveFailed")
+            Issue.record("Expected tagged NO to report possible partial completion")
         } catch let error as IMAPError {
-            guard case .moveFailed = error else {
-                Issue.record("Expected moveFailed, got \(error)")
+            guard case .moveFailedAfterPossiblePartialCompletion = error else {
+                Issue.record("Expected possible partial completion, got \(error)")
                 return
             }
         } catch {
-            Issue.record("Expected IMAPError.moveFailed, got \(error)")
+            Issue.record("Expected possible-partial IMAPError, got \(error)")
         }
     }
 
     @Test
-    func testMoveTaggedNOThrowsMoveFailed() async {
+    func testMoveTaggedNOReportsPossiblePartialCompletion() async {
         do {
             _ = try await executeMove(responses: ["A001 NO MOVE denied\r\n"])
-            Issue.record("Expected tagged NO to throw moveFailed")
+            Issue.record("Expected possible partial completion")
         } catch let error as IMAPError {
-            guard case .moveFailed = error else {
-                Issue.record("Expected moveFailed, got \(error)")
+            guard case .moveFailedAfterPossiblePartialCompletion = error else {
+                Issue.record("Expected possible partial completion, got \(error)")
                 return
             }
+            #expect(error.recoverySuggestion?.contains("Do not retry") == true)
         } catch {
-            Issue.record("Expected IMAPError.moveFailed, got \(error)")
+            Issue.record("Expected possible-partial IMAPError, got \(error)")
         }
     }
 
@@ -307,6 +308,34 @@ struct CopyUIDTests {
 
 extension CopyUIDTests {
     @Test(
+        "COPY and MOVE reject wildcard COPYUID members",
+        arguments: [
+            "A001 OK [COPYUID 42 * 101] completed\r\n",
+            "A001 OK [COPYUID 42 1 *] completed\r\n",
+            "A001 OK [COPYUID 42 1:* 101:102] completed\r\n"
+        ]
+    )
+    func testWildcardCopyUIDMembersAreRejected(_ response: String) async {
+        await expectMalformedCopyUID {
+            try await executeCopy(responses: [response])
+        }
+        await expectMalformedCopyUID {
+            try await executeMove(responses: [response])
+        }
+    }
+
+    @Test
+    func testNormalizedNumericMaximumIsConservativelyRejected() async {
+        let response = "A001 OK [COPYUID 42 4294967295 101] completed\r\n"
+        await expectMalformedCopyUID {
+            try await executeCopy(responses: [response])
+        }
+        await expectMalformedCopyUID {
+            try await executeMove(responses: [response])
+        }
+    }
+
+    @Test(
         "COPY and MOVE reject repeated COPYUID members",
         arguments: [
             "A001 OK [COPYUID 42 1,1 101,102] completed\r\n",
@@ -352,6 +381,12 @@ extension CopyUIDTests {
     @Test
     func testMalformedCopyUIDRecoveryDoesNotSuggestRetry() {
         let error = IMAPError.malformedCopyUIDAfterTaggedOK("duplicate source UID")
+        #expect(error.recoverySuggestion?.contains("Do not retry") == true)
+    }
+
+    @Test
+    func testLegacyMoveFailureRecoveryDoesNotSuggestRetry() {
+        let error = IMAPError.moveFailed("server rejected MOVE")
         #expect(error.recoverySuggestion?.contains("Do not retry") == true)
     }
 }

--- a/Tests/SwiftIMAPTests/IMAPTestServer.swift
+++ b/Tests/SwiftIMAPTests/IMAPTestServer.swift
@@ -44,9 +44,11 @@ final class IMAPTestServer {
     private var acceptSource: DispatchSourceRead?
     private let queue = DispatchQueue(label: "IMAPTestServer")
     private let messages: [Message]
+    private let advertisedCapabilities: [String]
     private let loginResponseDelay: TimeInterval
     private let metricsQueue = DispatchQueue(label: "IMAPTestServer.metrics")
     private var idleCommandCountStorage = 0
+    private var commandLogStorage: [String] = []
     private var clientFds: Set<Int32> = []
     private let clientFdsLock = NSLock()
     private let clientGroup = DispatchGroup()
@@ -58,6 +60,9 @@ final class IMAPTestServer {
         username: String = "testuser",
         password: String = "testpass",
         loginResponseDelay: TimeInterval = 0,
+        advertisedCapabilities: [String] = [
+            "IMAP4rev1", "AUTH=PLAIN", "LITERAL+", "ID", "NAMESPACE", "UIDPLUS", "IDLE"
+        ],
         maildirURL: URL
     ) throws {
         self.host = host
@@ -65,11 +70,16 @@ final class IMAPTestServer {
         self.username = username
         self.password = password
         self.loginResponseDelay = loginResponseDelay
+        self.advertisedCapabilities = advertisedCapabilities
         self.messages = try Self.loadMaildir(maildirURL)
     }
 
     var idleCommandCount: Int {
         metricsQueue.sync { idleCommandCountStorage }
+    }
+
+    var commandLog: [String] {
+        metricsQueue.sync { commandLogStorage }
     }
 
     private func recordIdleCommand() {
@@ -86,6 +96,10 @@ final class IMAPTestServer {
 
     private func recordIDCommand() {
         metricsQueue.sync { idCommandCountStorage += 1 }
+    }
+
+    private func recordCommand(_ line: String) {
+        metricsQueue.sync { commandLogStorage.append(line) }
     }
 
     /// Total connections ever accepted. Catches re-dials that never reach an
@@ -301,6 +315,7 @@ final class IMAPTestServer {
                 let tag = parts[0]
                 let command = parts[1].uppercased()
                 let args = parts.count > 2 ? parts[2] : ""
+                recordCommand(line)
 
                 if command == "IDLE" {
                     recordIdleCommand()
@@ -392,7 +407,7 @@ final class IMAPTestServer {
     ) -> String {
         switch command {
             case "CAPABILITY":
-                return "* CAPABILITY IMAP4rev1 AUTH=PLAIN LITERAL+ ID NAMESPACE UIDPLUS IDLE\r\n"
+                return "* CAPABILITY \(advertisedCapabilities.joined(separator: " "))\r\n"
                     + "\(tag) OK CAPABILITY completed\r\n"
             case "LOGIN":
                 if loginResponseDelay > 0 {
@@ -447,6 +462,16 @@ final class IMAPTestServer {
             case "SEARCH":
                 let uids = messages.map { String($0.uid) }.joined(separator: " ")
                 return "* SEARCH \(uids)\r\n\(tag) OK UID SEARCH completed\r\n"
+            case "MOVE":
+                guard advertisedCapabilities.contains("MOVE") else {
+                    return "\(tag) BAD UID MOVE not supported\r\n"
+                }
+                let moveParts = subargs.split(separator: " ", maxSplits: 1).map(String.init)
+                guard moveParts.count == 2 else { return "\(tag) BAD Invalid UID MOVE\r\n" }
+                if advertisedCapabilities.contains("UIDPLUS") {
+                    return "\(tag) OK [COPYUID 2 \(moveParts[0]) 101] UID MOVE completed\r\n"
+                }
+                return "\(tag) OK UID MOVE completed\r\n"
             default:
                 return "\(tag) BAD Unknown UID subcommand\r\n"
         }

--- a/Tests/SwiftIMAPTests/IMAPTestServer.swift
+++ b/Tests/SwiftIMAPTests/IMAPTestServer.swift
@@ -46,6 +46,8 @@ final class IMAPTestServer {
     private let messages: [Message]
     private let advertisedCapabilities: [String]
     private let loginResponseDelay: TimeInterval
+    private let rejectedUIDSubcommand: String?
+    private let copyUIDSourceOverride: String?
     private let metricsQueue = DispatchQueue(label: "IMAPTestServer.metrics")
     private var idleCommandCountStorage = 0
     private var commandLogStorage: [String] = []
@@ -60,6 +62,8 @@ final class IMAPTestServer {
         username: String = "testuser",
         password: String = "testpass",
         loginResponseDelay: TimeInterval = 0,
+        rejectedUIDSubcommand: String? = nil,
+        copyUIDSourceOverride: String? = nil,
         advertisedCapabilities: [String] = [
             "IMAP4rev1", "AUTH=PLAIN", "LITERAL+", "ID", "NAMESPACE", "UIDPLUS", "IDLE"
         ],
@@ -70,6 +74,8 @@ final class IMAPTestServer {
         self.username = username
         self.password = password
         self.loginResponseDelay = loginResponseDelay
+        self.rejectedUIDSubcommand = rejectedUIDSubcommand?.uppercased()
+        self.copyUIDSourceOverride = copyUIDSourceOverride
         self.advertisedCapabilities = advertisedCapabilities
         self.messages = try Self.loadMaildir(maildirURL)
     }
@@ -458,6 +464,9 @@ final class IMAPTestServer {
             return "\(tag) BAD Missing UID subcommand\r\n"
         }
         let subargs = parts.count > 1 ? parts[1] : ""
+        if subcmd == rejectedUIDSubcommand {
+            return "\(tag) NO Injected UID \(subcmd) failure\r\n"
+        }
         switch subcmd {
             case "FETCH":
                 return handleFetch(tag: tag, args: subargs, uidMode: true)
@@ -471,14 +480,16 @@ final class IMAPTestServer {
                 let moveParts = subargs.split(separator: " ", maxSplits: 1).map(String.init)
                 guard moveParts.count == 2 else { return "\(tag) BAD Invalid UID MOVE\r\n" }
                 if advertisesCapability("UIDPLUS") {
-                    return "\(tag) OK [COPYUID 2 \(moveParts[0]) 101] UID MOVE completed\r\n"
+                    let sourceUIDs = copyUIDSourceOverride ?? moveParts[0]
+                    return "\(tag) OK [COPYUID 2 \(sourceUIDs) 101] UID MOVE completed\r\n"
                 }
                 return "\(tag) OK UID MOVE completed\r\n"
             case "COPY":
                 let copyParts = subargs.split(separator: " ", maxSplits: 1).map(String.init)
                 guard copyParts.count == 2 else { return "\(tag) BAD Invalid UID COPY\r\n" }
                 if advertisesCapability("UIDPLUS") {
-                    return "\(tag) OK [COPYUID 2 \(copyParts[0]) 101] UID COPY completed\r\n"
+                    let sourceUIDs = copyUIDSourceOverride ?? copyParts[0]
+                    return "\(tag) OK [COPYUID 2 \(sourceUIDs) 101] UID COPY completed\r\n"
                 }
                 return "\(tag) OK UID COPY completed\r\n"
             case "STORE":

--- a/Tests/SwiftIMAPTests/IMAPTestServer.swift
+++ b/Tests/SwiftIMAPTests/IMAPTestServer.swift
@@ -443,6 +443,8 @@ final class IMAPTestServer {
                 return "* ID NIL\r\n\(tag) OK ID completed\r\n"
             case "NOOP":
                 return "\(tag) OK NOOP completed\r\n"
+            case "EXPUNGE":
+                return "\(tag) OK EXPUNGE completed\r\n"
             case "LOGOUT":
                 return "* BYE IMAP server shutting down\r\n\(tag) OK LOGOUT completed\r\n"
             default:
@@ -463,17 +465,36 @@ final class IMAPTestServer {
                 let uids = messages.map { String($0.uid) }.joined(separator: " ")
                 return "* SEARCH \(uids)\r\n\(tag) OK UID SEARCH completed\r\n"
             case "MOVE":
-                guard advertisedCapabilities.contains("MOVE") else {
+                guard advertisesCapability("MOVE") else {
                     return "\(tag) BAD UID MOVE not supported\r\n"
                 }
                 let moveParts = subargs.split(separator: " ", maxSplits: 1).map(String.init)
                 guard moveParts.count == 2 else { return "\(tag) BAD Invalid UID MOVE\r\n" }
-                if advertisedCapabilities.contains("UIDPLUS") {
+                if advertisesCapability("UIDPLUS") {
                     return "\(tag) OK [COPYUID 2 \(moveParts[0]) 101] UID MOVE completed\r\n"
                 }
                 return "\(tag) OK UID MOVE completed\r\n"
+            case "COPY":
+                let copyParts = subargs.split(separator: " ", maxSplits: 1).map(String.init)
+                guard copyParts.count == 2 else { return "\(tag) BAD Invalid UID COPY\r\n" }
+                if advertisesCapability("UIDPLUS") {
+                    return "\(tag) OK [COPYUID 2 \(copyParts[0]) 101] UID COPY completed\r\n"
+                }
+                return "\(tag) OK UID COPY completed\r\n"
+            case "STORE":
+                return "\(tag) OK UID STORE completed\r\n"
+            case "EXPUNGE":
+                return "\(tag) OK UID EXPUNGE completed\r\n"
             default:
                 return "\(tag) BAD Unknown UID subcommand\r\n"
+        }
+    }
+
+    private func advertisesCapability(_ expected: String) -> Bool {
+        advertisedCapabilities.contains { capability in
+            capability.utf8.elementsEqual(expected.lowercased().utf8) { candidate, expectedByte in
+                (candidate | 0x20) == expectedByte
+            }
         }
     }
 

--- a/Tests/SwiftIMAPTests/MoveCapabilityTests.swift
+++ b/Tests/SwiftIMAPTests/MoveCapabilityTests.swift
@@ -1,0 +1,116 @@
+import Foundation
+import NIO
+import NIOIMAPCore
+import Testing
+@testable import SwiftMail
+
+/// Does the public MOVE capability accessor report what the server actually advertised?
+///
+/// `supportsUIDPlus` was public while the MOVE capability was only visible through the
+/// `internal` `capabilities` set, so a caller could not decide for itself whether to issue a
+/// `MOVE` (RFC 6851) or to drive COPY + STORE `\Deleted` + EXPUNGE and own the resulting UID
+/// bookkeeping. These pin the accessor to the MOVE capability specifically: the interesting
+/// failure is not "always false", it is a copy-paste that leaves the body reading `.uidPlus`,
+/// which stays green against any server advertising both. The mixed-capability and
+/// not-aliased cases separate the two so that substitution goes red.
+@Suite("MOVE capability detection", .serialized, .timeLimit(.minutes(1)))
+struct MoveCapabilityTests {
+
+    // MARK: - IMAPServer
+
+    @Test("Server reports MOVE unsupported when it is not advertised")
+    func serverWithoutMoveReportsUnsupported() async {
+        let server = await makeServer(capabilities: [])
+        #expect(await server.supportsMove == false)
+    }
+
+    @Test("Server reports MOVE supported when it is advertised")
+    func serverWithMoveReportsSupported() async {
+        let server = await makeServer(capabilities: [.move])
+        #expect(await server.supportsMove)
+    }
+
+    @Test("Server MOVE support is independent of UIDPLUS")
+    func serverMoveIsNotAliasedToUIDPlus() async {
+        // UIDPLUS alone must not imply MOVE …
+        let uidPlusOnly = await makeServer(capabilities: [.uidPlus])
+        #expect(await uidPlusOnly.supportsMove == false)
+        #expect(await uidPlusOnly.supportsUIDPlus)
+
+        // … and MOVE alone must not imply UIDPLUS.
+        let moveOnly = await makeServer(capabilities: [.move])
+        #expect(await moveOnly.supportsMove)
+        #expect(await moveOnly.supportsUIDPlus == false)
+    }
+
+    @Test("Server finds MOVE among unrelated capabilities")
+    func serverMoveAmongMixedCapabilities() async {
+        let server = await makeServer(capabilities: [.idle, .move, .namespace])
+        #expect(await server.supportsMove)
+    }
+
+    // MARK: - IMAPNamedConnection
+
+    @Test("Named connection reports MOVE unsupported when it is not advertised")
+    func namedConnectionWithoutMove() async {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let named = makeNamedConnection(capabilities: [], group: group)
+        #expect(await named.supportsMove == false)
+        await shutDownGracefully(group)
+    }
+
+    @Test("Named connection reports MOVE supported when it is advertised")
+    func namedConnectionWithMove() async {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let named = makeNamedConnection(capabilities: [.move], group: group)
+        #expect(await named.supportsMove)
+        await shutDownGracefully(group)
+    }
+
+    @Test("Named connection MOVE support is independent of UIDPLUS")
+    func namedMoveIsNotAliasedToUIDPlus() async {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+
+        let uidPlusOnly = makeNamedConnection(capabilities: [.uidPlus], group: group)
+        #expect(await uidPlusOnly.supportsMove == false)
+        #expect(await uidPlusOnly.supportsUIDPlus)
+
+        let moveOnly = makeNamedConnection(capabilities: [.move], group: group)
+        #expect(await moveOnly.supportsMove)
+        #expect(await moveOnly.supportsUIDPlus == false)
+
+        await shutDownGracefully(group)
+    }
+
+    // MARK: - Helpers
+
+    /// Builds an unconnected `IMAPServer` whose primary connection advertises `capabilities`.
+    ///
+    /// The server owns an internally created `EventLoopGroup` it never exposes; no transport is
+    /// opened here, matching the existing unconnected-server suites.
+    private func makeServer(capabilities: Set<NIOIMAPCore.Capability>) async -> SwiftMail.IMAPServer {
+        let server = SwiftMail.IMAPServer(host: "imap.example.com", port: 993)
+        await server.primaryConnection.replaceCapabilitiesForTesting(capabilities)
+        return server
+    }
+
+    /// Builds an unconnected `IMAPNamedConnection` advertising `capabilities` on `group`.
+    private func makeNamedConnection(
+        capabilities: Set<NIOIMAPCore.Capability>,
+        group: MultiThreadedEventLoopGroup
+    ) -> IMAPNamedConnection {
+        let connection = IMAPConnection(
+            host: "localhost",
+            port: 1,
+            useTLS: false,
+            group: group,
+            loggerLabel: "test.imap",
+            outboundLabel: "test.imap.out",
+            inboundLabel: "test.imap.in",
+            connectionID: "test-move-capability",
+            connectionRole: "test"
+        )
+        connection.replaceCapabilitiesForTesting(capabilities)
+        return IMAPNamedConnection(name: "test", connection: connection, authenticateOnConnection: { _ in })
+    }
+}


### PR DESCRIPTION
## What changed

- Expose case-insensitive MOVE capability detection on IMAPServer and IMAPNamedConnection.
- Add a MoveFallbackPolicy parameter to the existing move APIs on both surfaces. The default preserves COPY + STORE \Deleted + EXPUNGE fallback; the disabled policy requires MOVE and emits MOVE without requiring UIDPLUS.
- Return COPYUID mappings from COPY and MOVE, including the RFC 6851-recommended untagged OK response before EXPUNGE responses.
- Report malformed or conflicting COPYUID evidence with the typed malformedCopyUIDAfterTaggedOK error. That error explicitly means the provider command completed and must not be resent.

## Why

The fallback choice belongs on the existing move API so callers can require server MOVE without learning a second entry point. MOVE capability tokens are ASCII case-insensitive, and UIDPLUS controls optional mapping evidence rather than whether UID MOVE is legal.

A tagged OK is authoritative that COPY or MOVE completed. Keeping malformed mapping distinct from an omitted mapping lets durable callers reconcile or resync without repeating an already-committed mutation. Retaining untagged OK COPYUID also supports the response ordering recommended by RFC 6851.

## Compatibility

Existing callers keep the same source-compatible move signature and the same fallback behavior through the default copyStoreExpunge policy. Callers that require one MOVE command pass disabled. The separate moveAtomically proposal has been removed.

## Validation

- swift build passed.
- swift test: 457 tests in 59 suites passed.
- swiftlint lint --strict --no-cache: 0 violations across 288 files.
- Integration coverage verifies policy selection, server and named-connection conveniences, mixed-case MOVE capability spellings, and no fallback commands under disabled.
- Handler coverage verifies tagged and untagged COPYUID, malformed and conflicting evidence, and tagged failure precedence.