### PR TITLE
Add read-only IMAP EXAMINE support

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Commands/ExamineMailboxCommand.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/ExamineMailboxCommand.swift
@@ -1,0 +1,29 @@
+import Foundation
+import NIO
+import NIOIMAP
+
+/// Command to select a mailbox in read-only mode.
+struct ExamineMailboxCommand: IMAPTaggedCommand {
+    typealias ResultType = Mailbox.Selection
+    typealias HandlerType = SelectHandler
+
+    let mailboxName: String
+    let timeoutSeconds: Int = 30
+
+    init(mailboxName: String) {
+        self.mailboxName = mailboxName
+    }
+
+    func validate() throws {
+        guard !mailboxName.isEmpty else {
+            throw IMAPError.invalidArgument("Mailbox name cannot be empty")
+        }
+    }
+
+    func toTaggedCommand(tag: String) -> TaggedCommand {
+        TaggedCommand(
+            tag: tag,
+            command: .examine(MailboxName(ByteBuffer(string: mailboxName)))
+        )
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/SelectHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/SelectHandler.swift
@@ -28,6 +28,12 @@ final class SelectHandler: BaseIMAPCommandHandler<Mailbox.Selection>, IMAPComman
     /// Handle a tagged OK response by succeeding the promise with the mailbox info
     /// - Parameter response: The tagged response
     override func handleTaggedOKResponse(_ response: TaggedResponse) {
+        // SELECT/EXAMINE communicate READ-WRITE or READ-ONLY in the tagged
+        // completion response. Capture it before fulfilling the result.
+        if case .ok(let responseText) = response.state, let code = responseText.code {
+            applyResponseCode(code)
+        }
+
         // Call super to handle CLIENTBUG warnings
         super.handleTaggedOKResponse(response)
 

--- a/Sources/SwiftMail/IMAP/IMAPNamedConnection+Mailbox.swift
+++ b/Sources/SwiftMail/IMAP/IMAPNamedConnection+Mailbox.swift
@@ -26,6 +26,17 @@ extension IMAPNamedConnection {
         try await select(mailbox: mailboxName)
     }
 
+    /// Select a mailbox read-only using IMAP EXAMINE.
+    ///
+    /// The server enforces the read-only selection: STORE and EXPUNGE operations
+    /// are not permitted while the mailbox remains selected this way.
+    @discardableResult
+    public func examineMailbox(_ mailboxName: String) async throws -> Mailbox.Selection {
+        try await ensureAuthenticated()
+        let command = ExamineMailboxCommand(mailboxName: resolveMailboxPath(mailboxName))
+        return try await executeCommand(command)
+    }
+
     /// Close the currently selected mailbox (expunges `\Deleted` messages).
     public func closeMailbox() async throws {
         let command = CloseCommand()

--- a/Sources/SwiftMail/IMAP/IMAPServer+Helpers.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Helpers.swift
@@ -14,13 +14,17 @@ extension IMAPServer {
     func executeCommand<CommandType: IMAPCommand>(
         _ command: CommandType
     ) async throws -> CommandType.ResultType {
+        try await ensurePrimaryConnectionAuthenticated()
+
+        return try await primaryConnection.executeCommand(command)
+    }
+
+    func ensurePrimaryConnectionAuthenticated() async throws {
         if let authentication, !primaryConnection.isAuthenticated {
             logger.info("Primary connection not authenticated; re-authenticating before command")
             try await authentication.authenticate(on: primaryConnection)
             namespaces = primaryConnection.namespacesSnapshot
         }
-
-        return try await primaryConnection.executeCommand(command)
     }
 
     func resolveMailboxPath(_ mailbox: String) -> String {

--- a/Sources/SwiftMail/IMAP/IMAPServer+Mailbox.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Mailbox.swift
@@ -44,6 +44,24 @@ extension IMAPServer {
     }
 
     /**
+     Select a mailbox in read-only mode
+
+     This method uses IMAP EXAMINE to make the mailbox current while asking the server
+     to enforce read-only access. STORE and EXPUNGE operations are not permitted while
+     the mailbox remains selected this way.
+
+     - Parameter mailboxName: The name of the mailbox to select read-only
+     - Returns: Status information about the selected mailbox
+     - Throws:
+     - `IMAPError.selectFailed` if the mailbox cannot be selected
+     - `IMAPError.connectionFailed` if not connected
+     */
+    @discardableResult public func examineMailbox(_ mailboxName: String) async throws -> Mailbox.Selection {
+        let command = ExamineMailboxCommand(mailboxName: resolveMailboxPath(mailboxName))
+        return try await executeCommand(command)
+    }
+
+    /**
      Close the currently selected mailbox
 
      This method closes the currently selected mailbox and expunges any messages

--- a/Sources/SwiftMail/IMAP/IMAPServer+Mailbox.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Mailbox.swift
@@ -57,6 +57,7 @@ extension IMAPServer {
      - `IMAPError.connectionFailed` if not connected
      */
     @discardableResult public func examineMailbox(_ mailboxName: String) async throws -> Mailbox.Selection {
+        try await ensurePrimaryConnectionAuthenticated()
         let command = ExamineMailboxCommand(mailboxName: resolveMailboxPath(mailboxName))
         return try await executeCommand(command)
     }

--- a/Tests/SwiftIMAPTests/ExamineMailboxCommandTests.swift
+++ b/Tests/SwiftIMAPTests/ExamineMailboxCommandTests.swift
@@ -1,0 +1,36 @@
+import NIO
+import NIOEmbedded
+@preconcurrency import NIOIMAP
+import Testing
+@testable import SwiftMail
+
+@Suite(.serialized, .timeLimit(.minutes(1)))
+struct ExamineMailboxCommandTests {
+    @Test
+    func rejectsEmptyMailboxName() {
+        let command = ExamineMailboxCommand(mailboxName: "")
+
+        #expect(throws: IMAPError.self) {
+            try command.validate()
+        }
+    }
+
+    @Test
+    func serializesExamineRatherThanSelect() async throws {
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
+        let command = ExamineMailboxCommand(mailboxName: "INBOX")
+        let tagged = command.toTaggedCommand(tag: "E001")
+        let outbound = IMAPClientHandler.OutboundIn.part(CommandStreamPart.tagged(tagged))
+
+        try await channel.writeAndFlush(outbound)
+
+        guard var buffer = try await channel.readOutbound(as: ByteBuffer.self) else {
+            Issue.record("Expected outbound bytes")
+            return
+        }
+        let wire = buffer.readString(length: buffer.readableBytes)
+
+        #expect(wire == "E001 EXAMINE \"INBOX\"\r\n")
+        #expect(wire?.contains("SELECT") == false)
+    }
+}

--- a/Tests/SwiftIMAPTests/IMAPPlaintextIntegrationTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPPlaintextIntegrationTests.swift
@@ -46,6 +46,9 @@ import Testing
                 try await server.login(username: "testuser", password: "testpass")
                 let status = try await server.selectMailbox("INBOX")
                 #expect(status.messageCount == 1)
+                let readOnlyStatus = try await server.examineMailbox("INBOX")
+                #expect(readOnlyStatus.messageCount == 1)
+                #expect(readOnlyStatus.isReadOnly)
                 try await server.disconnect()
             }
         }

--- a/Tests/SwiftIMAPTests/IMAPPlaintextIntegrationTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPPlaintextIntegrationTests.swift
@@ -52,5 +52,39 @@ import Testing
                 try await server.disconnect()
             }
         }
+
+        @Test(.timeLimit(.minutes(1)))
+        func reconnectsBeforeResolvingExamineMailboxPath() async throws {
+            let tempRoot = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+            let maildir = tempRoot.appendingPathComponent("Maildir")
+            try FileManager.default.createDirectory(at: maildir, withIntermediateDirectories: true)
+            defer {
+                try? FileManager.default.removeItem(at: tempRoot)
+            }
+
+            let testServer = try IMAPTestServer(
+                host: "localhost",
+                port: 0,
+                username: "testuser",
+                password: "testpass",
+                personalNamespacePrefix: "INBOX.",
+                namespaceDelimiter: ".",
+                maildirURL: maildir
+            )
+            try testServer.start()
+
+            try await testServer.run {
+                let server = IMAPServer(host: "127.0.0.1", port: testServer.port, useTLS: false)
+                try await server.connect()
+                try await server.login(username: "testuser", password: "testpass")
+                try await server.disconnect()
+
+                let status = try await server.examineMailbox("Sent")
+
+                #expect(status.isReadOnly)
+                #expect(testServer.lastExaminedMailbox == "INBOX.Sent")
+                try await server.disconnect()
+            }
+        }
     }
 #endif

