### PR TITLE
Add validated partial IMAP body part fetching

### DIFF
--- a/Sources/SwiftMail/Core/Logging/MailLogger.swift
+++ b/Sources/SwiftMail/Core/Logging/MailLogger.swift
@@ -8,6 +8,9 @@ import NIOIMAP
 
 /// Base class for mail protocol loggers
 class MailLogger: ChannelDuplexHandler, @unchecked Sendable {
+    static let maximumInboundBufferEntries = 256
+    static let maximumInboundBufferBytes = 64 * 1024
+
     // Type definitions
     typealias OutboundIn = Any
     typealias OutboundOut = Any
@@ -23,6 +26,8 @@ class MailLogger: ChannelDuplexHandler, @unchecked Sendable {
 
     // Make inboundBuffer accessible for modification by subclasses
     var inboundBuffer: [String] = []
+    private(set) var inboundBufferByteCount = 0
+    private(set) var droppedInboundResponseCount = 0
 
     /// Initialize a new mail logger
     /// - Parameters:
@@ -36,17 +41,30 @@ class MailLogger: ChannelDuplexHandler, @unchecked Sendable {
     /// Add a response to the inbound buffer
     func bufferInboundResponse(_ message: String) {
         lock.withLock {
+            let byteCount = message.utf8.count
+            guard inboundBuffer.count < Self.maximumInboundBufferEntries,
+                  byteCount <= Self.maximumInboundBufferBytes - inboundBufferByteCount else {
+                droppedInboundResponseCount += 1
+                return
+            }
             inboundBuffer.append(message)
+            inboundBufferByteCount += byteCount
         }
     }
 
     /// Flush the inbound buffer
     func flushInboundBuffer() {
         lock.withLock {
-            if !inboundBuffer.isEmpty {
-                let lines = inboundBuffer.joined(separator: ", ")
+            if !inboundBuffer.isEmpty || droppedInboundResponseCount > 0 {
+                var lines = inboundBuffer.joined(separator: ", ")
+                if droppedInboundResponseCount > 0 {
+                    let omission = "<\(droppedInboundResponseCount) responses omitted>"
+                    lines = lines.isEmpty ? omission : "\(lines), \(omission)"
+                }
                 inboundLogger.trace(Logger.Message(stringLiteral: lines))
                 inboundBuffer.removeAll()
+                inboundBufferByteCount = 0
+                droppedInboundResponseCount = 0
             }
         }
     }
@@ -54,7 +72,7 @@ class MailLogger: ChannelDuplexHandler, @unchecked Sendable {
     /// Check if there are buffered messages
     func hasBufferedMessages() -> Bool {
         lock.withLock {
-            return !inboundBuffer.isEmpty
+            return !inboundBuffer.isEmpty || droppedInboundResponseCount > 0
         }
     }
 

--- a/Sources/SwiftMail/IMAP/IMAP/Commands/FetchCommands.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/FetchCommands.swift
@@ -101,6 +101,9 @@ struct FetchMessagePartCommand<T: MessageIdentifier>: IMAPTaggedCommand {
     /// The section path to fetch (e.g., [1], [1, 1], [2], etc.)
     let section: Section
 
+    /// Optional encoded-byte range for a partial body fetch.
+    let range: ClosedRange<UInt32>?
+
     /// Custom timeout for this operation
     var timeoutSeconds: Int { return 60 }
 
@@ -108,9 +111,29 @@ struct FetchMessagePartCommand<T: MessageIdentifier>: IMAPTaggedCommand {
     /// - Parameters:
     ///   - identifier: The message identifier to fetch
     ///   - sectionPath: The section path to fetch as an array of integers
-    init(identifier: T, section: Section) {
+    init(identifier: T, section: Section, range: ClosedRange<UInt32>? = nil) {
         self.identifier = identifier
         self.section = section
+        self.range = range
+    }
+
+    func makeHandler(commandTag: String, promise: EventLoopPromise<Data>) -> FetchPartHandler {
+        guard let range else {
+            return FetchPartHandler(commandTag: commandTag, promise: promise)
+        }
+        let expectedIdentifier: PartialFetchIdentifier = T.self == UID.self
+            ? .uid(identifier.value)
+            : .sequenceNumber(identifier.value)
+        return FetchPartHandler(
+            commandTag: commandTag,
+            promise: promise,
+            partialRequest: .init(
+                identifier: expectedIdentifier,
+                section: SectionSpecifier(part: .init(section.components)),
+                offset: Int(range.lowerBound),
+                count: range.count
+            )
+        )
     }
 
     /// Convert to an IMAP tagged command
@@ -124,7 +147,7 @@ struct FetchMessagePartCommand<T: MessageIdentifier>: IMAPTaggedCommand {
         let section = SectionSpecifier(part: part)
 
         let attributes: [FetchAttribute] = [
-            .bodySection(peek: true, section, nil)
+            .bodySection(peek: true, section, range)
         ]
 
         if T.self == UID.self {

--- a/Sources/SwiftMail/IMAP/IMAP/Commands/IMAPCommand.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/IMAPCommand.swift
@@ -22,6 +22,13 @@ protocol IMAPCommand where ResultType: Sendable {
 
     /// Send the command to the server.
     func send(on channel: Channel, tag: String) async throws
+
+    /// Build the response handler. Commands with request-specific validation
+    /// may override the default implementation.
+    func makeHandler(
+        commandTag: String,
+        promise: EventLoopPromise<ResultType>
+    ) -> HandlerType
 }
 
 /// A command that can be represented as a tagged IMAP command.
@@ -36,6 +43,13 @@ extension IMAPCommand {
 
     func validate() throws {
         // Default implementation does no validation
+    }
+
+    func makeHandler(
+        commandTag: String,
+        promise: EventLoopPromise<ResultType>
+    ) -> HandlerType {
+        HandlerType(commandTag: commandTag, promise: promise)
     }
 }
 

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/FetchPartHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/FetchPartHandler.swift
@@ -5,99 +5,241 @@ import Foundation
 @preconcurrency import NIOIMAP
 import NIOIMAPCore
 import NIO
-import NIOConcurrencyHelpers
 
-/// Handler for IMAP FETCH PART command
+enum PartialFetchIdentifier: Sendable {
+    case uid(UInt32)
+    case sequenceNumber(UInt32)
+}
+
+struct PartialFetchRequest: Sendable {
+    let identifier: PartialFetchIdentifier
+    let section: SectionSpecifier
+    let offset: Int
+    let count: Int
+}
+
+/// Handler for full and validated partial IMAP FETCH PART commands.
 final class FetchPartHandler: BaseIMAPCommandHandler<Data>, IMAPCommandHandler, @unchecked Sendable {
-    /// Collected message part data
-    private var partData: Data = Data()
-
-    private var parts: [MessagePart]?
-
-    /// Expected byte count for the streaming data
-    private var expectedByteCount: Int?
-
-    /// Sequence number we are currently collecting for
-    private var currentSequence: SequenceNumber?
-
-    /// Whether we've already finished collecting our requested part
+    private let partialRequest: PartialFetchRequest?
+    private var partData = Data()
     private var didFinishPart = false
 
-    /// Handle a tagged OK response by succeeding the promise with the collected data
-    /// - Parameter response: The tagged response
+    // Partial-response state. A UID may follow the literal, so validation is
+    // finalized only when the current FETCH group finishes.
+    private var currentSequence: UInt32?
+    private var currentUID: UInt32?
+    private var currentIncludesExpectedUID = false
+    private var currentData = Data()
+    private var currentDeclaredCount: Int?
+    private var currentBodyCount = 0
+    private var currentError: PartialFetchError?
+    private var collectingBody = false
+    private var matchedCount = 0
+    private var sawBodyGroup = false
+    private var sawMatchingGroup = false
+    private var validationError: PartialFetchError?
+
+    override init(commandTag: String, promise: EventLoopPromise<Data>) {
+        self.partialRequest = nil
+        super.init(commandTag: commandTag, promise: promise)
+    }
+
+    init(
+        commandTag: String,
+        promise: EventLoopPromise<Data>,
+        partialRequest: PartialFetchRequest
+    ) {
+        self.partialRequest = partialRequest
+        super.init(commandTag: commandTag, promise: promise)
+    }
+
     override func handleTaggedOKResponse(_ response: TaggedResponse) {
-        // Call super to handle CLIENTBUG warnings
         super.handleTaggedOKResponse(response)
-
-        // Succeed with the collected data
-        let collectedPartData = lock.withLock { self.partData }
-        succeedWithResult(collectedPartData)
-    }
-
-    /// Handle a tagged error response
-    /// - Parameter response: The tagged response
-    override func handleTaggedErrorResponse(_ response: TaggedResponse) {
-        failWithError(IMAPError.fetchFailed(String(describing: response.state)))
-    }
-
-    /// Process an incoming response
-    /// - Parameter response: The response to process
-    /// - Returns: Whether the response was handled by this handler
-    override func processResponse(_ response: Response) -> Bool {
-        // Call the base class implementation to buffer the response
-        let handled = super.processResponse(response)
-
-        // Process fetch responses
-        if case .fetch(let fetchResponse) = response {
-            processFetchResponse(fetchResponse)
+        guard partialRequest != nil else {
+            succeedWithResult(lock.withLock { partData })
+            return
         }
-
-        // Return the result from the base class
-        return handled
+        let result: Result<Data, PartialFetchError> = lock.withLock {
+            if let validationError { return .failure(validationError) }
+            guard matchedCount == 1 else {
+                if sawMatchingGroup || sawBodyGroup {
+                    return .failure(.invalidResponse("missing or ambiguous requested body"))
+                }
+                return .failure(.messageNotFound)
+            }
+            return .success(partData)
+        }
+        switch result {
+            case .success(let data): succeedWithResult(data)
+            case .failure(let error): failWithError(error)
+        }
     }
 
-    /// Process a fetch response. Hoist the `didFinishPart` guard above the
-    /// switch so each case stays single-purpose.
-    /// - Parameter fetchResponse: The fetch response to process
-    private func processFetchResponse(_ fetchResponse: FetchResponse) {
+    override func handleTaggedErrorResponse(_ response: TaggedResponse) {
+        if partialRequest != nil, case .bad = response.state {
+            failWithError(PartialFetchError.serverRejected)
+        } else {
+            failWithError(IMAPError.fetchFailed(String(describing: response.state)))
+        }
+    }
+
+    override func processResponse(_ response: Response) -> Bool {
+        guard case .fetch(let fetchResponse) = response else {
+            return super.processResponse(response)
+        }
+        if partialRequest != nil {
+            return lock.withLock {
+                processPartialFetchResponse(fetchResponse)
+                return isCompleted
+            }
+        } else {
+            _ = super.processResponse(response)
+            processFullFetchResponse(fetchResponse)
+        }
+        return false
+    }
+
+    override func handleUntaggedResponse(_ response: Response) -> Bool {
+        guard partialRequest != nil else { return super.handleUntaggedResponse(response) }
+        // Keep only connection-termination responses. Retaining streaming FETCH
+        // events in the base history would defeat the requested byte bound.
+        if case .untagged(.conditionalState(.bye)) = response {
+            return super.handleUntaggedResponse(response)
+        }
+        if case .fatal = response { return super.handleUntaggedResponse(response) }
+        return false
+    }
+
+    private func processFullFetchResponse(_ response: FetchResponse) {
         guard !didFinishPart else { return }
-        switch fetchResponse {
-            case .start(let seq):
-                currentSequence = SequenceNumber(seq.rawValue)
-                lock.withLock { self.partData.removeAll(keepingCapacity: true) }
-
-            case .simpleAttribute(let attribute):
-                processMessageAttribute(attribute)
-
-            case .streamingBegin(_, let byteCount):
-                expectedByteCount = byteCount
-
+        switch response {
+            case .start:
+                lock.withLock { partData.removeAll(keepingCapacity: true) }
             case .streamingBytes(let data):
-                lock.withLock {
-                    self.partData.append(Data(data.readableBytesView))
-                }
-
+                lock.withLock { partData.append(contentsOf: data.readableBytesView) }
             case .finish:
                 didFinishPart = true
-
             default:
                 break
         }
     }
 
-    /// Process a message attribute
-    /// - Parameter attribute: The attribute to process
-    private func processMessageAttribute(_ attribute: MessageAttribute) {
-        switch attribute {
-            case .body(let bodyStructure, _):
-                if case .valid(let structure) = bodyStructure {
-                    lock.withLock {
-                        self.parts = .init(structure)
-                    }
-                }
+    private func processPartialFetchResponse(_ response: FetchResponse) {
+        guard let request = partialRequest else { return }
+        switch response {
+            case .start(let sequence):
+                resetCurrentGroup()
+                currentSequence = sequence.rawValue
+            case .startUID(let uid):
+                resetCurrentGroup()
+                recordUID(uid.rawValue, request: request)
+            case .simpleAttribute(let attribute):
+                processPartialAttribute(attribute, request: request)
+            case .streamingBegin(let kind, let count):
+                beginBody(kind: kind, declaredCount: count, request: request)
+            case .streamingBytes(let bytes):
+                appendPartialBytes(bytes, request: request)
+            case .streamingEnd:
+                collectingBody = false
+            case .finish:
+                finishCurrentGroup(request: request)
+                resetCurrentGroup()
+        }
+    }
 
+    private func processPartialAttribute(_ attribute: MessageAttribute, request: PartialFetchRequest) {
+        switch attribute {
+            case .uid(let uid):
+                recordUID(uid.rawValue, request: request)
+            case .nilBody(let kind):
+                beginBody(kind: kind, declaredCount: 0, request: request)
+                currentError = .invalidResponse("requested body section was NIL")
             default:
                 break
         }
+    }
+
+    private func recordUID(_ uid: UInt32, request: PartialFetchRequest) {
+        if case .uid(let expected) = request.identifier, uid == expected {
+            currentIncludesExpectedUID = true
+        }
+        guard let currentUID else {
+            self.currentUID = uid
+            return
+        }
+        if currentUID != uid {
+            currentError = .invalidResponse("conflicting UID attributes")
+        }
+    }
+
+    private func appendPartialBytes(_ bytes: ByteBuffer, request: PartialFetchRequest) {
+        guard collectingBody else { return }
+        guard bytes.readableBytes <= request.count - currentData.count else {
+            rejectUnsafeResponse("literal exceeded requested count")
+            return
+        }
+        currentData.append(contentsOf: bytes.readableBytesView)
+    }
+
+    private func beginBody(kind: StreamingKind, declaredCount: Int, request: PartialFetchRequest) {
+        currentBodyCount += 1
+        guard currentBodyCount == 1 else {
+            rejectUnsafeResponse("multiple body literals")
+            return
+        }
+        guard case .body(let section, let offset) = kind,
+              section == request.section,
+              offset == request.offset else {
+            rejectUnsafeResponse("section or partial origin did not match request")
+            return
+        }
+        guard declaredCount <= request.count else {
+            rejectUnsafeResponse("literal exceeded requested count")
+            return
+        }
+        currentDeclaredCount = declaredCount
+        collectingBody = true
+    }
+
+    private func rejectUnsafeResponse(_ reason: String) {
+        let error = PartialFetchError.invalidResponse(reason)
+        currentError = error
+        collectingBody = false
+        failWithError(error)
+    }
+
+    private func finishCurrentGroup(request: PartialFetchRequest) {
+        if currentBodyCount > 0 { sawBodyGroup = true }
+        guard identifierMatches(request.identifier) else { return }
+        sawMatchingGroup = true
+        guard currentBodyCount > 0 else { return }
+        matchedCount += 1
+        guard matchedCount == 1 else {
+            validationError = .invalidResponse("multiple matching FETCH responses")
+            return
+        }
+        if currentError == nil, currentDeclaredCount != currentData.count {
+            currentError = .invalidResponse("literal length did not match declaration")
+        }
+        partData = currentData
+        validationError = currentError
+    }
+
+    private func identifierMatches(_ expected: PartialFetchIdentifier) -> Bool {
+        switch expected {
+            case .uid(let uid): currentUID == uid || currentIncludesExpectedUID
+            case .sequenceNumber(let sequence): currentSequence == sequence
+        }
+    }
+
+    private func resetCurrentGroup() {
+        currentSequence = nil
+        currentUID = nil
+        currentIncludesExpectedUID = false
+        currentData.removeAll(keepingCapacity: true)
+        currentDeclaredCount = nil
+        currentBodyCount = 0
+        currentError = nil
+        collectingBody = false
     }
 }

--- a/Sources/SwiftMail/IMAP/IMAP/IMAPLogger.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/IMAPLogger.swift
@@ -67,38 +67,20 @@ final class IMAPLogger: MailLogger, @unchecked Sendable {
     override func channelRead(context: ChannelHandlerContext, data: NIOAny) {
         let response = unwrapInboundIn(data)
 
-        // Get log message, abbreviating FETCH responses if needed
-        let logMessage: String
-        if let resp = response as? Response {
-            logMessage = abbreviateResponse(resp)
-        } else {
-            logMessage = String(describing: response)
+        // The preceding streamingBegin event already records the literal size.
+        // Retaining one diagnostic string per fragment defeats bounded fetches.
+        if let response = response as? Response,
+           case .fetch(let fetchResponse) = response,
+           case .streamingBytes = fetchResponse {
+            context.fireChannelRead(data)
+            return
         }
 
         // Add the response to the buffer
-        bufferInboundResponse(decorate(logMessage))
+        bufferInboundResponse(decorate(String(describing: response)))
 
         // Forward the response to the next handler
         context.fireChannelRead(data)
     }
 
-    /// Abbreviate FETCH responses containing large body data
-    private func abbreviateResponse(_ response: Response) -> String {
-        // Check if this is a FETCH response
-        if case .fetch(let fetchResponse) = response {
-            // Check if it's streaming bytes (large body data)
-            if case .streamingBytes(let buffer) = fetchResponse {
-                let size = buffer.readableBytes
-                if size > 256 {
-                    // Truncate to first 256 bytes and show size
-                    var preview = buffer
-                    let previewData = preview.readString(length: min(256, size)) ?? ""
-                    return ".fetch(.streamingBytes(\(size) bytes): \(previewData)..."
-                }
-            }
-        }
-
-        // For non-FETCH or small responses, use default string representation
-        return String(describing: response)
-    }
 }

--- a/Sources/SwiftMail/IMAP/IMAPConnection+CommandExecution.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+CommandExecution.swift
@@ -79,7 +79,7 @@ extension IMAPConnection {
 
         let resultPromise = channel.eventLoop.makePromise(of: CommandType.ResultType.self)
         let tag = generateCommandTag()
-        let handler = CommandType.HandlerType.init(commandTag: tag, promise: resultPromise)
+        let handler = command.makeHandler(commandTag: tag, promise: resultPromise)
         let scheduledTask = scheduleCommandTimeout(
             channel: channel,
             timeoutSeconds: command.timeoutSeconds,

--- a/Sources/SwiftMail/IMAP/IMAPConnection+Connection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+Connection.swift
@@ -307,6 +307,11 @@ extension IMAPConnection {
             }
         }
 
+        if let partialError = error as? PartialFetchError,
+           case .invalidResponse = partialError {
+            return true
+        }
+
         // Raw NIO transport failure (e.g. writeAndFlush on a closed channel). The substring
         // check below misses most ChannelError cases — `String(describing:)` returns just the
         // case name (`alreadyClosed`, `ioOnClosedChannel`, `connectPending`, `inputClosed`,

--- a/Sources/SwiftMail/IMAP/IMAPServer+Fetch.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Fetch.swift
@@ -49,6 +49,34 @@ extension IMAPServer {
     }
 
     /**
+     Fetches a validated byte range of a message part without setting `\\Seen`.
+
+     The wire request is `BODY.PEEK[section]<offset.count>`. The response must
+     echo the requested section and offset and contain at most `count` bytes.
+     Returned bytes remain transfer-encoded; callers should join chunks before decoding.
+     */
+    public func fetchPart<T: MessageIdentifier>(
+        section: Section,
+        of identifier: T,
+        offset: Int,
+        count: Int
+    ) async throws -> Data {
+        guard offset >= 0, count > 0,
+              let start = UInt32(exactly: offset),
+              UInt32(exactly: count) != nil,
+              let countMinusOne = UInt32(exactly: count - 1) else {
+            throw PartialFetchError.invalidRange
+        }
+        let end = start.addingReportingOverflow(countMinusOne)
+        guard !end.overflow else { throw PartialFetchError.invalidRange }
+        return try await executeCommand(FetchMessagePartCommand(
+            identifier: identifier,
+            section: section,
+            range: start...end.partialValue
+        ))
+    }
+
+    /**
      Fetch multiple body parts in a pipelined burst (RFC 3501 §5.5).
 
      Sends all FETCH BODY[section] commands without awaiting individual responses.

--- a/Sources/SwiftMail/IMAP/Models/PartialFetchError.swift
+++ b/Sources/SwiftMail/IMAP/Models/PartialFetchError.swift
@@ -1,0 +1,12 @@
+/// A failure to issue or validate a partial IMAP body fetch.
+public enum PartialFetchError: Error, Equatable, Sendable {
+    /// The requested offset/count cannot be represented by the IMAP grammar.
+    case invalidRange
+    /// The server returned no matching message for the requested identifier.
+    case messageNotFound
+    /// The server rejected valid partial-FETCH syntax with a tagged BAD response.
+    case serverRejected
+    /// The response did not identify or bound the requested body range safely.
+    case invalidResponse(String)
+
+}

--- a/Tests/SwiftIMAPTests/IMAPTestServer.swift
+++ b/Tests/SwiftIMAPTests/IMAPTestServer.swift
@@ -20,6 +20,14 @@ enum IMAPTestError: Error {
 /// A minimal IMAP4rev1 server implemented in Swift using POSIX sockets.
 /// Uses POSIX sockets directly since Network.framework doesn't work in the iOS simulator.
 final class IMAPTestServer {
+    enum PartialFetchBehavior {
+        case honor
+        case ignoreRange
+        case wrongOffset
+        case rejectWithBad
+        case rejectWithNo
+    }
+
     struct Message {
         let uid: Int
         let raw: Data
@@ -50,6 +58,7 @@ final class IMAPTestServer {
     private let copyUIDSourceOverride: String?
     private let personalNamespacePrefix: String
     private let namespaceDelimiter: Character
+    private let partialFetchBehavior: PartialFetchBehavior
     private let metricsQueue = DispatchQueue(label: "IMAPTestServer.metrics")
     private var idleCommandCountStorage = 0
     private var commandLogStorage: [String] = []
@@ -71,6 +80,7 @@ final class IMAPTestServer {
         ],
         personalNamespacePrefix: String = "",
         namespaceDelimiter: Character = "/",
+        partialFetchBehavior: PartialFetchBehavior = .honor,
         maildirURL: URL
     ) throws {
         self.host = host
@@ -83,6 +93,7 @@ final class IMAPTestServer {
         self.advertisedCapabilities = advertisedCapabilities
         self.personalNamespacePrefix = personalNamespacePrefix
         self.namespaceDelimiter = namespaceDelimiter
+        self.partialFetchBehavior = partialFetchBehavior
         self.messages = try Self.loadMaildir(maildirURL)
     }
 
@@ -281,6 +292,13 @@ final class IMAPTestServer {
             close(clientFd)
             return
         }
+        #if os(macOS)
+            var noSigPipe: Int32 = 1
+            setsockopt(
+                clientFd, SOL_SOCKET, SO_NOSIGPIPE,
+                &noSigPipe, socklen_t(MemoryLayout<Int32>.size)
+            )
+        #endif
         recordAcceptedConnection()
 
         // Handle on a background queue
@@ -411,7 +429,13 @@ final class IMAPTestServer {
             guard let ptr = buf.baseAddress else { return }
             var sent = 0
             while sent < data.count {
-                let bytesWritten = write(fileDescriptor, ptr + sent, data.count - sent)
+                #if os(Linux)
+                    let bytesWritten = Glibc.send(
+                        fileDescriptor, ptr + sent, data.count - sent, Int32(MSG_NOSIGNAL)
+                    )
+                #else
+                    let bytesWritten = write(fileDescriptor, ptr + sent, data.count - sent)
+                #endif
                 if bytesWritten <= 0 { return }
                 sent += bytesWritten
             }
@@ -555,6 +579,17 @@ final class IMAPTestServer {
         }
 
         let matched = parseSequenceSet(seqStr, uidMode: uidMode)
+        let partialRequest = parsePartialBodyRequest(itemsStr)
+        if partialRequest != nil {
+            switch partialFetchBehavior {
+                case .rejectWithBad:
+                    return "\(tag) BAD Partial FETCH ranges are unsupported\r\n"
+                case .rejectWithNo:
+                    return "\(tag) NO Partial FETCH is temporarily unavailable\r\n"
+                default:
+                    break
+            }
+        }
         var response = ""
 
         for msg in matched {
@@ -579,6 +614,14 @@ final class IMAPTestServer {
             if itemsStr.contains("BODYSTRUCTURE") {
                 fetchItems.append("BODYSTRUCTURE \(buildBodystructure(msg))")
             }
+            if let request = partialRequest, request.section == "1" {
+                fetchItems.append(partialBodyFetchItem(request, body: msg.body))
+            }
+            if partialRequest == nil,
+               itemsStr.contains("BODY.PEEK[1]") || itemsStr.contains("BODY[1]") {
+                let bodyString = String(data: msg.body, encoding: .utf8) ?? ""
+                fetchItems.append("BODY[1] {\(msg.body.count)}\r\n\(bodyString)")
+            }
             if itemsStr.contains("BODY[]") || itemsStr.contains("BODY.PEEK[]") {
                 let rawStr = String(data: msg.raw, encoding: .utf8) ?? ""
                 fetchItems.append("BODY[] {\(msg.raw.count)}\r\n\(rawStr)")
@@ -597,6 +640,45 @@ final class IMAPTestServer {
 
         response += "\(tag) OK \(uidMode ? "UID " : "")FETCH completed\r\n"
         return response
+    }
+
+    private struct PartialBodyRequest {
+        let section: String
+        let offset: Int
+        let count: Int
+    }
+
+    private func parsePartialBodyRequest(_ items: String) -> PartialBodyRequest? {
+        let pattern = #"BODY(?:\.PEEK)?\[([0-9]+(?:\.[0-9]+)*)\]<([0-9]+)\.([0-9]+)>"#
+        guard let regex = try? NSRegularExpression(pattern: pattern),
+              let match = regex.firstMatch(in: items, range: NSRange(items.startIndex..., in: items)),
+              let sectionRange = Range(match.range(at: 1), in: items),
+              let offsetRange = Range(match.range(at: 2), in: items),
+              let countRange = Range(match.range(at: 3), in: items),
+              let offset = Int(items[offsetRange]),
+              let count = Int(items[countRange]) else {
+            return nil
+        }
+        return PartialBodyRequest(section: String(items[sectionRange]), offset: offset, count: count)
+    }
+
+    private func partialBodyFetchItem(
+        _ request: PartialBodyRequest,
+        body: Data
+    ) -> String {
+        let start = min(request.offset, body.count)
+        let end = min(start + request.count, body.count)
+        let bytes = body.subdata(in: start..<end)
+        let bodyString = String(data: bytes, encoding: .utf8) ?? ""
+        switch partialFetchBehavior {
+            case .honor, .rejectWithBad, .rejectWithNo:
+                return "BODY[\(request.section)]<\(request.offset)> {\(bytes.count)}\r\n\(bodyString)"
+            case .wrongOffset:
+                return "BODY[\(request.section)]<\(request.offset + 1)> {\(bytes.count)}\r\n\(bodyString)"
+            case .ignoreRange:
+                let wholeBody = String(data: body, encoding: .utf8) ?? ""
+                return "BODY[\(request.section)] {\(body.count)}\r\n\(wholeBody)"
+        }
     }
 
     private func parseSequenceSet(_ seqStr: String, uidMode: Bool) -> [Message] {

--- a/Tests/SwiftIMAPTests/PartialFetchLoggingTests.swift
+++ b/Tests/SwiftIMAPTests/PartialFetchLoggingTests.swift
@@ -1,0 +1,61 @@
+import Logging
+import NIO
+import NIOEmbedded
+@preconcurrency import NIOIMAP
+import NIOIMAPCore
+import Testing
+@testable import SwiftMail
+
+@Suite("Partial BODY.PEEK diagnostic bounds")
+struct PartialFetchLoggingTests {
+    @Test("Diagnostics stay bounded and reset after flushing")
+    func boundedDiagnostics() throws {
+        let logger = IMAPLogger(
+            outboundLogger: Logger(label: "partial-fetch-test.out"),
+            inboundLogger: Logger(label: "partial-fetch-test.in")
+        )
+        let channel = EmbeddedChannel()
+        try channel.pipeline.syncOperations.addHandler(logger)
+        var fragment = ByteBufferAllocator().buffer(capacity: 1)
+        fragment.writeString("x")
+        for _ in 0..<10_000 {
+            try channel.writeInbound(Response.fetch(.streamingBytes(fragment)))
+            _ = try channel.readInbound(as: Response.self)
+        }
+        #expect(logger.inboundBuffer.isEmpty)
+
+        for _ in 0..<1_000 {
+            try channel.writeInbound(Response.untagged(.mailboxData(.sort([2, 1], 1))))
+            _ = try channel.readInbound(as: Response.self)
+        }
+        #expect(logger.inboundBuffer.count <= MailLogger.maximumInboundBufferEntries)
+        #expect(logger.inboundBufferByteCount <= MailLogger.maximumInboundBufferBytes)
+        #expect(logger.droppedInboundResponseCount > 0)
+
+        logger.flushInboundBuffer()
+        #expect(logger.inboundBuffer.isEmpty)
+        #expect(logger.inboundBufferByteCount == 0)
+        #expect(logger.droppedInboundResponseCount == 0)
+        logger.bufferInboundResponse("fresh")
+        #expect(logger.inboundBuffer == ["fresh"])
+        logger.flushInboundBuffer()
+
+        logger.bufferInboundResponse(String(repeating: "é", count: 40_000))
+        #expect(logger.inboundBuffer.isEmpty)
+        #expect(logger.inboundBufferByteCount == 0)
+        #expect(logger.droppedInboundResponseCount == 1)
+        #expect(logger.hasBufferedMessages())
+        logger.flushInboundBuffer()
+        #expect(logger.droppedInboundResponseCount == 0)
+        #expect(!logger.hasBufferedMessages())
+
+        let mediumMessage = String(repeating: "x", count: 40 * 1024)
+        logger.bufferInboundResponse(mediumMessage)
+        logger.bufferInboundResponse(mediumMessage)
+        #expect(logger.inboundBuffer == [mediumMessage])
+        #expect(logger.inboundBufferByteCount == mediumMessage.utf8.count)
+        #expect(logger.droppedInboundResponseCount == 1)
+        logger.flushInboundBuffer()
+        _ = try channel.finish()
+    }
+}

--- a/Tests/SwiftIMAPTests/PartialFetchTests.swift
+++ b/Tests/SwiftIMAPTests/PartialFetchTests.swift
@@ -1,0 +1,228 @@
+import Foundation
+import NIO
+@preconcurrency import NIOIMAP
+import Testing
+@testable import SwiftMail
+
+@Suite("Partial BODY.PEEK fetching", .serialized, .timeLimit(.minutes(3)))
+struct PartialFetchTests {
+    @Test("Command encodes offset and count on the wire")
+    func commandWireFormat() async throws {
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
+        let command = FetchMessagePartCommand(
+            identifier: UID(42),
+            section: Section([2, 1]),
+            range: 1_048_576...1_572_863
+        )
+        let tagged = command.toTaggedCommand(tag: "P001")
+        try await channel.writeAndFlush(
+            IMAPClientHandler.OutboundIn.part(CommandStreamPart.tagged(tagged))
+        )
+
+        var outbound = try #require(await channel.readOutbound(as: ByteBuffer.self))
+        #expect(outbound.readString(length: outbound.readableBytes)
+            == "P001 UID FETCH 42 (BODY.PEEK[2.1]<1048576.524288>)\r\n")
+
+        let sequenceChannel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
+        let sequenceCommand = FetchMessagePartCommand(
+            identifier: SwiftMail.SequenceNumber(42),
+            section: Section([2, 1]),
+            range: 0...3
+        )
+        try await sequenceChannel.writeAndFlush(IMAPClientHandler.OutboundIn.part(
+            CommandStreamPart.tagged(sequenceCommand.toTaggedCommand(tag: "P002"))
+        ))
+        var sequenceOutbound = try #require(
+            await sequenceChannel.readOutbound(as: ByteBuffer.self)
+        )
+        #expect(sequenceOutbound.readString(length: sequenceOutbound.readableBytes)
+            == "P002 FETCH 42 (BODY.PEEK[2.1]<0.4>)\r\n")
+    }
+
+    @Test("Invalid ranges fail before connecting")
+    func invalidRanges() async {
+        let server = IMAPServer(host: "127.0.0.1", port: 9, useTLS: false)
+        for (offset, count) in [
+            (-1, 1),
+            (0, 0),
+            (Int(UInt32.max), 2),
+            (Int(UInt32.max) + 1, 1),
+            (0, Int(UInt32.max) + 1)
+        ] {
+            await #expect(throws: PartialFetchError.invalidRange) {
+                _ = try await server.fetchPart(
+                    section: Section([1]), of: UID(1), offset: offset, count: count
+                )
+            }
+        }
+    }
+
+    #if os(macOS)
+    @Test("Bounded wire fetches reconstruct more than 32 MiB")
+    func reconstructsLargeBody() async throws {
+        let body = Data(repeating: 0x61, count: 33 * 1024 * 1024 + 257)
+        let fixture = try makeFixture(body: body)
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+        let testServer = try IMAPTestServer(maildirURL: fixture.maildir)
+        try testServer.start()
+
+        try await testServer.run {
+            let server = IMAPServer(
+                host: "127.0.0.1",
+                port: testServer.port,
+                useTLS: false,
+                responseBufferLimit: 4 * 1024 * 1024
+            )
+            try await server.connect()
+            try await server.login(username: "testuser", password: "testpass")
+            _ = try await server.selectMailbox("INBOX")
+
+            let chunkSize = 1024 * 1024
+            var assembled = Data()
+            var offset = 0
+            while offset < body.count {
+                let chunk = try await server.fetchPart(
+                    section: Section([1]), of: UID(1), offset: offset, count: chunkSize
+                )
+                assembled.append(chunk)
+                offset += chunk.count
+            }
+            let eof = try await server.fetchPart(
+                section: Section([1]), of: UID(1), offset: body.count, count: chunkSize
+            )
+            let sequenceChunk = try await server.fetchPart(
+                section: Section([1]),
+                of: SwiftMail.SequenceNumber(1),
+                offset: 0,
+                count: 4
+            )
+
+            #expect(assembled == body)
+            #expect(eof.isEmpty)
+            #expect(sequenceChunk == body.prefix(4))
+            #expect(testServer.commandLog.filter { $0.contains("BODY.PEEK[1]<") }.count == 36)
+            try await server.disconnect()
+        }
+    }
+
+    @Test("Ignored and malformed ranges are rejected")
+    func rejectsInvalidResponses() async throws {
+        let cases: [(IMAPTestServer.PartialFetchBehavior, Data)] = [
+            (.ignoreRange, Data(repeating: 0x61, count: 33 * 1024 * 1024 + 257)),
+            (.wrongOffset, Data("small body".utf8))
+        ]
+        for (behavior, body) in cases {
+            let fixture = try makeFixture(body: body)
+            defer { try? FileManager.default.removeItem(at: fixture.root) }
+            let testServer = try IMAPTestServer(
+                partialFetchBehavior: behavior,
+                maildirURL: fixture.maildir
+            )
+            try testServer.start()
+            try await testServer.run {
+                let server = try await connectedServer(testServer)
+                await #expect(throws: PartialFetchError.invalidResponse(
+                    "section or partial origin did not match request"
+                )) {
+                    _ = try await server.fetchPart(
+                        section: Section([1]), of: UID(1), offset: 3, count: 4
+                    )
+                }
+                let remainedConnected = await server.isConnected
+                #expect(!remainedConnected)
+                try await server.connect()
+                try await server.login(username: "testuser", password: "testpass")
+                _ = try await server.selectMailbox("INBOX")
+                #expect(testServer.acceptedConnectionCount == 2)
+                #expect(try await !server.fetchStructure(UID(1)).isEmpty)
+                try await server.disconnect()
+            }
+        }
+    }
+
+    @Test("No-match and unsupported-server outcomes stay distinct")
+    func terminalOutcomes() async throws {
+        let fixture = try makeFixture(body: Data("small body".utf8))
+        defer { try? FileManager.default.removeItem(at: fixture.root) }
+
+        let normalServer = try IMAPTestServer(maildirURL: fixture.maildir)
+        try normalServer.start()
+        try await normalServer.run {
+            let server = try await connectedServer(normalServer)
+            let ordinaryPart = try await server.fetchPart(section: Section([1]), of: UID(1))
+            #expect(ordinaryPart == Data("small body".utf8))
+            await #expect(throws: PartialFetchError.messageNotFound) {
+                _ = try await server.fetchPart(
+                    section: Section([1]), of: UID(999), offset: 0, count: 4
+                )
+            }
+            try await server.disconnect()
+        }
+
+        let rejectingServer = try IMAPTestServer(
+            partialFetchBehavior: .rejectWithBad,
+            maildirURL: fixture.maildir
+        )
+        try rejectingServer.start()
+        try await rejectingServer.run {
+            let server = try await connectedServer(rejectingServer)
+            await #expect(throws: PartialFetchError.serverRejected) {
+                _ = try await server.fetchPart(
+                    section: Section([1]), of: UID(1), offset: 0, count: 4
+                )
+            }
+            #expect(try await !server.fetchStructure(UID(1)).isEmpty)
+            try await server.disconnect()
+        }
+
+        let temporaryFailureServer = try IMAPTestServer(
+            partialFetchBehavior: .rejectWithNo,
+            maildirURL: fixture.maildir
+        )
+        try temporaryFailureServer.start()
+        try await temporaryFailureServer.run {
+            let server = try await connectedServer(temporaryFailureServer)
+            await #expect(throws: IMAPError.self) {
+                _ = try await server.fetchPart(
+                    section: Section([1]), of: UID(1), offset: 0, count: 4
+                )
+            }
+            #expect(try await !server.fetchStructure(UID(1)).isEmpty)
+            try await server.disconnect()
+        }
+    }
+
+    private func connectedServer(_ testServer: IMAPTestServer) async throws -> SwiftMail.IMAPServer {
+        let server = SwiftMail.IMAPServer(host: "127.0.0.1", port: testServer.port, useTLS: false)
+        try await server.connect()
+        try await server.login(username: "testuser", password: "testpass")
+        _ = try await server.selectMailbox("INBOX")
+        return server
+    }
+
+    private func makeFixture(body: Data) throws -> (root: URL, maildir: URL) {
+        let root = FileManager.default.temporaryDirectory.appendingPathComponent(UUID().uuidString)
+        let maildir = root.appendingPathComponent("Maildir")
+        let current = maildir.appendingPathComponent("cur")
+        try FileManager.default.createDirectory(at: current, withIntermediateDirectories: true)
+        try FileManager.default.createDirectory(
+            at: maildir.appendingPathComponent("new"),
+            withIntermediateDirectories: true
+        )
+        var message = Data(("""
+        From: Sender <sender@example.com>\r
+        To: Recipient <recipient@example.com>\r
+        Subject: Partial fetch test\r
+        Date: Thu, 01 Jan 1970 00:00:00 +0000\r
+        Message-ID: <partial-fetch@example.com>\r
+        Content-Type: text/plain; charset=utf-8\r
+        Content-Transfer-Encoding: base64\r
+        \r
+
+        """).utf8)
+        message.append(body)
+        try message.write(to: current.appendingPathComponent("1.eml"))
+        return (root, maildir)
+    }
+    #endif
+}

--- a/Tests/SwiftIMAPTests/PartialFetchValidationTests.swift
+++ b/Tests/SwiftIMAPTests/PartialFetchValidationTests.swift
@@ -1,0 +1,294 @@
+import Foundation
+import NIO
+import NIOEmbedded
+@preconcurrency import NIOIMAP
+import NIOIMAPCore
+import Testing
+@testable import SwiftMail
+
+@Suite("Partial BODY.PEEK validation", .serialized)
+struct PartialFetchValidationTests {
+    private struct FailureCase {
+        let responses: [FetchResponse]
+        let identifier: PartialFetchIdentifier
+        let expected: PartialFetchError
+    }
+
+    @Test("Conflicting UID attributes are rejected")
+    func conflictingUIDs() async {
+        await assertUIDConflict(
+            start: .start(NIOIMAPCore.SequenceNumber(rawValue: 1)),
+            uids: [999, 1]
+        )
+        await assertUIDConflict(
+            start: .start(NIOIMAPCore.SequenceNumber(rawValue: 1)),
+            uids: [1, 999]
+        )
+        await assertUIDConflict(
+            start: .startUID(NIOIMAPCore.UID(rawValue: 999)),
+            uids: [1]
+        )
+    }
+
+    @Test("Malformed body literals are rejected")
+    func malformedBodyLiterals() async {
+        let section = SectionSpecifier(part: .init([1]))
+        let otherSection = SectionSpecifier(part: .init([2]))
+        let start = matchingStart()
+        let validBody = bodyResponses(section: section)
+        let cases = [
+            FailureCase(
+                responses: start + [
+                    .streamingBegin(kind: .body(section: otherSection, offset: 0), byteCount: 4),
+                    .streamingBytes(buffer("data")), .streamingEnd, .finish
+                ],
+                identifier: .uid(1),
+                expected: .invalidResponse("section or partial origin did not match request")
+            ),
+            FailureCase(
+                responses: start + [
+                    .streamingBegin(kind: .body(section: section, offset: 0), byteCount: 5), .finish
+                ],
+                identifier: .uid(1),
+                expected: .invalidResponse("literal exceeded requested count")
+            ),
+            FailureCase(
+                responses: start + [
+                    .streamingBegin(kind: .body(section: section, offset: 0), byteCount: 4),
+                    .streamingBytes(buffer("abc")), .streamingBytes(buffer("de")),
+                    .streamingEnd, .finish
+                ],
+                identifier: .uid(1),
+                expected: .invalidResponse("literal exceeded requested count")
+            ),
+            FailureCase(
+                responses: start + Array(validBody.dropLast()) + [
+                    .streamingBegin(kind: .body(section: section, offset: 0), byteCount: 0),
+                    .streamingEnd, .finish
+                ],
+                identifier: .uid(1),
+                expected: .invalidResponse("multiple body literals")
+            ),
+            FailureCase(
+                responses: start + [
+                    .streamingBegin(kind: .body(section: section, offset: 0), byteCount: 4),
+                    .streamingBytes(buffer("abc")), .streamingEnd, .finish
+                ],
+                identifier: .uid(1),
+                expected: .invalidResponse("literal length did not match declaration")
+            )
+        ]
+        await assertFailures(cases)
+    }
+
+    @Test("Unsafe declarations fail before tagged completion")
+    func unsafeDeclarationFailsImmediately() async {
+        let loop = EmbeddedEventLoop()
+        let promise = loop.makePromise(of: Data.self)
+        let handler = makeHandler(promise: promise)
+        _ = handler.processResponse(.fetch(.start(.init(rawValue: 1))))
+        _ = handler.processResponse(.fetch(.simpleAttribute(.uid(.init(rawValue: 1)))))
+
+        let handled = handler.processResponse(.fetch(.streamingBegin(
+            kind: .body(section: SectionSpecifier(part: .init([1])), offset: nil),
+            byteCount: 33 * 1024 * 1024 + 257
+        )))
+        loop.run()
+
+        #expect(handled)
+        await #expect(throws: PartialFetchError.invalidResponse(
+            "section or partial origin did not match request"
+        )) {
+            _ = try await promise.futureResult.get()
+        }
+    }
+
+    @Test("Missing and ambiguous message responses are rejected")
+    func ambiguousResponses() async {
+        let section = SectionSpecifier(part: .init([1]))
+        let start = matchingStart()
+        let validBody = bodyResponses(section: section)
+        let cases = [
+            FailureCase(
+                responses: start + validBody + start + validBody,
+                identifier: .uid(1),
+                expected: .invalidResponse("multiple matching FETCH responses")
+            ),
+            FailureCase(
+                responses: start + [
+                    .simpleAttribute(.nilBody(.body(section: section, offset: 0))), .finish
+                ],
+                identifier: .uid(1),
+                expected: .invalidResponse("requested body section was NIL")
+            ),
+            FailureCase(
+                responses: start + [.finish],
+                identifier: .uid(1),
+                expected: .invalidResponse("missing or ambiguous requested body")
+            ),
+            FailureCase(
+                responses: [
+                    .start(.init(rawValue: 1)),
+                    .simpleAttribute(.uid(.init(rawValue: 999)))
+                ] + validBody,
+                identifier: .uid(1),
+                expected: .invalidResponse("missing or ambiguous requested body")
+            ),
+            FailureCase(
+                responses: [.start(.init(rawValue: 2))] + validBody,
+                identifier: .sequenceNumber(1),
+                expected: .invalidResponse("missing or ambiguous requested body")
+            )
+        ]
+        await assertFailures(cases)
+    }
+
+    private func matchingStart() -> [FetchResponse] {
+        [.start(.init(rawValue: 1)), .simpleAttribute(.uid(.init(rawValue: 1)))]
+    }
+
+    private func bodyResponses(section: SectionSpecifier) -> [FetchResponse] {
+        [
+            .streamingBegin(kind: .body(section: section, offset: 0), byteCount: 4),
+            .streamingBytes(buffer("data")), .streamingEnd, .finish
+        ]
+    }
+
+    private func assertFailures(_ cases: [FailureCase]) async {
+        for testCase in cases {
+            await assertPartialFailure(
+                testCase.responses,
+                identifier: testCase.identifier,
+                expected: testCase.expected
+            )
+        }
+    }
+
+    @Test("Opaque bytes are returned without text conversion")
+    func preservesOpaqueBytes() async throws {
+        let section = SectionSpecifier(part: .init([1]))
+        let bytes = Data([0x00, 0xff, 0x01, 0xfe])
+        let result = try await partialHandlerResult([
+            .start(.init(rawValue: 1)),
+            .simpleAttribute(.uid(.init(rawValue: 1))),
+            .streamingBegin(kind: .body(section: section, offset: 0), byteCount: bytes.count),
+            .streamingBytes(buffer(bytes)),
+            .streamingEnd,
+            .finish
+        ]).get()
+        #expect(result == bytes)
+    }
+
+    @Test("Connection termination responses fail the partial command")
+    func connectionTerminationResponses() async {
+        let responses: [Response] = [
+            .untagged(.conditionalState(.bye(ResponseText(text: "test shutdown")))),
+            .fatal(ResponseText(text: "test decoder failure"))
+        ]
+        for response in responses {
+            let loop = EmbeddedEventLoop()
+            let promise = loop.makePromise(of: Data.self)
+            let handler = makeHandler(promise: promise)
+            #expect(handler.processResponse(response))
+            loop.run()
+            await #expect(throws: IMAPError.self) {
+                _ = try await promise.futureResult.get()
+            }
+        }
+    }
+
+    private func assertUIDConflict(start: FetchResponse, uids: [UInt32]) async {
+        let section = SectionSpecifier(part: .init([1]))
+        var responses: [FetchResponse] = [
+            start,
+            .streamingBegin(kind: .body(section: section, offset: 0), byteCount: 4),
+            .streamingBytes(buffer("evil")),
+            .streamingEnd
+        ]
+        responses += uids.map { .simpleAttribute(.uid(.init(rawValue: $0))) }
+        responses.append(.finish)
+        await assertPartialFailure(
+            responses,
+            expected: .invalidResponse("conflicting UID attributes")
+        )
+    }
+
+    private func assertPartialFailure(
+        _ responses: [FetchResponse],
+        identifier: PartialFetchIdentifier = .uid(1),
+        expected: PartialFetchError
+    ) async {
+        await #expect(throws: expected) {
+            _ = try await partialHandlerResult(responses, identifier: identifier).get()
+        }
+    }
+
+    private func partialHandlerResult(
+        _ responses: [FetchResponse],
+        identifier: PartialFetchIdentifier = .uid(1)
+    ) async -> Result<Data, Error> {
+        let loop = EmbeddedEventLoop()
+        let promise = loop.makePromise(of: Data.self)
+        let handler = makeHandler(promise: promise, identifier: identifier)
+        for response in responses { _ = handler.processResponse(.fetch(response)) }
+        _ = handler.processResponse(.tagged(TaggedResponse(
+            tag: "P001",
+            state: .ok(ResponseText(text: "completed"))
+        )))
+        loop.run()
+        do {
+            return .success(try await promise.futureResult.get())
+        } catch {
+            return .failure(error)
+        }
+    }
+
+    private func makeHandler(
+        promise: EventLoopPromise<Data>,
+        identifier: PartialFetchIdentifier = .uid(1)
+    ) -> FetchPartHandler {
+        FetchPartHandler(
+            commandTag: "P001",
+            promise: promise,
+            partialRequest: .init(
+                identifier: identifier,
+                section: SectionSpecifier(part: .init([1])),
+                offset: 0,
+                count: 4
+            )
+        )
+    }
+
+    private func buffer(_ string: String) -> ByteBuffer {
+        buffer(Data(string.utf8))
+    }
+
+    private func buffer(_ data: Data) -> ByteBuffer {
+        var buffer = ByteBufferAllocator().buffer(capacity: data.count)
+        buffer.writeBytes(data)
+        return buffer
+    }
+}
+
+extension PartialFetchValidationTests {
+    @Test("Unrelated untagged responses do not complete the handler")
+    func ignoresUnrelatedUntaggedResponse() async throws {
+        let loop = EmbeddedEventLoop()
+        let promise = loop.makePromise(of: Data.self)
+        let handler = makeHandler(promise: promise)
+        let unrelated = Response.untagged(.mailboxData(.sort([2, 1], 1)))
+        #expect(!handler.processResponse(unrelated))
+
+        for response in matchingStart() + bodyResponses(
+            section: SectionSpecifier(part: .init([1]))
+        ) {
+            _ = handler.processResponse(.fetch(response))
+        }
+        _ = handler.processResponse(.tagged(TaggedResponse(
+            tag: "P001",
+            state: .ok(ResponseText(text: "completed"))
+        )))
+        loop.run()
+        #expect(try await promise.futureResult.get() == Data("data".utf8))
+    }
+}


### PR DESCRIPTION
## Status

Ready for review.

## Why

SwiftMail currently fetches an entire MIME part in one IMAP response. A caller cannot bound the response size for a large part, and cannot tell whether a server honored a requested partial range. Raising a parser limit only moves that failure threshold.

## What

- Add `fetchPart(section:of:offset:count:)` for `BODY.PEEK[section]<offset.count>` requests.
- Reuse `FetchMessagePartCommand` and its existing full-part path; the range is optional.
- Validate message identity, section, echoed origin, declared length, received length, duplicate groups, and ambiguous responses before returning bytes.
- Return transfer-encoded bytes unchanged so callers can concatenate chunks before decoding.
- Keep diagnostics bounded while omitting streaming literal fragments from logs.
- Fail immediately and recycle the connection when a malformed streaming declaration proves unread literal bytes remain.

## How

The command uses SwiftNIO IMAP's existing ranged `bodySection` grammar. The existing fetch handler gains request-aware validation only when a range is present, leaving ordinary full-part behavior unchanged. Valid tagged `BAD`, tagged `NO`, no-match, malformed-response, and transport-terminal outcomes remain distinct so callers can make truthful retry decisions.

## Risks

The validation deliberately rejects ambiguous or non-conforming partial responses rather than returning potentially wrong bytes. Such a response also forces a reconnect because its unread literal can no longer be parsed safely. Compliant full and partial fetch behavior is unchanged.

## Verification

- Full Swift package suite: 508 tests across 65 suites passed.
- Focused partial-fetch suite: 13 tests across 3 suites passed.
- Reconstructed a 33 MiB + 257 byte part in 1 MiB chunks with a 4 MiB parser buffer, including zero-byte EOF and sequence-number fetching.
- Covered ignored ranges larger than 32 MiB, wrong origins, malformed literals, UID conflicts, opaque bytes, tagged `BAD`/`NO`, BYE/FATAL, and bounded logger state.
- Strict SwiftLint passed on all changed files.
- Four-angle review gate: architecture, correctness, robustness, and mutation-based test coverage.

## Scope

The patch adds 319 production lines and 666 test lines. It does not overlap the files changed by open PRs #214, #215, #216, or #218.

## Next action

Maintainer review and merge.
