### PR TITLE
Preserve repeated selective IMAP header fields in MessageInfo

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Handler/FetchMessageInfoHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/FetchMessageInfoHandler.swift
@@ -97,7 +97,12 @@ final class FetchMessageInfoHandler: BaseIMAPCommandHandler<[MessageInfo]>, IMAP
         // independently with the same total UTF-8/Latin-1 policy used by the
         // EML parser so one malformed field cannot discard the entire literal.
         let headerBlock = EMLParser.decodeHeaderBlock(currentHeaderLiteral)
-        let allHeaders = EMLParser.parseHeaders(headerBlock)
+
+        // Parse once in lossless order; derive the legacy dict from the ordered result
+        // so repeated fields never require two passes.
+        let orderedHeaders = EMLParser.parseAllHeaders(headerBlock)
+        let allHeaders = Dictionary(orderedHeaders.map { ($0.key, $0.value) },
+                                    uniquingKeysWith: { _, last in last })
 
         // Headers already exposed via ENVELOPE or stored in dedicated fields
         let envelopeKeys: Set<String> = [
@@ -115,6 +120,9 @@ final class FetchMessageInfoHandler: BaseIMAPCommandHandler<[MessageInfo]>, IMAP
 
         let referencesValue = allHeaders["references"]?.trimmingCharacters(in: .whitespacesAndNewlines)
         let additionalHeaders = allHeaders.filter { !envelopeKeys.contains($0.key) }
+        let additionalHeaderFields = orderedHeaders
+            .filter { !envelopeKeys.contains($0.key) }
+            .map { HeaderField(name: $0.key, value: $0.value) }
 
         lock.withLock {
             guard let index = currentMessageIndex() else { return }
@@ -128,6 +136,7 @@ final class FetchMessageInfoHandler: BaseIMAPCommandHandler<[MessageInfo]>, IMAP
             }
 
             header.additionalFields = additionalHeaders.isEmpty ? nil : additionalHeaders
+            header.additionalHeaderFields = additionalHeaderFields.isEmpty ? nil : additionalHeaderFields
             self.messageInfos[index] = header
         }
     }

--- a/Sources/SwiftMail/IMAP/Models/HeaderField.swift
+++ b/Sources/SwiftMail/IMAP/Models/HeaderField.swift
@@ -1,0 +1,15 @@
+// HeaderField.swift
+
+/// A single RFC 5322 header field instance, preserving wire order and repeated values.
+public struct HeaderField: Codable, Hashable, Sendable {
+    /// Lowercased field name, matching the key convention used in ``MessageInfo/additionalFields``.
+    public let name: String
+
+    /// Unfolded, trimmed field value.
+    public let value: String
+
+    public init(name: String, value: String) {
+        self.name = name
+        self.value = value
+    }
+}

--- a/Sources/SwiftMail/IMAP/Models/HeaderField.swift
+++ b/Sources/SwiftMail/IMAP/Models/HeaderField.swift
@@ -1,5 +1,7 @@
 // HeaderField.swift
 