--- a/Tests/SwiftIMAPTests/IMAPTestServer.swift
+++ b/Tests/SwiftIMAPTests/IMAPTestServer.swift
@@ -413,6 +413,18 @@ final class IMAPTestServer {
                     + "* OK [PERMANENTFLAGS (\\Seen \\Answered \\Flagged \\Deleted \\Draft \\*)]"
                     + " Flags permitted\r\n"
                     + "\(tag) OK [READ-WRITE] SELECT completed\r\n"
+            case "EXAMINE":
+                guard authenticated else { return "\(tag) NO Not authenticated\r\n" }
+                let mailbox = args.trimmingCharacters(in: .init(charactersIn: "\" "))
+                selectedMailbox = mailbox
+                let count = messages.count
+                let uidnext = (messages.last?.uid ?? 0) + 1
+                return "* \(count) EXISTS\r\n* 0 RECENT\r\n"
+                    + "* OK [UIDVALIDITY 1] UIDs valid\r\n"
+                    + "* OK [UIDNEXT \(uidnext)] Predicted next UID\r\n"
+                    + "* FLAGS (\\Seen \\Answered \\Flagged \\Deleted \\Draft)\r\n"
+                    + "* OK [PERMANENTFLAGS ()] No permanent flags permitted\r\n"
+                    + "\(tag) OK [READ-ONLY] EXAMINE completed\r\n"
             case "UID":
                 guard selectedMailbox != nil else { return "\(tag) NO No mailbox selected\r\n" }
                 return handleUID(tag: tag, args: args)

--- a/Tests/SwiftIMAPTests/IMAPTestServer.swift
+++ b/Tests/SwiftIMAPTests/IMAPTestServer.swift
@@ -45,6 +45,8 @@ final class IMAPTestServer {
     private let queue = DispatchQueue(label: "IMAPTestServer")
     private let messages: [Message]
     private let loginResponseDelay: TimeInterval
+    private let personalNamespacePrefix: String
+    private let namespaceDelimiter: Character
     private let metricsQueue = DispatchQueue(label: "IMAPTestServer.metrics")
     private var idleCommandCountStorage = 0
     private var clientFds: Set<Int32> = []
@@ -58,6 +60,8 @@ final class IMAPTestServer {
         username: String = "testuser",
         password: String = "testpass",
         loginResponseDelay: TimeInterval = 0,
+        personalNamespacePrefix: String = "",
+        namespaceDelimiter: Character = "/",
         maildirURL: URL
     ) throws {
         self.host = host
@@ -65,6 +69,8 @@ final class IMAPTestServer {
         self.username = username
         self.password = password
         self.loginResponseDelay = loginResponseDelay
+        self.personalNamespacePrefix = personalNamespacePrefix
+        self.namespaceDelimiter = namespaceDelimiter
         self.messages = try Self.loadMaildir(maildirURL)
     }
 
@@ -86,6 +92,16 @@ final class IMAPTestServer {
 
     private func recordIDCommand() {
         metricsQueue.sync { idCommandCountStorage += 1 }
+    }
+
+    var lastExaminedMailbox: String? {
+        metricsQueue.sync { lastExaminedMailboxStorage }
+    }
+
+    private var lastExaminedMailboxStorage: String?
+
+    private func recordExaminedMailbox(_ mailbox: String) {
+        metricsQueue.sync { lastExaminedMailboxStorage = mailbox }
     }
 
     /// Total connections ever accepted. Catches re-dials that never reach an
@@ -416,6 +432,7 @@ final class IMAPTestServer {
             case "EXAMINE":
                 guard authenticated else { return "\(tag) NO Not authenticated\r\n" }
                 let mailbox = args.trimmingCharacters(in: .init(charactersIn: "\" "))
+                recordExaminedMailbox(mailbox)
                 selectedMailbox = mailbox
                 let count = messages.count
                 let uidnext = (messages.last?.uid ?? 0) + 1
@@ -432,7 +449,8 @@ final class IMAPTestServer {
                 guard selectedMailbox != nil else { return "\(tag) NO No mailbox selected\r\n" }
                 return handleFetch(tag: tag, args: args, uidMode: false)
             case "NAMESPACE":
-                return "* NAMESPACE ((\"\" \"/\")) NIL NIL\r\n\(tag) OK NAMESPACE completed\r\n"
+                return "* NAMESPACE ((\"\(personalNamespacePrefix)\" \"\(namespaceDelimiter)\")) NIL NIL\r\n"
+                    + "\(tag) OK NAMESPACE completed\r\n"
             case "LIST":
                 return "* LIST (\\HasNoChildren) \"/\" \"INBOX\"\r\n\(tag) OK LIST completed\r\n"
             case "ID":


### PR DESCRIPTION
Supersedes #207, keeping its original commits and adding the fixes requested there.