### PR TITLE
Fix release test access to IMAP buffer limits

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -205,11 +205,9 @@ final class IMAPConnection {
         certificateVerificationPolicy
     }
 
-    #if DEBUG
     var responseBufferLimitForTesting: Int {
         responseBufferLimit
     }
-    #endif
 
     var namespacesSnapshot: NamespaceResponse? {
         namespaces

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -288,12 +288,10 @@ public actor IMAPServer {
         return .plainText
     }
 
-    #if DEBUG
     /// Test-only access to the response buffer limit configured on the primary connection.
     var primaryResponseBufferLimitForTesting: Int {
         primaryConnection.responseBufferLimit
     }
-    #endif
 
     deinit {
         // Same non-blocking pattern as SMTPServer.deinit. The callback form needs


### PR DESCRIPTION
## What

Keep the existing internal, read-only response-buffer test probes available in release builds as well as debug builds.

## Why

PR #179 added unconditional coverage for response-buffer propagation, but wrapped the two probes used by that suite in `#if DEBUG`. SwiftPM compiles the library without `DEBUG` under `swift test -c release`, while still compiling the test target, so the release test build fails before any tests can run.

This is a prerequisite for #208 so that its release-configuration validation can be evaluated on a green upstream baseline instead of being described as a pre-existing failure. Please land this small fix first; #208 can then incorporate the updated `main`.

## Impact

No public API or runtime behavior changes. The affected properties remain internal, read-only test accessors. This also keeps the buffer-limit suite active in release builds rather than skipping it.

## Checks

- `swift test` — 435 tests passed
- `swift test -c release` — 435 tests passed
- `swiftlint lint --strict --quiet`
- `git diff --check`
- independent audit — clean

Signed-off-by: Kwang Moo Yi <kmyi@tabmail.ai>