+import Foundation
+
 /// A single RFC 5322 header field instance, preserving wire order and repeated values.
 public struct HeaderField: Codable, Hashable, Sendable {
     /// Lowercased field name, matching the key convention used in ``MessageInfo/additionalFields``.
@@ -8,8 +10,34 @@ public struct HeaderField: Codable, Hashable, Sendable {
     /// Unfolded, trimmed field value.
     public let value: String
 
+    /// Normalizes into the stored representation, so a directly-constructed field
+    /// equals — and filters alongside — the parsed field carrying the same header.
     public init(name: String, value: String) {
-        self.name = name
-        self.value = value
+        self.name = Self.normalized(name: name)
+        self.value = Self.normalized(value: value)
+    }
+
+    /// Decoded fields normalize too: the invariants belong to the representation,
+    /// not to one construction path.
+    public init(from decoder: any Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        self.init(name: try container.decode(String.self, forKey: .name),
+                  value: try container.decode(String.self, forKey: .value))
+    }
+
+    /// Field names compare case-insensitively (RFC 5322 §3.6.8), so the stored
+    /// form is lowercased — the convention `EMLParser` already applies.
+    private static func normalized(name: String) -> String {
+        name.trimmingCharacters(in: .whitespaces).lowercased()
+    }
+
+    /// Unfolds the way `EMLParser` does — continuation lines rejoin with a single
+    /// space (RFC 5322 §2.2.3) — then trims.
+    private static func normalized(value: String) -> String {
+        value
+            .split(omittingEmptySubsequences: false, whereSeparator: \.isNewline)
+            .map { $0.trimmingCharacters(in: .whitespaces) }
+            .filter { !$0.isEmpty }
+            .joined(separator: " ")
     }
 }

--- a/Sources/SwiftMail/IMAP/Models/MessageInfo.swift
+++ b/Sources/SwiftMail/IMAP/Models/MessageInfo.swift
@@ -47,8 +47,11 @@ public struct MessageInfo: Codable, Sendable {
     /// The message parts
     public var parts: [MessagePart]
 
-    /// Additional header fields
+    /// Additional header fields (last-value-wins dictionary, source-compatible).
     public var additionalFields: [String: String]?
+
+    /// Additional header fields in wire order, preserving repeated field instances.
+    public var additionalHeaderFields: [HeaderField]?
 
     /// The total size of the message in bytes, from `RFC822.SIZE`. Only populated when the fetch
     /// request asks for it.
@@ -70,6 +73,7 @@ public struct MessageInfo: Codable, Sendable {
         case flags
         case parts
         case additionalFields
+        case additionalHeaderFields
         case size
     }
 
@@ -86,7 +90,8 @@ public struct MessageInfo: Codable, Sendable {
     ///   - messageId: The message ID
     ///   - flags: The flags of the message
     ///   - parts: The message parts
-    ///   - additionalFields: Additional header fields
+    ///   - additionalFields: Additional header fields (last-value-wins dictionary)
+    ///   - additionalHeaderFields: Additional header fields in wire order, preserving repeated instances
     ///   - size: The total size of the message in bytes (RFC822.SIZE)
     public init(
         sequenceNumber: SequenceNumber,
@@ -104,6 +109,7 @@ public struct MessageInfo: Codable, Sendable {
         flags: [Flag] = [],
         parts: [MessagePart] = [],
         additionalFields: [String: String]? = nil,
+        additionalHeaderFields: [HeaderField]? = nil,
         size: Int? = nil
     ) {
         self.sequenceNumber = sequenceNumber
@@ -121,6 +127,7 @@ public struct MessageInfo: Codable, Sendable {
         self.flags = flags
         self.parts = parts
         self.additionalFields = additionalFields
+        self.additionalHeaderFields = additionalHeaderFields
         self.size = size
     }
 }
@@ -145,6 +152,7 @@ public extension MessageInfo {
             flags: try container.decodeIfPresent([Flag].self, forKey: .flags) ?? [],
             parts: try container.decodeIfPresent([MessagePart].self, forKey: .parts) ?? [],
             additionalFields: try container.decodeIfPresent([String: String].self, forKey: .additionalFields),
+            additionalHeaderFields: try container.decodeIfPresent([HeaderField].self, forKey: .additionalHeaderFields),
             size: try container.decodeIfPresent(Int.self, forKey: .size)
         )
     }

--- a/Tests/SwiftIMAPTests/AdditionalHeaderFieldsTests.swift
+++ b/Tests/SwiftIMAPTests/AdditionalHeaderFieldsTests.swift
@@ -1,0 +1,96 @@
+import Foundation
+import NIO
+import NIOEmbedded
+@preconcurrency import NIOIMAP
+@preconcurrency import NIOIMAPCore
+import Testing
+@testable import SwiftMail
+
+@Suite(.serialized, .timeLimit(.minutes(1)))
+struct AdditionalHeaderFieldsTests {
+    @Test
+    func testRepeatedAdditionalFieldsArePreservedInOrder() async throws {
+        let headerBlock = """
+        List-Unsubscribe: <mailto:leave@example.com>\r
+        List-Unsubscribe: <https://example.com/unsubscribe>\r
+        \r
+        """
+
+        let infos = try await executeFetch(
+            [
+                fetchResponse(
+                    sequenceNumber: 1,
+                    envelope: envelopeAttribute(messageId: "<msg@example.com>"),
+                    headerFields: ["List-Unsubscribe"],
+                    headerBlock: headerBlock
+                ),
+                "A001 OK FETCH completed\r\n"
+            ]
+        )
+
+        #expect(infos.count == 1)
+
+        let fields = infos[0].additionalHeaderFields?.filter { $0.name == "list-unsubscribe" }
+        #expect(fields?.count == 2)
+        #expect(fields?[0].value == "<mailto:leave@example.com>")
+        #expect(fields?[1].value == "<https://example.com/unsubscribe>")
+
+        #expect(infos[0].additionalFields?["list-unsubscribe"] == "<https://example.com/unsubscribe>")
+    }
+
+    @Test
+    func testAdditionalHeaderFieldsCodableRoundTrip() throws {
+        let fields: [HeaderField] = [
+            HeaderField(name: "list-unsubscribe", value: "<mailto:leave@example.com>"),
+            HeaderField(name: "list-unsubscribe", value: "<https://example.com/unsubscribe>")
+        ]
+        var info = MessageInfo(sequenceNumber: SequenceNumber(1))
+        info.additionalHeaderFields = fields
+
+        let data = try JSONEncoder().encode(info)
+        let decoded = try JSONDecoder().decode(MessageInfo.self, from: data)
+
+        #expect(decoded.additionalHeaderFields?.count == 2)
+        #expect(decoded.additionalHeaderFields?[0].name == "list-unsubscribe")
+        #expect(decoded.additionalHeaderFields?[0].value == "<mailto:leave@example.com>")
+        #expect(decoded.additionalHeaderFields?[1].value == "<https://example.com/unsubscribe>")
+    }
+
+    private func executeFetch(_ rawResponses: [String]) async throws -> [MessageInfo] {
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
+
+        let promise = channel.eventLoop.makePromise(of: [MessageInfo].self)
+        let handler = FetchMessageInfoHandler(commandTag: "A001", promise: promise)
+        try await channel.pipeline.addHandler(handler)
+
+        let command = TaggedCommand(tag: "A001", command: .noop)
+        try await channel.writeAndFlush(IMAPClientHandler.OutboundIn.part(.tagged(command)))
+        _ = try await channel.readOutbound(as: ByteBuffer.self)
+
+        for rawResponse in rawResponses {
+            var buffer = channel.allocator.buffer(capacity: rawResponse.utf8.count)
+            buffer.writeString(rawResponse)
+            try await channel.writeInbound(buffer)
+        }
+
+        return try await promise.futureResult.get()
+    }
+
+    private func fetchResponse(
+        sequenceNumber: Int,
+        envelope: String,
+        headerFields: [String],
+        headerBlock: String
+    ) -> String {
+        let fieldsList = headerFields.joined(separator: " ")
+        let count = headerBlock.utf8.count
+        return "* \(sequenceNumber) FETCH (ENVELOPE \(envelope)"
+            + " BODY[HEADER.FIELDS (\(fieldsList))] {\(count)}\r\n"
+            + "\(headerBlock))\r\n"
+    }
+
+    private func envelopeAttribute(messageId: String, inReplyTo: String? = nil) -> String {
+        let inReplyToValue = inReplyTo.map { "\"\($0)\"" } ?? "NIL"
+        return "(NIL NIL NIL NIL NIL NIL NIL NIL \(inReplyToValue) \"\(messageId)\")"
+    }
+}

--- a/Tests/SwiftIMAPTests/AdditionalHeaderFieldsTests.swift
+++ b/Tests/SwiftIMAPTests/AdditionalHeaderFieldsTests.swift
@@ -39,6 +39,47 @@ struct AdditionalHeaderFieldsTests {
     }
 
     @Test
+    func testDirectlyConstructedFieldMatchesParsedField() async throws {
+        let headerBlock = """
+        List-Unsubscribe: <mailto:leave@example.com>\r
+        \r
+        """
+
+        let infos = try await executeFetch(
+            [
+                fetchResponse(
+                    sequenceNumber: 1,
+                    envelope: envelopeAttribute(messageId: "<msg@example.com>"),
+                    headerFields: ["List-Unsubscribe"],
+                    headerBlock: headerBlock
+                ),
+                "A001 OK FETCH completed\r\n"
+            ]
+        )
+
+        let parsed = try #require(infos.first?.additionalHeaderFields?.first)
+
+        // A caller writing the header the way it appears on the wire must land on
+        // the same value, or equality and name filtering would depend on where the
+        // field came from.
+        #expect(HeaderField(name: "List-Unsubscribe", value: " <mailto:leave@example.com> ") == parsed)
+    }
+
+    @Test
+    func testHeaderFieldNormalizesNameCaseFoldedValueAndDecodedInput() throws {
+        let mixedCase = HeaderField(name: "  List-Unsubscribe  ", value: "  <mailto:leave@example.com>  ")
+        #expect(mixedCase.name == "list-unsubscribe")
+        #expect(mixedCase.value == "<mailto:leave@example.com>")
+
+        // Folded values rejoin with a single space, as the parser produces them.
+        #expect(HeaderField(name: "x", value: "first\r\n  second\r\n\tthird").value == "first second third")
+
+        // Decoding is a construction path too — it must not smuggle in raw input.
+        let raw = Data(#"{"name":"List-Unsubscribe","value":"  <mailto:leave@example.com>  "}"#.utf8)
+        #expect(try JSONDecoder().decode(HeaderField.self, from: raw) == mixedCase)
+    }
+
+    @Test
     func testAdditionalHeaderFieldsCodableRoundTrip() throws {
         let fields: [HeaderField] = [
             HeaderField(name: "list-unsubscribe", value: "<mailto:leave@example.com>"),


### PR DESCRIPTION
Closes #212.

Selective IMAP header fetches lost repeated field instances before they reached consumers, because `EMLParser.parseHeaders(_:)` assigns values by lowercased field name and a later field overwrote an earlier one with the same name.

## Changes

- **New `HeaderField`** (`Codable, Hashable, Sendable`) — a single RFC 5322 header field instance: lowercased `name`, unfolded/trimmed `value`.
- **New `MessageInfo.additionalHeaderFields: [HeaderField]?`** — a lossless, wire-order companion to the existing `additionalFields` dictionary.
- **`FetchMessageInfoHandler.applyCollectedThreadingHeaders()`** now calls `EMLParser.parseAllHeaders` once and derives the legacy dictionary from the ordered result via `Dictionary(uniquingKeysWith:)`.

The existing `additionalFields` dictionary keeps its current last-value-wins behavior, so this is source-compatible.

## Verification

`AdditionalHeaderFieldsTests` covers the issue's reproduction case — a `BODY[HEADER.FIELDS (List-Unsubscribe)]` literal carrying both a `mailto:` and an `https:` instance — and asserts both survive in wire order. Folded values remain unfolded; field matching remains case-insensitive.

---

**Note on provenance:** the MissionControl agent that wrote this commit completed and verified the work, then hung on an MCP call before it could open the PR (the daemon was CPU-saturated by an unrelated quadratic `watches` resource read). The branch was pushed and this PR opened by hand; the code and tests are the agent's, unmodified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
