### PR TITLE
Expose supportsMove, mirroring supportsUIDPlus

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -90,6 +90,15 @@ public actor IMAPServer {
         capabilities.contains(.uidPlus)
     }
 
+    /// Whether the primary connection advertised MOVE (RFC 6851).
+    ///
+    /// Exposed so callers can tell an atomic `MOVE` from the `COPY` + `STORE \Deleted` + `EXPUNGE`
+    /// fallback that `move(messages:to:)` performs when the extension is missing. A client with a
+    /// no-delete policy needs to know which one it is about to get, and cannot currently ask.
+    public var supportsMove: Bool {
+        capabilities.contains(.move)
+    }
+
     var certificatePolicyForTesting: MailCertificateVerificationPolicy {
         primaryConnection.certificateVerificationPolicyForTesting
     }


### PR DESCRIPTION
`move(messages:to:)` falls back to `COPY` + `STORE \Deleted` + `EXPUNGE` when the server does not
advertise the MOVE extension. That is a reasonable default, but a caller cannot detect it: the
fallback is chosen internally and `capabilities` is not public.

This matters for clients with a no-delete policy. A bare `EXPUNGE` removes every message in the
mailbox already flagged `\Deleted`, including messages flagged by another client, so "archive this
one message" can silently delete unrelated mail on a server without MOVE.

This adds the same one-line accessor that already exists for UIDPLUS:

```swift
public var supportsMove: Bool { capabilities.contains(.move) }
```

No behaviour change; it only lets a caller decide whether to proceed or refuse.