### PR TITLE
[WIP] Avoid calling ProcessInfo.processInfo.hostName for privacy fix

### DIFF
--- a/Sources/SwiftMail/SMTP/Commands/EHLOCommand.swift
+++ b/Sources/SwiftMail/SMTP/Commands/EHLOCommand.swift
@@ -14,17 +14,28 @@ struct EHLOCommand: SMTPCommand {
     /// Timeout in seconds for EHLO command (typically quick to respond)
     let timeoutSeconds: Int = 30
 
-    /// The hostname to use for the EHLO command
-    let hostname: String
+    /// The client identity to use for the EHLO command
+    let clientIdentity: String
 
     /// Initialize a new EHLO command
-    /// - Parameter hostname: The hostname to use for the EHLO command
-    init(hostname: String) {
-        self.hostname = hostname
+    /// - Parameter clientIdentity: The RFC 5321 domain or address literal to use for the EHLO command
+    init(clientIdentity: String) {
+        self.clientIdentity = clientIdentity
     }
 
     /// Convert the command to a string that can be sent to the server
     func toCommandString() -> String {
-        return "EHLO \(hostname)"
+        return "EHLO \(clientIdentity)"
+    }
+
+    /// Reject malformed identities before they can alter the SMTP command stream.
+    func validate() throws {
+        let bytes = clientIdentity.utf8
+        guard (1...255).contains(bytes.count),
+            bytes.allSatisfy({ (33...126).contains($0) }) else {
+            throw SMTPError.commandFailed(
+                "EHLO client identity must be 1...255 printable ASCII characters without whitespace"
+            )
+        }
     }
 }

--- a/Sources/SwiftMail/SMTP/SMTPServer+Capabilities.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer+Capabilities.swift
@@ -26,7 +26,7 @@ extension SMTPServer {
 
     @discardableResult
     func fetchCapabilities(holding permit: SMTPOperationGate.Permit) async throws -> [String] {
-        let command = EHLOCommand(hostname: ProcessInfo.processInfo.hostName)
+        let command = EHLOCommand(clientIdentity: clientIdentity)
 
         do {
             let response = try await executeCommand(command, holding: permit)

--- a/Sources/SwiftMail/SMTP/SMTPServer+Connection.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer+Connection.swift
@@ -201,6 +201,11 @@ extension SMTPServer {
                 } else {
                     try await startTLS(holding: permit)
                 }
+
+                // RFC 3207 resets the SMTP protocol state after STARTTLS. Use
+                // the same stored client identity when establishing the new
+                // EHLO state and refreshing the encrypted capabilities.
+                try await fetchCapabilities(holding: permit)
             } catch {
                 let failureMessage = "STARTTLS failed for \(host):\(port): \(error.localizedDescription). "
                     + "Cannot continue without encryption."
@@ -335,8 +340,8 @@ extension SMTPServer {
      Upgrade the connection to use TLS
 
      This method upgrades a plain connection to use TLS encryption using the
-     STARTTLS command. After successful upgrade, it re-fetches server capabilities
-     as they may change.
+     STARTTLS command. The caller re-fetches server capabilities after a successful
+     upgrade, as they may change.
 
      - Throws:
        - `SMTPError.tlsFailed` if TLS negotiation fails
@@ -378,15 +383,5 @@ extension SMTPServer {
 
         // Set TLS flag
         isTLSEnabled = true
-
-        // Send EHLO again after STARTTLS and update capabilities
-        let ehloCommand = EHLOCommand(hostname: ProcessInfo.processInfo.hostName)
-        let rawResponse = try await executeCommand(ehloCommand, holding: permit)
-
-        // Parse capabilities from raw response
-        let capabilities = parseCapabilities(from: rawResponse)
-
-        // Store capabilities for later use
-        self.capabilities = capabilities
     }
 }

--- a/Sources/SwiftMail/SMTP/SMTPServer.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer.swift
@@ -56,11 +56,21 @@ public actor SMTPServer {
 
     // MARK: - Properties
 
+    /// The privacy-safe identity used by default in SMTP `EHLO` commands.
+    ///
+    /// RFC 5321 permits an address literal when a client has no stable,
+    /// fully-qualified hostname. This loopback literal requires no hostname,
+    /// DNS, Bonjour, or local-network lookup.
+    public static let defaultClientIdentity = "[127.0.0.1]"
+
     /** The hostname of the SMTP server */
     let host: String
 
     /** The port number of the SMTP server */
     let port: Int
+
+    /// The domain or address literal sent as the client identity in every `EHLO` command.
+    public let clientIdentity: String
 
     /** The requested SMTP transport security policy */
     let transportSecurity: MailTransportSecurity
@@ -150,6 +160,10 @@ public actor SMTPServer {
        - certificateVerificationPolicy: The certificate verification policy to use for TLS connections
        - numberOfThreads: The number of threads to use for the event loop group
        - submissionTimeouts: Timeout budgets for the SMTP mail-submission dialogue
+       - clientIdentity: The RFC 5321 domain or address literal sent in `EHLO` commands. The
+         lookup-free default is ``SMTPServer/defaultClientIdentity``. A configured value is
+         sent before TLS as well as after STARTTLS, so it should not contain private device
+         information.
 
      `.automatic` infers the initial security mode from the port:
      - Port 25: Plain SMTP (not recommended)
@@ -166,10 +180,12 @@ public actor SMTPServer {
         certificateVerificationPolicy: MailCertificateVerificationPolicy = .fullVerification,
         minimumTLSVersion: MailTLSMinimumVersion = .tlsv12,
         numberOfThreads: Int = 1,
-        submissionTimeouts: SMTPSubmissionTimeouts = SMTPSubmissionTimeouts()
+        submissionTimeouts: SMTPSubmissionTimeouts = SMTPSubmissionTimeouts(),
+        clientIdentity: String = SMTPServer.defaultClientIdentity
     ) {
         self.host = host
         self.port = port
+        self.clientIdentity = clientIdentity
         self.transportSecurity = transportSecurity
         self.certificateVerificationPolicy = certificateVerificationPolicy
         self.minimumTLSVersion = minimumTLSVersion

--- a/Sources/SwiftMail/SwiftMail.docc/Articles/GettingStartedWithSMTP.md
+++ b/Sources/SwiftMail/SwiftMail.docc/Articles/GettingStartedWithSMTP.md
@@ -21,6 +21,30 @@ Common SMTP ports:
 - 465: SSL/TLS
 - 25: Unencrypted (not recommended)
 
+## Configuring the EHLO Client Identity
+
+SMTP begins a session by sending a client identity with `EHLO`. SwiftMail
+defaults to the RFC 5321 address literal `[127.0.0.1]`, which requires no
+hostname, Bonjour, DNS, or local-network lookup and does not disclose the
+device's name.
+
+If your SMTP provider expects a stable, fully-qualified domain name, configure
+one explicitly:
+
+```swift
+let smtpServer = SMTPServer(
+    host: "smtp.example.com",
+    port: 587,
+    clientIdentity: "mail.example.com"
+)
+```
+
+SwiftMail uses the configured value for the initial `EHLO` and again after a
+STARTTLS upgrade. Because the initial command can be sent before encryption,
+do not put private device or user information in this value. The identity must
+be a single printable ASCII domain or address literal as defined by
+[RFC 5321](https://www.rfc-editor.org/rfc/rfc5321.html#section-4.1.1.1).
+
 ## Configuring Submission Timeouts
 
 SwiftMail uses separate timeout budgets for the SMTP command replies, message

--- a/Tests/SwiftSMTPTests/SMTPTransportSecurityTests.swift
+++ b/Tests/SwiftSMTPTests/SMTPTransportSecurityTests.swift
@@ -6,6 +6,114 @@ import Testing
 
 @Suite(.serialized, .timeLimit(.minutes(1)))
 struct SMTPTransportSecurityTests {
+    private func captureEHLOCommand(
+        from channel: NIOAsyncTestingChannel,
+        while operation: @escaping @Sendable () async throws -> Void
+    ) async throws -> String {
+        let operationTask = Task {
+            try await operation()
+        }
+
+        for _ in 0..<200 {
+            if var outbound = try await channel.readOutbound(as: ByteBuffer.self) {
+                let command = outbound.readString(length: outbound.readableBytes) ?? ""
+                try await channel.writeInbound(
+                    SMTPResponse(
+                        code: 250,
+                        message: "250-smtp.test greets you\n250 STARTTLS"
+                    )
+                )
+                try await operationTask.value
+                return command
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+
+        operationTask.cancel()
+        try? await channel.close().get()
+        _ = await operationTask.result
+        throw SMTPError.connectionFailed("Expected an outbound EHLO command")
+    }
+
+    private func ehloCommandsAcrossSTARTTLS(clientIdentity: String) async throws -> [String] {
+        let server = SMTPServer(
+            host: "smtp.example.com",
+            port: 587,
+            clientIdentity: clientIdentity
+        )
+        let channel = NIOAsyncTestingChannel()
+        let address = try SocketAddress(ipAddress: "127.0.0.1", port: 587)
+        try await channel.connect(to: address)
+        await server.replaceChannelForTesting(channel)
+
+        let initialCommand = try await captureEHLOCommand(from: channel) {
+            _ = try await server.fetchCapabilities()
+        }
+        let postSTARTTLSCommand = try await captureEHLOCommand(from: channel) {
+            // Isolate the SMTP state transition from the TLS byte transport.
+            // Production performs this same capability refresh after installing TLS.
+            try await server.applyPostEHLOTLSPolicy(
+                transportMode: .startTLSRequired,
+                capabilities: ["STARTTLS"],
+                startTLSOverrideForTesting: {}
+            )
+        }
+
+        await server.replaceChannelForTesting(nil)
+        try await channel.close().get()
+        return [initialCommand, postSTARTTLSCommand]
+    }
+
+    @Test
+    func smtpServerUsesPrivacySafeDefaultClientIdentity() async {
+        let server = SMTPServer(host: "smtp.example.com", port: 587)
+
+        #expect(await server.clientIdentity == SMTPServer.defaultClientIdentity)
+        #expect(SMTPServer.defaultClientIdentity == "[127.0.0.1]")
+    }
+
+    @Test
+    func smtpServerStoresConfiguredClientIdentity() async {
+        let server = SMTPServer(
+            host: "smtp.example.com",
+            port: 587,
+            clientIdentity: "mail.example.com"
+        )
+
+        #expect(await server.clientIdentity == "mail.example.com")
+    }
+
+    @Test
+    func defaultClientIdentityIsUsedBeforeAndAfterSTARTTLS() async throws {
+        let commands = try await ehloCommandsAcrossSTARTTLS(
+            clientIdentity: SMTPServer.defaultClientIdentity
+        )
+
+        #expect(commands == [
+            "EHLO [127.0.0.1]\r\n",
+            "EHLO [127.0.0.1]\r\n"
+        ])
+    }
+
+    @Test
+    func configuredClientIdentityIsUsedBeforeAndAfterSTARTTLS() async throws {
+        let commands = try await ehloCommandsAcrossSTARTTLS(clientIdentity: "mail.example.com")
+
+        #expect(commands == [
+            "EHLO mail.example.com\r\n",
+            "EHLO mail.example.com\r\n"
+        ])
+    }
+
+    @Test
+    func clientIdentityRejectsSMTPCommandInjection() {
+        let command = EHLOCommand(clientIdentity: "mail.example.com\r\nNOOP")
+
+        #expect(throws: SMTPError.self) {
+            try command.validate()
+        }
+    }
+
     @Test
     func smtpServerDefaultsToFullCertificateVerification() async {
         let server = SMTPServer(host: "smtp.example.com", port: 587)


### PR DESCRIPTION
Calling `ProcessInfo.processInfo.hostName` triggers a privacy confirmation asking for access to local networks. This breaks SMTP for sending emails if you decline the permission when the prompt shows up.


- Replace hostname lookup in EHLO with a privacy-safe [127.0.0.1] default, avoiding local-network access and device-name disclosure.
- Add configurable, validated clientIdentity support, reused before and after STARTTLS.
- Document the new behavior and add tests for defaults, customization, STARTTLS reuse, and command-injection prevention.


Still trying to improve things.