### PR TITLE
Encode MIME parameters and anchor parameter parsing to the RFC 2045 grammar

### DIFF
--- a/Sources/SwiftMail/Extensions/Email+Content.swift
+++ b/Sources/SwiftMail/Extensions/Email+Content.swift
@@ -181,7 +181,7 @@ extension Email {
 
         for attachment in self.regularAttachments {
             content += "--\(context.mainBoundary)\r\n"
-            content += "Content-Type: \(attachment.mimeType)\r\n"
+            content += "Content-Type: \(MIMEHeaderEncoding.fieldBody(attachment.mimeType))\r\n"
             if let invite = calendarInviteText(for: attachment, use8BitMIME: context.use8BitMIME) {
                 // RFC 6047 iMIP: calendar invites need an inline (or absent)
                 // Content-Disposition for clients to render the Accept/Decline UI,
@@ -192,11 +192,11 @@ extension Email {
                 // The filename keeps non-calendar clients able to save the .ics,
                 // mirroring how Gmail's own outgoing invites are formatted.
                 content += "Content-Transfer-Encoding: \(invite.encoding)\r\n"
-                content += "Content-Disposition: inline; filename=\"\(attachment.filename)\"\r\n\r\n"
+                content += "Content-Disposition: inline; \(Self.filenameParameter(attachment))\r\n\r\n"
                 content += terminatedICSBody(invite.text)
             } else {
                 content += "Content-Transfer-Encoding: base64\r\n"
-                content += "Content-Disposition: attachment; filename=\"\(attachment.filename)\"\r\n\r\n"
+                content += "Content-Disposition: attachment; \(Self.filenameParameter(attachment))\r\n\r\n"
                 content += encodedAttachmentBody(attachment.data) + "\r\n\r\n"
             }
         }
@@ -275,7 +275,7 @@ extension Email {
         content += "\(context.textBody)\r\n\r\n"
 
         content += "--\(context.altBoundary)\r\n"
-        content += "Content-Type: \(invite.mimeType)\r\n"
+        content += "Content-Type: \(MIMEHeaderEncoding.fieldBody(invite.mimeType))\r\n"
         content += "Content-Transfer-Encoding: \(encoding)\r\n\r\n"
         content += terminatedICSBody(icsText)
 
@@ -295,12 +295,13 @@ extension Email {
 
         for attachment in self.inlineAttachments {
             content += "--\(context.relatedBoundary)\r\n"
-            content += "Content-Type: \(attachment.mimeType); name=\"\(attachment.filename)\"\r\n"
+            content += "Content-Type: \(MIMEHeaderEncoding.fieldBody(attachment.mimeType)); "
+            content += "\(MIMEHeaderEncoding.parameter(name: "name", value: attachment.filename))\r\n"
             content += "Content-Transfer-Encoding: base64\r\n"
             if let contentID = attachment.contentID {
-                content += "Content-ID: <\(contentID)>\r\n"
+                content += "Content-ID: <\(MIMEHeaderEncoding.fieldBody(contentID))>\r\n"
             }
-            content += "Content-Disposition: inline; filename=\"\(attachment.filename)\"\r\n\r\n"
+            content += "Content-Disposition: inline; \(Self.filenameParameter(attachment))\r\n\r\n"
             content += encodedAttachmentBody(attachment.data) + "\r\n\r\n"
         }
 
@@ -332,6 +333,11 @@ extension Email {
             .endLineWithCarriageReturn,
             .endLineWithLineFeed
         ])
+    }
+
+    /// The `filename` parameter for an attachment's `Content-Disposition`.
+    private static func filenameParameter(_ attachment: Attachment) -> String {
+        MIMEHeaderEncoding.parameter(name: "filename", value: attachment.filename)
     }
 
     /// Formats the current date in RFC 2822 format for the Date header.

--- a/Sources/SwiftMail/MIME/EMLParser+Multipart.swift
+++ b/Sources/SwiftMail/MIME/EMLParser+Multipart.swift
@@ -204,7 +204,10 @@ extension EMLParser {
         let partDisposition = headers["content-disposition"]
         let partContentId = headers["content-id"]?.trimmingCharacters(in: .init(charactersIn: "<>"))
 
-        let filename = extractFilename(from: partContentType) ?? extractFilename(from: partDisposition ?? "")
+        // Both headers are handed to one call so the `filename`-over-`name`
+        // ranking holds across them; resolving the Content-Type to completion
+        // first would let its `name*` outrank the disposition's `filename`.
+        let filename = extractFilename(from: partContentType, partDisposition ?? "")
 
         if partContentType.lowercased().hasPrefix("multipart/") {
             // Recursive multipart

--- a/Sources/SwiftMail/MIME/EMLParser+Parameters.swift
+++ b/Sources/SwiftMail/MIME/EMLParser+Parameters.swift
@@ -13,14 +13,66 @@ extension EMLParser {
         return parts.first.map { String($0).trimmingCharacters(in: .whitespaces) } ?? contentType
     }
 
+    /// Split a header field body into its top-level `;`-separated segments.
+    ///
+    /// A `;` between the quotes of a parameter value is part of that value —
+    /// `name="a;b.pdf"` is one parameter, not two — so splitting has to know
+    /// where the quotes are, or a value the sender chooses decides where the
+    /// parameters are.
+    ///
+    /// An RFC 2045 quoted-pair inside the quotes — a `\` before any character —
+    /// is honored: the escaped character stands for itself, so a `\"` does not
+    /// close the value. The quoted-string reader in
+    /// ``extractHeaderParam(from:named:)`` applies the identical rule, so the
+    /// two agree on where a value ends; if they did not, a parameter could be
+    /// found in a segment whose value the reader then runs past.
+    static func parameterSegments(of header: String) -> [Substring] {
+        var segments: [Substring] = []
+        var start = header.startIndex
+        var index = header.startIndex
+        var inQuotes = false
+
+        while index < header.endIndex {
+            let character = header[index]
+            if inQuotes && character == "\\" {
+                // Quoted-pair: the next character is literal, so it can neither
+                // close the quote nor separate parameters. Skip both here, as
+                // the value reader unescapes them, or the two disagree on where
+                // the quoted value ends.
+                index = header.index(after: index)
+                if index < header.endIndex {
+                    index = header.index(after: index)
+                }
+                continue
+            }
+            if character == "\"" {
+                inQuotes.toggle()
+            } else if character == ";" && !inQuotes {
+                if start < index {
+                    segments.append(header[start..<index])
+                }
+                start = header.index(after: index)
+            }
+            index = header.index(after: index)
+        }
+
+        if start < header.endIndex {
+            segments.append(header[start...])
+        }
+        return segments
+    }
+
     /// Clean a Content-Type value for storage in MessagePart.
     /// Preserves charset and other relevant params, strips name/filename/boundary.
     static func cleanContentType(_ contentType: String) -> String {
-        let components = contentType.split(separator: ";")
+        let components = parameterSegments(of: contentType)
         guard let mimeType = components.first else { return contentType }
 
         var result = String(mimeType).trimmingCharacters(in: .whitespaces)
-        let skipParams: Set<String> = ["name", "filename", "boundary"]
+        // The RFC 2231 extended spellings are skipped alongside the plain ones,
+        // so a name that had to be written as `name*=` is not left in the stored
+        // content type for a later re-serialization to append a second copy of.
+        let skipParams: Set<String> = ["name", "filename", "boundary", "name*", "filename*"]
 
         for component in components.dropFirst() {
             let trimmed = String(component).trimmingCharacters(in: .whitespaces)
@@ -40,46 +92,120 @@ extension EMLParser {
     }
 
     /// Extract a named parameter from a header value (e.g. `boundary="abc"` → `abc`).
+    ///
+    /// `name` has to be the whole attribute of a parameter, not merely a
+    /// substring of the header. The values are sender-chosen, so an unanchored
+    /// search lets a sender put an attribute *inside* a legal quoted value and
+    /// pick what the library reports: a `filename="evil.exe name*=UTF-8''invoice.pdf"`
+    /// is one parameter naming `evil.exe …`, and reading its interior `name*=`
+    /// reports `invoice.pdf` instead. Anchoring also keeps `name` and `filename`
+    /// distinct attributes, so neither is found inside the other.
     static func extractHeaderParam(from header: String, named name: String) -> String? {
-        // Case-insensitive search for name=value or name="value"
-        let pattern = name + "="
-        guard let range = header.range(of: pattern, options: .caseInsensitive) else {
-            return nil
+        let attribute = name.lowercased()
+
+        for segment in parameterSegments(of: header) {
+            guard let equals = segment.firstIndex(of: "=") else { continue }
+            let candidate = segment[..<equals].trimmingCharacters(in: .whitespaces).lowercased()
+            guard candidate == attribute else { continue }
+
+            let value = String(segment[segment.index(after: equals)...])
+                .trimmingCharacters(in: .whitespaces)
+
+            // A quoted value ends at the first unescaped `"`; an unquoted value
+            // already ends at the segment's `;`. The quoted form is read with
+            // the same RFC 2045 quoted-pair rule the splitter used to find this
+            // segment — a `\` escapes the next character — and unescaped as it
+            // is read, so `"a\"b"` yields `a"b`.
+            if value.hasPrefix("\"") {
+                return unquote(value)
+            }
+
+            return value
         }
 
-        var value = String(header[range.upperBound...]).trimmingCharacters(in: .whitespaces)
-
-        // Remove quotes
-        if value.hasPrefix("\"") {
-            value.removeFirst()
-            if let endQuote = value.firstIndex(of: "\"") {
-                value = String(value[value.startIndex..<endQuote])
-            }
-        } else {
-            // Unquoted — take until semicolon or end
-            if let semi = value.firstIndex(of: ";") {
-                value = String(value[value.startIndex..<semi])
-            }
-            value = value.trimmingCharacters(in: .whitespaces)
-        }
-
-        return value
+        return nil
     }
 
-    /// Extract filename from Content-Type or Content-Disposition header.
-    static func extractFilename(from header: String) -> String? {
-        // Try filename* (RFC 5987 extended) first, then filename, then name
-        if let filename = extractHeaderParam(from: header, named: "filename*") {
-            // Strip encoding prefix like "UTF-8''filename.txt"
-            if let idx = filename.range(of: "''") {
-                let value = String(filename[idx.upperBound...])
-                return value.removingPercentEncoding ?? value
+    /// Read a MIME quoted-string, stopping at the first unescaped `"` and
+    /// unescaping each RFC 2045 quoted-pair (`\x` → `x`). `quoted` must begin
+    /// with the opening `"`.
+    private static func unquote(_ quoted: String) -> String {
+        var result = ""
+        var index = quoted.index(after: quoted.startIndex) // past the opening quote
+
+        while index < quoted.endIndex {
+            let character = quoted[index]
+            if character == "\\" {
+                let next = quoted.index(after: index)
+                guard next < quoted.endIndex else { break }
+                result.append(quoted[next])
+                index = quoted.index(after: next)
+            } else if character == "\"" {
+                break
+            } else {
+                result.append(character)
+                index = quoted.index(after: index)
             }
-            return filename
         }
 
-        return extractHeaderParam(from: header, named: "filename")
-            ?? extractHeaderParam(from: header, named: "name")
+        return result
+    }
+
+    /// The `filename`/`name` spellings a part's filename can be written as, in
+    /// the order they outrank each other. `true` selects the RFC 2231 extended
+    /// spelling (`filename*=`), `false` the literal one.
+    private static let filenameSpellings: [(attribute: String, extended: Bool)] = [
+        ("filename", true),
+        ("filename", false),
+        ("name", true),
+        ("name", false)
+    ]
+
+    /// Extract the filename from the headers that can carry one — a part's
+    /// Content-Type and Content-Disposition — given in the order the caller
+    /// considers them.
+    ///
+    /// Precedence is by ATTRIBUTE first and spelling second:
+    /// `filename*`, `filename`, `name*`, `name`.
+    ///
+    /// RFC 2183 §2.3 makes `filename` the parameter that names the file; `name`
+    /// is the deprecated Content-Type spelling, so `filename` outranks it in
+    /// either spelling. RFC 2231 §4 ranks only the two spellings of ONE
+    /// attribute — where a sender writes both, the encoded one carries the
+    /// characters the literal one could not — so `filename*` outranks
+    /// `filename` and `name*` outranks `name`, but neither extended spelling
+    /// reaches past the attribute above it. A `filename` that cannot be written
+    /// literally is emitted as `filename*=`, and the Content-Type `name` the
+    /// same way, so a serializer's own output reads back either way.
+    ///
+    /// The ranking is resolved across all of the headers together rather than
+    /// one header at a time: taking the first header that yields anything would
+    /// let a Content-Type `name*` win over a Content-Disposition `filename`,
+    /// which is the reverse of RFC 2183 §2.3.
+    static func extractFilename(from headers: String...) -> String? {
+        for spelling in filenameSpellings {
+            for header in headers {
+                let value = spelling.extended
+                    ? extractExtendedHeaderParam(from: header, named: spelling.attribute)
+                    : extractHeaderParam(from: header, named: spelling.attribute)
+                if let value {
+                    return value
+                }
+            }
+        }
+
+        return nil
+    }
+
+    /// Extract an RFC 2231 extended parameter (`name*=charset'language'value`)
+    /// and percent-decode its value. A single segment only — continuations
+    /// (`name*0*=`) are not read.
+    static func extractExtendedHeaderParam(from header: String, named name: String) -> String? {
+        guard let raw = extractHeaderParam(from: header, named: name + "*") else { return nil }
+        // Strip the encoding prefix, e.g. "UTF-8''filename.txt".
+        guard let separator = raw.range(of: "''") else { return raw }
+        let value = String(raw[separator.upperBound...])
+        return value.removingPercentEncoding ?? value
     }
 
     /// Extract the disposition type (e.g. "attachment", "inline") from Content-Disposition.

--- a/Sources/SwiftMail/MIME/EMLSerializer.swift
+++ b/Sources/SwiftMail/MIME/EMLSerializer.swift
@@ -132,26 +132,26 @@ public struct EMLSerializer {
     private static func serializePartHeaders(_ part: MessagePart) -> String {
         var headers = ""
 
-        var contentType = part.contentType
+        var contentType = MIMEHeaderEncoding.fieldBody(part.contentType)
         if let filename = part.filename {
-            contentType += "; name=\"\(filename)\""
+            contentType += "; " + MIMEHeaderEncoding.parameter(name: "name", value: filename)
         }
         headers += "Content-Type: \(contentType)\r\n"
 
         if let encoding = part.encoding {
-            headers += "Content-Transfer-Encoding: \(encoding)\r\n"
+            headers += "Content-Transfer-Encoding: \(MIMEHeaderEncoding.fieldBody(encoding))\r\n"
         }
 
         if let disposition = part.disposition {
-            var dispValue = disposition
+            var dispValue = MIMEHeaderEncoding.fieldBody(disposition)
             if let filename = part.filename {
-                dispValue += "; filename=\"\(filename)\""
+                dispValue += "; " + MIMEHeaderEncoding.parameter(name: "filename", value: filename)
             }
             headers += "Content-Disposition: \(dispValue)\r\n"
         }
 
         if let contentId = part.contentId {
-            headers += "Content-ID: <\(contentId)>\r\n"
+            headers += "Content-ID: <\(MIMEHeaderEncoding.fieldBody(contentId))>\r\n"
         }
 
         return headers

--- a/Sources/SwiftMail/MIME/MIMEHeaderEncoding.swift
+++ b/Sources/SwiftMail/MIME/MIMEHeaderEncoding.swift
@@ -1,0 +1,113 @@
+// MIMEHeaderEncoding.swift
+// Serialization of MIME header parameters and of the field bodies that carry
+// them. Used by every place the library writes a part header, so that a value
+// which cannot be written literally has exactly one treatment.
+
+import Foundation
+
+/// Writes MIME header parameters and header field bodies.
+///
+/// Values such as an attachment filename or a content type arrive from callers
+/// and, on the receive side, from remote senders. Interpolating them straight
+/// into a header line lets an embedded `"` close the quoted-string and start
+/// another parameter, and lets a CR or LF end the field and open a new one.
+enum MIMEHeaderEncoding {
+
+    /// Emit `name=value` for a MIME header parameter.
+    ///
+    /// A value that can be written literally inside a quoted-string is emitted
+    /// as `name="value"`, byte for byte as before. Anything else — an embedded
+    /// `"` or `\`, a control character, or non-ASCII text — is emitted as a
+    /// single RFC 2231 §4 extended parameter, `name*=UTF-8''<percent-encoded>`.
+    ///
+    /// Exactly one of the two forms is emitted, selected by the value; the two
+    /// are never emitted side by side, so a receiver has nothing to choose
+    /// between. The extended form is deliberately a single segment: RFC 2231 §3
+    /// continuations (`name*0*=`, `name*1*=`) would be legal but are far less
+    /// widely implemented, and the value has to survive one header line.
+    static func parameter(name: String, value: String) -> String {
+        guard value.unicodeScalars.allSatisfy(isSafeInQuotedString) else {
+            return "\(name)*=UTF-8''\(percentEncoded(value))"
+        }
+        return "\(name)=\"\(value)\""
+    }
+
+    /// Make `value` safe to interpolate into a header field body.
+    ///
+    /// RFC 5322 §2.2 limits a field body to printable US-ASCII plus SP and HTAB,
+    /// and a CR or LF *ends the field*, so anything after one is read as a new
+    /// header. Values that carry their own parameter syntax — a content type
+    /// such as `text/calendar; method=REQUEST`, a Content-ID — cannot be wrapped
+    /// in an encoded-word or an extended parameter without destroying that
+    /// syntax, so the scalars a field body cannot hold are removed instead.
+    ///
+    /// A value that is already a valid field body is returned unchanged, so this
+    /// only ever alters a value that could not have been emitted correctly.
+    static func fieldBody(_ value: String) -> String {
+        guard value.unicodeScalars.contains(where: isForbiddenInFieldBody) else { return value }
+        var scalars = String.UnicodeScalarView()
+        for scalar in value.unicodeScalars where !isForbiddenInFieldBody(scalar) {
+            scalars.append(scalar)
+        }
+        return String(scalars)
+    }
+
+    // MARK: - Predicates
+
+    /// Whether `scalar` can appear literally between the quotes of a MIME
+    /// parameter's quoted-string: printable US-ASCII, minus the `"` that would
+    /// close it and the `\` that would start a quoted-pair.
+    ///
+    /// Stricter than ``isForbiddenInFieldBody`` on one scalar, HTAB, and
+    /// deliberately: a parameter value has somewhere else to go — HTAB survives
+    /// exactly as `%09` in the extended form — whereas a field body that must
+    /// keep its own parameter syntax has no encoded form to fall back to and so
+    /// keeps HTAB literally, as the legal WSP it is. Rejecting it here also
+    /// avoids emitting whitespace a receiver unfolding the header may collapse.
+    private static func isSafeInQuotedString(_ scalar: Unicode.Scalar) -> Bool {
+        guard scalar.value >= 0x20, scalar.value < 0x7F else { return false }
+        return scalar != "\"" && scalar != "\\"
+    }
+
+    /// Whether `scalar` is one a header field body cannot carry literally: a C0
+    /// control, DEL, a C1 control, or non-ASCII text. HTAB is excluded — it is
+    /// WSP, which RFC 5322 §3.2.5 allows literally.
+    ///
+    /// Decided on the Unicode SCALAR, never on `Character`: CR-LF is a single
+    /// extended grapheme cluster, so `Character.isASCII` answers `true` for a
+    /// whole `\r\n` pair and cannot see it.
+    private static func isForbiddenInFieldBody(_ scalar: Unicode.Scalar) -> Bool {
+        if scalar.value == 0x09 { return false } // HTAB is legal WSP
+        return scalar.value < 0x20 || scalar.value >= 0x7F
+    }
+
+    // MARK: - RFC 2231 percent-encoding
+
+    /// RFC 2231 §7 `attribute-char`: any US-ASCII character except SPACE, the
+    /// controls, `*`, `'`, `%` and the RFC 2045 tspecials. Everything else is
+    /// percent-encoded from its UTF-8 bytes.
+    private static let attributeCharacters: Set<UInt8> = {
+        var allowed = Set<UInt8>()
+        allowed.formUnion(UInt8(ascii: "a")...UInt8(ascii: "z"))
+        allowed.formUnion(UInt8(ascii: "A")...UInt8(ascii: "Z"))
+        allowed.formUnion(UInt8(ascii: "0")...UInt8(ascii: "9"))
+        allowed.formUnion("!#$&+-.^_`{|}~".utf8)
+        return allowed
+    }()
+
+    private static let hexDigits = Array("0123456789ABCDEF".utf8)
+
+    private static func percentEncoded(_ value: String) -> String {
+        var encoded = ""
+        for byte in value.utf8 {
+            if attributeCharacters.contains(byte) {
+                encoded.unicodeScalars.append(Unicode.Scalar(byte))
+            } else {
+                encoded.unicodeScalars.append("%")
+                encoded.unicodeScalars.append(Unicode.Scalar(hexDigits[Int(byte >> 4)]))
+                encoded.unicodeScalars.append(Unicode.Scalar(hexDigits[Int(byte & 0x0F)]))
+            }
+        }
+        return encoded
+    }
+}

--- a/Tests/SwiftIMAPTests/EMLSerializerTests.swift
+++ b/Tests/SwiftIMAPTests/EMLSerializerTests.swift
@@ -195,3 +195,152 @@ struct EMLSerializerTests {
         #expect(str.contains("<p>HTML</p>"))
     }
 }
+
+/// MIME parameter and field-body serialization in ``EMLSerializer``. Every
+/// assertion is made on the serialized bytes, or on what ``EMLParser`` recovers
+/// from them.
+@Suite("EML Serializer parameter encoding", .serialized, .tags(.mime), .timeLimit(.minutes(1)))
+struct EMLSerializerParameterEncodingTests {
+
+    private static func message(
+        contentType: String = "application/pdf",
+        disposition: String? = "attachment",
+        filename: String?,
+        contentId: String? = nil
+    ) -> Message {
+        let header = MessageInfo(
+            sequenceNumber: SequenceNumber(0),
+            subject: "Parameters",
+            from: "sender@example.com",
+            to: ["recipient@example.com"]
+        )
+        let part = MessagePart(
+            section: Section([1]),
+            contentType: contentType,
+            disposition: disposition,
+            encoding: "base64",
+            filename: filename,
+            contentId: contentId,
+            data: Data("cGF5bG9hZA==".utf8)
+        )
+        return Message(header: header, parts: [part])
+    }
+
+    @Test("A quote in a part filename cannot forge a second parameter")
+    func filenameQuoteCannotForgeAParameter() throws {
+        let filename = #"a"; boundary="X.pdf"#
+        let reparsed = try Message(emlData: Self.message(filename: filename).emlData())
+
+        #expect(reparsed.parts.compactMap { $0.filename } == [filename])
+    }
+
+    @Test("A hostile part filename is emitted in exactly one spelling")
+    func hostileFilenameHasExactlyOneSpelling() throws {
+        let data = try Self.message(filename: #"a"; boundary="X.pdf"#).emlData()
+        let text = String(data: data, encoding: .utf8)!
+
+        // The extended spelling on both the Content-Type `name` and the
+        // Content-Disposition `filename`, and the literal spelling on neither:
+        // a receiver is never handed two candidate values to choose between.
+        #expect(text.contains(#"; name*=UTF-8''a%22%3B%20boundary%3D%22X.pdf"#))
+        #expect(text.contains(#"; filename*=UTF-8''a%22%3B%20boundary%3D%22X.pdf"#))
+        #expect(!text.contains(#"name=""#))
+        #expect(!text.contains(#"filename=""#))
+    }
+
+    @Test("A backslash in a part filename cannot start a quoted-pair")
+    func backslashInFilenameIsEncoded() throws {
+        let filename = #"report\final.pdf"#
+        let data = try Self.message(filename: filename).emlData()
+        let text = String(data: data, encoding: .utf8)!
+
+        #expect(text.contains(#"; filename*=UTF-8''report%5Cfinal.pdf"#))
+        #expect(!text.contains(#"filename=""#))
+        #expect(try Message(emlData: data).parts.compactMap { $0.filename } == [filename])
+    }
+
+    @Test("A semicolon in a part filename does not corrupt the stored content type")
+    func semicolonInFilenameDoesNotCorruptTheContentType() throws {
+        let filename = "a;b.pdf"
+        let data = try Self.message(filename: filename).emlData()
+        let text = String(data: data, encoding: .utf8)!
+        let reparsed = try Message(emlData: data)
+
+        // A `;` is legal between the quotes, so it stays literal on the wire —
+        // and the parameter it sits in is still one parameter on the way back.
+        #expect(text.contains(#"; name="a;b.pdf""#))
+        #expect(reparsed.parts.compactMap { $0.filename } == [filename])
+        #expect(reparsed.parts.map { $0.contentType } == ["application/pdf"])
+    }
+
+    @Test("A non-ASCII part filename does not put 8-bit octets in a header")
+    func nonASCIIFilenameStaysSevenBit() throws {
+        let filename = "발표자료.pdf"
+        let data = try Self.message(filename: filename).emlData()
+        let text = String(data: data, encoding: .utf8)!
+
+        #expect(text.unicodeScalars.allSatisfy { $0.isASCII })
+        #expect(try Message(emlData: data).parts.compactMap { $0.filename } == [filename])
+    }
+
+    @Test("An ordinary part filename is emitted exactly as before")
+    func ordinaryFilenameIsByteIdentical() throws {
+        let data = try Self.message(filename: "report.pdf").emlData()
+        let text = String(data: data, encoding: .utf8)!
+
+        #expect(text.contains(#"Content-Type: application/pdf; name="report.pdf""#))
+        #expect(text.contains(#"Content-Disposition: attachment; filename="report.pdf""#))
+        #expect(try Message(emlData: data).parts.compactMap { $0.filename } == ["report.pdf"])
+    }
+
+    @Test("A CRLF in a part content type cannot open a second header field")
+    func contentTypeCannotInjectAHeaderField() throws {
+        let message = Self.message(
+            contentType: "application/pdf\r\nBcc: attacker@example.com",
+            filename: "report.pdf"
+        )
+        let lines = String(data: try message.emlData(), encoding: .utf8)!.components(separatedBy: "\r\n")
+
+        #expect(!lines.contains { $0.lowercased().hasPrefix("bcc:") })
+        #expect(lines.filter { $0.lowercased().hasPrefix("content-type:") }.count == 1)
+    }
+
+    @Test("A CRLF in a part Content-ID cannot open a second header field")
+    func contentIdCannotInjectAHeaderField() throws {
+        let message = Self.message(
+            filename: "logo.png",
+            contentId: "logo@example.com>\r\nBcc: attacker@example.com"
+        )
+        let lines = String(data: try message.emlData(), encoding: .utf8)!.components(separatedBy: "\r\n")
+
+        #expect(!lines.contains { $0.lowercased().hasPrefix("bcc:") })
+        #expect(lines.filter { $0.hasPrefix("Content-ID: ") }.count == 1)
+    }
+
+    @Test("A CRLF in a part disposition cannot open a second header field")
+    func dispositionCannotInjectAHeaderField() throws {
+        let message = Self.message(
+            disposition: "attachment\r\nBcc: attacker@example.com",
+            filename: "report.pdf"
+        )
+        let lines = String(data: try message.emlData(), encoding: .utf8)!.components(separatedBy: "\r\n")
+
+        #expect(!lines.contains { $0.lowercased().hasPrefix("bcc:") })
+        #expect(lines.filter { $0.lowercased().hasPrefix("content-disposition:") }.count == 1)
+    }
+
+    @Test("A literal quote in a part filename round-trips through the extended form")
+    func embeddedQuoteFilenameRoundTrips() throws {
+        // The serializer never emits an RFC 2045 quoted-pair — a `"` is not safe
+        // in a quoted-string, so the name is written `name*=`/`filename*=` — and
+        // the parser recovers the literal quote, so the library reads back its
+        // own output without the reader's quoted-pair path ever being exercised.
+        let filename = #"a"b.pdf"#
+        let data = try Self.message(filename: filename).emlData()
+        let text = String(data: data, encoding: .utf8)!
+
+        #expect(text.contains(#"; filename*=UTF-8''a%22b.pdf"#))
+        #expect(!text.contains(#"filename=""#))
+        #expect(try Message(emlData: data).parts.compactMap { $0.filename } == [filename])
+    }
+}

--- a/Tests/SwiftIMAPTests/EMLTests.swift
+++ b/Tests/SwiftIMAPTests/EMLTests.swift
@@ -223,3 +223,160 @@ struct EMLParserTests {
         #expect(EMLParser.extractBoundary(from: ct3) == nil)
     }
 }
+
+/// Parameter extraction is anchored to parameter boundaries: an attribute is
+/// only an attribute where a parameter can start, never inside another
+/// parameter's quoted value. A sender chooses those values, so a substring
+/// match there is a sender-chosen parse.
+@Suite("MIME parameter parsing", .serialized, .tags(.mime), .timeLimit(.minutes(1)))
+struct MIMEParameterParsingTests {
+
+    @Test("An attribute inside a quoted value is not a parameter")
+    func quotedValueCannotForgeAParameter() {
+        // One legal parameter whose value happens to contain `name*=`. Reading
+        // that as an extended parameter reports `invoice.pdf"` for a file the
+        // sender named `evil.exe …`.
+        let header = #"attachment; filename="evil.exe name*=UTF-8''invoice.pdf""#
+
+        #expect(EMLParser.extractFilename(from: header) == #"evil.exe name*=UTF-8''invoice.pdf"#)
+    }
+
+    @Test("A boundary inside a quoted value is not the boundary")
+    func quotedValueCannotForgeABoundary() {
+        let contentType = #"multipart/mixed; name="x boundary=forged"; boundary=real"#
+
+        #expect(EMLParser.extractBoundary(from: contentType) == "real")
+    }
+
+    @Test("A semicolon inside a quoted filename does not split the content type")
+    func semicolonInQuotedValueDoesNotSplitTheContentType() {
+        let contentType = #"application/pdf; name="a;b.pdf"; charset=UTF-8"#
+
+        #expect(EMLParser.cleanContentType(contentType) == "application/pdf; charset=UTF-8")
+        #expect(EMLParser.extractFilename(from: contentType) == "a;b.pdf")
+    }
+
+    @Test("The extended spelling still wins over the literal one")
+    func extendedParameterKeepsPrecedence() {
+        let header = "attachment; filename=\"fallback.pdf\"; filename*=UTF-8''r%C3%A9sum%C3%A9.pdf"
+
+        #expect(EMLParser.extractFilename(from: header) == "résumé.pdf")
+    }
+
+    @Test("An extended name parameter reads back from a Content-Type")
+    func extendedNameParameterReadsBack() {
+        let contentType = "application/pdf; name*=UTF-8''%EB%B0%9C%ED%91%9C.pdf"
+
+        #expect(EMLParser.extractFilename(from: contentType) == "발표.pdf")
+        #expect(EMLParser.cleanContentType(contentType) == "application/pdf")
+    }
+
+    @Test("An extended name parameter still outranks a literal one")
+    func extendedNameOutranksLiteralName() {
+        // RFC 2231 §4, within ONE attribute: where a sender writes both
+        // spellings of `name`, the extended one carries the characters the
+        // literal one could not.
+        let contentType = "application/pdf; name=\"lit.pdf\"; name*=UTF-8''ext.pdf"
+
+        #expect(EMLParser.extractFilename(from: contentType) == "ext.pdf")
+    }
+
+    @Test("A literal filename outranks an extended name")
+    func literalFilenameOutranksExtendedName() {
+        // RFC 2183 §2.3 ranks the ATTRIBUTES: `filename` names the file, `name`
+        // is the deprecated Content-Type spelling. RFC 2231 §4 ranks only the
+        // two spellings of ONE attribute, so `name*` does not reach past
+        // `filename` — it is the deprecated attribute however it is spelled.
+        let header = "application/pdf; filename=\"lit.pdf\"; name*=UTF-8''ext.pdf"
+
+        #expect(EMLParser.extractFilename(from: header) == "lit.pdf")
+    }
+
+    @Test("A Content-Disposition filename outranks a Content-Type extended name")
+    func dispositionFilenameOutranksContentTypeExtendedName() throws {
+        // The attribute ranking has to hold across the two headers a part's
+        // filename can come from, not only within each of them: resolving the
+        // Content-Type to completion first would let its `name*` win over the
+        // Content-Disposition's `filename`, reversing RFC 2183 §2.3.
+        let filename = try attachmentFilename(
+            contentType: "application/pdf; name*=UTF-8''display.pdf",
+            disposition: "attachment; filename=\"real.pdf\""
+        )
+
+        #expect(filename == "real.pdf")
+    }
+
+    @Test("A Content-Disposition filename outranks a Content-Type literal name")
+    func dispositionFilenameOutranksContentTypeLiteralName() throws {
+        // Same ranking, neither parameter encoded. The two headers normally
+        // carry the same value — this library's own serializer writes them that
+        // way — so this only decides a part whose headers disagree, and RFC 2183
+        // §2.3 says the disagreement is settled by `filename`.
+        let filename = try attachmentFilename(
+            contentType: "application/pdf; name=\"display.pdf\"",
+            disposition: "attachment; filename=\"real.pdf\""
+        )
+
+        #expect(filename == "real.pdf")
+    }
+
+    // MARK: - RFC 2045 quoted-pairs
+
+    @Test("An escaped quote does not expose a quoted value's interior")
+    func escapedQuoteDoesNotExposeInteriorParameter() {
+        // `\"` is an escaped quote inside the value, so the quoted-string does
+        // not close until the final `"`: `name` is one parameter whose value is
+        // the whole literal, and there is no separate `name*` to be read.
+        let header = #"attachment; name="a\"; name*=UTF-8''evil.pdf""#
+
+        #expect(EMLParser.extractFilename(from: header) == #"a"; name*=UTF-8''evil.pdf"#)
+    }
+
+    @Test("An escaped quote does not expose a forged boundary")
+    func escapedQuoteDoesNotExposeForgedBoundary() {
+        let contentType = #"multipart/mixed; x="a\"; boundary=evil"; boundary=real"#
+
+        #expect(EMLParser.extractBoundary(from: contentType) == "real")
+    }
+
+    @Test("A quoted value's escaped quote is unescaped, not truncated")
+    func quotedPairIsUnescaped() {
+        // `filename="a\"b.pdf"` is the single value `a"b.pdf`.
+        let header = #"attachment; filename="a\"b.pdf""#
+
+        #expect(EMLParser.extractFilename(from: header) == #"a"b.pdf"#)
+    }
+
+    @Test("A value with no quoted-pair is returned byte-identically")
+    func ordinaryQuotedValueIsUnchanged() {
+        #expect(EMLParser.extractFilename(from: #"attachment; filename="report.pdf""#) == "report.pdf")
+    }
+
+    /// Parse a two-part multipart/mixed whose second part carries the given
+    /// headers, and return that part's resolved filename.
+    private func attachmentFilename(contentType: String, disposition: String) throws -> String? {
+        let eml = """
+        From: sender@example.com\r
+        To: recipient@example.com\r
+        Subject: Filename precedence\r
+        Content-Type: multipart/mixed; boundary="outer"\r
+        \r
+        --outer\r
+        Content-Type: text/plain; charset=UTF-8\r
+        \r
+        Message body here.\r
+        --outer\r
+        Content-Type: \(contentType)\r
+        Content-Disposition: \(disposition)\r
+        Content-Transfer-Encoding: base64\r
+        \r
+        SGVsbG8gV29ybGQ=\r
+        --outer--\r
+        """
+
+        let message = try Message(emlData: Data(eml.utf8))
+
+        try #require(message.parts.count == 2, "Expected 2 parts, got \(message.parts.count)")
+        return message.parts[1].filename
+    }
+}

--- a/Tests/SwiftSMTPTests/SMTPTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPTests.swift
@@ -2045,4 +2045,181 @@ struct SMTPTests {
         return offsets
     }
 }
-// swiftlint:enable file_length type_body_length
+// swiftlint:enable type_body_length
+
+/// MIME parameter and field-body serialization in ``Email/constructContent(use8BitMIME:)``.
+/// Every assertion is made on the final serialized bytes, or on what
+/// ``Message/init(emlData:)`` recovers from them.
+@Suite("MIME parameter encoding", .serialized, .timeLimit(.minutes(1)))
+struct MIMEParameterEncodingTests {
+
+    private static func email(
+        subject: String = "Attachments",
+        htmlBody: String? = nil,
+        attachments: [SwiftMail.Attachment]
+    ) -> Email {
+        Email(
+            sender: EmailAddress(address: "me@example.com"),
+            recipients: [EmailAddress(address: "you@example.com")],
+            subject: subject,
+            textBody: "body",
+            htmlBody: htmlBody,
+            attachments: attachments
+        )
+    }
+
+    private static func attachment(
+        filename: String,
+        mimeType: String = "application/pdf",
+        contentID: String? = nil,
+        isInline: Bool = false,
+        body: String = "attachment payload"
+    ) -> SwiftMail.Attachment {
+        SwiftMail.Attachment(
+            filename: filename,
+            mimeType: mimeType,
+            data: Data(body.utf8),
+            contentID: contentID,
+            isInline: isInline
+        )
+    }
+
+    // MARK: - Filename parameters
+
+    @Test("A quote in a filename cannot forge a second parameter")
+    func filenameQuoteCannotForgeAParameter() throws {
+        let filename = #"a"; boundary="X.pdf"#
+        let content = Self.email(attachments: [Self.attachment(filename: filename)]).constructContent()
+        let message = try Message(emlData: Data(content.utf8))
+
+        // Exactly one part carries a filename, and it is the caller's — not a
+        // prefix cut short at the embedded quote.
+        #expect(message.parts.compactMap { $0.filename } == [filename])
+    }
+
+    @Test("A non-ASCII filename does not put 8-bit octets in a header")
+    func nonASCIIFilenameStaysSevenBit() throws {
+        let filename = "발표자료.pdf"
+        let content = Self.email(attachments: [Self.attachment(filename: filename)]).constructContent()
+
+        // Subject, body and payload are all ASCII here, so the whole message
+        // must be 7-bit: RFC 5322 §2.2 admits nothing else in a header.
+        #expect(content.unicodeScalars.allSatisfy { $0.isASCII })
+
+        let message = try Message(emlData: Data(content.utf8))
+        #expect(message.parts.compactMap { $0.filename } == [filename])
+    }
+
+    @Test("A hostile filename is emitted in exactly one spelling")
+    func hostileFilenameHasExactlyOneSpelling() {
+        let content = Self.email(attachments: [
+            Self.attachment(filename: #"a"; boundary="X.pdf"#)
+        ]).constructContent()
+
+        // The extended spelling is present and the literal one is absent, so a
+        // receiver is never handed two candidate values to choose between.
+        #expect(content.contains(#"; filename*=UTF-8''a%22%3B%20boundary%3D%22X.pdf"#))
+        #expect(!content.contains(#"filename=""#))
+    }
+
+    @Test("A backslash in a filename cannot start a quoted-pair")
+    func backslashInFilenameIsEncoded() throws {
+        let filename = #"report\final.pdf"#
+        let content = Self.email(attachments: [Self.attachment(filename: filename)]).constructContent()
+
+        #expect(content.contains(#"; filename*=UTF-8''report%5Cfinal.pdf"#))
+        #expect(!content.contains(#"filename=""#))
+        #expect(try Message(emlData: Data(content.utf8)).parts.compactMap { $0.filename } == [filename])
+    }
+
+    @Test("An ordinary filename is emitted exactly as before")
+    func ordinaryFilenameIsByteIdentical() throws {
+        let content = Self.email(attachments: [Self.attachment(filename: "report.pdf")]).constructContent()
+
+        #expect(content.contains(#"Content-Disposition: attachment; filename="report.pdf""#))
+        let message = try Message(emlData: Data(content.utf8))
+        #expect(message.parts.compactMap { $0.filename } == ["report.pdf"])
+    }
+
+    @Test("A CRLF in an inline attachment filename cannot open a second header field")
+    func inlineFilenameCannotInjectAHeaderField() throws {
+        let filename = "logo\r\nBcc: attacker@example.com.png"
+        let email = Self.email(
+            htmlBody: "<p>hi</p>",
+            attachments: [Self.attachment(
+                filename: filename,
+                mimeType: "image/png",
+                contentID: "logo@example.com",
+                isInline: true
+            )]
+        )
+        let content = email.constructContent()
+
+        #expect(!content.components(separatedBy: "\r\n").contains { $0.lowercased().hasPrefix("bcc:") })
+        let message = try Message(emlData: Data(content.utf8))
+        #expect(message.parts.compactMap { $0.filename } == [filename])
+    }
+
+    // MARK: - Content-Type field bodies
+
+    @Test("A CRLF in an attachment content type cannot open a second header field")
+    func attachmentContentTypeCannotInjectAHeaderField() throws {
+        let email = Self.email(attachments: [Self.attachment(
+            filename: "a.txt",
+            mimeType: "text/plain\r\nBcc: attacker@example.com"
+        )])
+        let content = email.constructContent()
+
+        #expect(!content.components(separatedBy: "\r\n").contains { $0.lowercased().hasPrefix("bcc:") })
+        // The part structure is untouched: the text body and the attachment.
+        #expect(try Message(emlData: Data(content.utf8)).parts.count == 2)
+    }
+
+    @Test("A CRLF in a calendar invite content type cannot open a second header field")
+    func calendarContentTypeCannotInjectAHeaderField() {
+        let ics = "BEGIN:VCALENDAR\r\nVERSION:2.0\r\nEND:VCALENDAR\r\n"
+        let email = Self.email(attachments: [Self.attachment(
+            filename: "invite.ics",
+            mimeType: "text/calendar; method=REQUEST\r\nBcc: attacker@example.com",
+            body: ics
+        )])
+        let content = email.constructContent()
+        let lines = content.components(separatedBy: "\r\n")
+
+        // The invite still takes the multipart/alternative iMIP shape, so this
+        // exercises the calendar arm rather than falling back to base64.
+        #expect(content.contains("Content-Type: multipart/alternative;"))
+        #expect(!lines.contains { $0.lowercased().hasPrefix("bcc:") })
+    }
+
+    @Test("An ordinary content type is emitted exactly as before")
+    func ordinaryContentTypeIsByteIdentical() {
+        let content = Self.email(attachments: [Self.attachment(
+            filename: "a.txt",
+            mimeType: "text/plain; charset=windows-1252"
+        )]).constructContent()
+
+        #expect(content.contains("Content-Type: text/plain; charset=windows-1252\r\n"))
+    }
+
+    // MARK: - Content-ID
+
+    @Test("A CRLF in a Content-ID cannot open a second header field")
+    func contentIDCannotInjectAHeaderField() {
+        let email = Self.email(
+            htmlBody: "<p>hi</p>",
+            attachments: [Self.attachment(
+                filename: "logo.png",
+                mimeType: "image/png",
+                contentID: "logo@example.com>\r\nBcc: attacker@example.com",
+                isInline: true
+            )]
+        )
+        let lines = email.constructContent().components(separatedBy: "\r\n")
+
+        #expect(!lines.contains { $0.lowercased().hasPrefix("bcc:") })
+        #expect(lines.filter { $0.hasPrefix("Content-ID: ") }.count == 1)
+    }
+}
+
+// swiftlint:enable file_length


### PR DESCRIPTION
## Problem

Two halves of the same defect: the library writes MIME header parameters by string interpolation, and reads them back with a substring search. Both treat sender- or caller-chosen text as if it were grammar.

### Writing

Every place the library writes a part header interpolates the value directly:

```swift
contentType += "; name=\"\(filename)\""
dispValue   += "; filename=\"\(filename)\""
content     += "Content-Type: \(attachment.mimeType)\r\n"
content     += "Content-ID: <\(contentID)>\r\n"
```

`Attachment` and `MessagePart` store what the caller gave them verbatim and nothing validates in between, so:

- a `"` in a filename closes the quoted-string and the remainder is read as further parameters — a filename of `a"; boundary="X.pdf` rewrites the part's parameter list;
- a CR or LF in a filename, content type, disposition or Content-ID ends the field, and everything after it is read as new header fields (`Bcc:` of the attacker's choosing);
- a non-ASCII filename goes out as raw UTF-8 inside a quoted-string, which RFC 5322 §2.2 does not allow a header field body to carry.

There are **six** filename sites (two in `EMLSerializer.serializePartHeaders`, two in `Email.writeMultipartMixed`, two in `Email.writeHTMLWithInlineAttachments`) and **four** content-type sites, each hand-rolled.

### Reading

`EMLParser.extractHeaderParam` located a parameter by searching for `<name>=` as a plain substring, and `cleanContentType` split on every `;`. Neither knows the RFC 2045 §5.1 grammar, so structure placed inside a legal quoted value was obeyed:

```
multipart/mixed; name="x boundary=forged"; boundary=real
```

reported the boundary as `forged"` rather than `real` — a sender choosing how a multipart body is split. And `application/pdf; name="a;b.pdf"` was stored as the corrupt `application/pdf; b.pdf"`, because a `;` is perfectly legal between the quotes.

These halves are one PR because they are one round trip: the writer must emit an RFC 2231 extended parameter for values a quoted-string cannot carry, and the parser must read that spelling back, or the library cannot parse its own output.

## What changed

**Parser first** (commit 1), so each commit is correct on its own and the series bisects.

`parameterSegments(of:)` splits a field body into its top-level `;`-separated segments while tracking quoted-string state, and an attribute now matches only when it is the *whole* attribute of a segment. Both the splitter and the quoted-string value reader honour an RFC 2045 quoted-pair — inside the quotes a `\` makes the next character literal — so the two agree on where a value ends. If they did not, a parameter could be found in a segment whose value the reader then runs past: `attachment; name="a\"; name*=UTF-8''evil.pdf"` is *one* parameter whose value is the whole literal, and a splitter toggling on every `"` would re-open the split early and expose the interior `name*`.

`extractFilename` gains the RFC 2231 §4 extended spelling of `name` alongside the `filename*` it already decoded, and the resolution order is now written once as data, ranked by **attribute first and spelling second**: `filename*`, `filename`, `name*`, `name`. RFC 2183 §2.3 ranks the attributes — `filename` names the file, `name` is the deprecated Content-Type spelling. RFC 2231 §4 ranks only the two spellings of *one* attribute; it does not rank `name*` over `filename`. The order is resolved across both headers at once, because a per-header order cannot express a ranking between attributes living in different headers.

**Writer** (commit 2). All six filename sites go through one shared `MIMEHeaderEncoding.parameter(name:value:)`. A value that can be written literally inside a quoted-string is emitted as `name="value"`, byte for byte as before; anything else is emitted as a single RFC 2231 §4 extended parameter, `name*=UTF-8''<percent-encoded>`. **Exactly one of the two forms, selected by the value, never both**, so a receiver has nothing to choose between. The extended form is deliberately a single segment — RFC 2231 §3 continuations (`name*0*=`) are legal but far less widely implemented, and the value has to survive one header line.

The content-type, Content-ID, disposition and transfer-encoding values are different in kind: they legitimately carry their own parameter syntax (`text/calendar; method=REQUEST`, `charset=…`), so they cannot be wrapped in an extended parameter without destroying it. They go through `MIMEHeaderEncoding.fieldBody`, which removes the scalars RFC 5322 §2.2 excludes from a field body and returns an already-valid value unchanged.

> **A design question for you.** `fieldBody` *strips* the offending scalars. The stricter alternative is to reject the value, but that would make `constructContent()` throwing, so this PR takes the non-breaking option. If you would rather it throw, that is a one-commit change on top and I am happy to make it — it is your API compatibility call, not mine.

Membership in both predicates is decided on the Unicode **scalar**, never on `Character`: CR-LF is a single extended grapheme cluster, so `Character.isASCII` answers `true` for a whole `\r\n` pair and cannot see it. The two predicates disagree over HTAB deliberately, and the reason is documented at the point of disagreement — a parameter value has an encoded form to fall back to and round-trips HTAB exactly as `%09`, whereas a field body that must keep its own parameter syntax has none and keeps it as the legal WSP it is.

## Compatibility

**No public API change.** `MIMEHeaderEncoding` is internal; `EMLParser.extractFilename(from:)` becomes variadic to take both headers, but it too is internal. No public signature, access level or type is altered, so this is source-compatible including for function values.

Output is **byte-identical** for every value that could already be emitted correctly — pinned by four non-vacuity tests rather than asserted.

One deliberate **receive-side behaviour** change, stated plainly:

> A part whose Content-Type and Content-Disposition carry **different** filenames now resolves to the disposition's `filename`, where it previously resolved to the Content-Type's `name`.

That is the same RFC 2183 §2.3 ranking rather than a second rule, and it can only decide a part whose two headers disagree. Where they agree — the ordinary case, and what this library's own serializer emits — there is no difference.

## Tests

33 tests added, asserted on the final serialized bytes and on what `Message(emlData:)` recovers from them, never on the encoder in isolation. Red-first was measured, not assumed:

| commit | added | red against the parent | green guard / twin |
|---|---|---|---|
| Anchor MIME parameter parsing… | 13 | **8** | 5 |
| Encode MIME parameters… | 20 | **16** | 4 |

The parser reds are the forged boundary, the corrupt content type, the two escaped-quote spoofs, the value truncated at its quoted-pair, the cross-header ranking, and the two `name*` cases (red because the spelling had no support at all, not because it was mis-handled). The writer reds are the forged-parameter filename coming back as `"a"`, the Korean filename putting 8-bit octets in a header, and a CRLF in a filename, content type, calendar content type, disposition or Content-ID producing a `Bcc:` line.

The green ones are the reason to trust the rest. On the parser side they hold the attribute ranking from *both* directions, so the two precedence rules cannot be collapsed into one, and one of them is precisely why the extended spelling can be added safely: an attribute inside a quoted value must not be read as a parameter — something the base satisfied only by accident, because it could not decode `name*` anywhere. On the writer side an ordinary filename, an ordinary part filename, `text/plain; charset=windows-1252`, and a `;` inside a quoted filename all stay byte-identical.

Coverage deliberately includes sites reachable only through the library's own API and not through any one caller's path — the `writeHTMLWithInlineAttachments` inline-attachment `name`/`filename` pair and both Content-ID sites — so the whole surface is pinned rather than the parts one application happens to exercise.

## Validation

- `swift test` — **528 tests in 65 suites passed** (up from 495 in 62 on `main`)
- `swift test -c release` — **528 tests in 65 suites passed**
- `swift build` — no warnings in `Sources/SwiftMail`; the two `Demos` `LogHandler` deprecations are pre-existing and untouched
- `swiftlint lint --strict` — 0 violations across the changed files
- Branched from `a2d4a94`, re-confirmed as `main` immediately before opening this PR

## Deliberately left out

Kept out so this PR stays one concern; happy to follow up:

- **`Email.writeHeaders` interpolates caller-supplied `additionalHeaders` raw** — `content += "\(key): \(value)\r\n"`, neither key nor value validated. The remedy is a validation decision on arbitrary header names rather than encoding, so it needs an API call from you.
- **RFC 2231 §3 continuations** for parameter values too long for one line — the writer emits a single segment and the reader accepts a single segment. Worth doing if you want long non-ASCII filenames folded rather than carried on one line.
- **`MessageID` components** and a CR/LF in `EmailAddress.address`, both of which reach the top-level header block by the same interpolation.

Boundaries are *not* on this list: every one is library-generated (`UUID().uuidString` / `generateBoundary()`), so no caller or remote sender can steer them.

## Note

This is one of a pair with #215, which fixes the RFC 2047 encoder and the address display-name formatter for the same class of defect in the *top-level* header block. The two share no files and can be reviewed and merged in either order.
