### PR TITLE
Expose Gmail attributes on named IMAP connections

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAPNamedConnection+Gmail.swift
+++ b/Sources/SwiftMail/IMAP/IMAPNamedConnection+Gmail.swift
@@ -1,0 +1,34 @@
+import Foundation
+import NIOIMAPCore
+
+extension IMAPNamedConnection {
+    /// Whether this connection advertised Gmail's `X-GM-EXT-1` capability.
+    public var supportsGmailExtensions: Bool {
+        capabilities.contains(.gmailExtensions)
+    }
+
+    /// Fetches Gmail-native attributes for the given UIDs on this named connection.
+    ///
+    /// Requires the `X-GM-EXT-1` capability; other IMAP servers answer with a
+    /// tagged BAD. Gate calls on `Capability.gmailExtensions` being advertised.
+    public func fetchGmailAttributes(
+        for identifierSet: UIDSet
+    ) async throws -> [UID: GmailMessageAttributes] {
+        let command = FetchGmailAttributesCommand(identifierSet: identifierSet)
+        let records = try await executeCommand(command)
+
+        var result: [UID: GmailMessageAttributes] = [:]
+        for record in records {
+            guard let uid = record.uid,
+                  let messageID = record.messageID,
+                  let threadID = record.threadID
+            else { continue }
+            result[uid] = GmailMessageAttributes(
+                messageID: messageID,
+                threadID: threadID,
+                labels: record.labels
+            )
+        }
+        return result
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAPNamedConnection+Gmail.swift
+++ b/Sources/SwiftMail/IMAP/IMAPNamedConnection+Gmail.swift
@@ -4,13 +4,13 @@ import NIOIMAPCore
 extension IMAPNamedConnection {
     /// Whether this connection advertised Gmail's `X-GM-EXT-1` capability.
     public var supportsGmailExtensions: Bool {
-        capabilities.contains(.gmailExtensions)
+        capabilities.containsGmailExtensionsCapability
     }
 
     /// Fetches Gmail-native attributes for the given UIDs on this named connection.
     ///
     /// Requires the `X-GM-EXT-1` capability; other IMAP servers answer with a
-    /// tagged BAD. Gate calls on `Capability.gmailExtensions` being advertised.
+    /// tagged BAD. Gate calls on `supportsGmailExtensions`.
     public func fetchGmailAttributes(
         for identifierSet: UIDSet
     ) async throws -> [UID: GmailMessageAttributes] {

--- a/Sources/SwiftMail/IMAP/IMAPServer+Gmail.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Gmail.swift
@@ -2,6 +2,11 @@ import Foundation
 import NIOIMAPCore
 
 extension IMAPServer {
+    /// Whether the primary connection advertised Gmail's `X-GM-EXT-1` capability.
+    public var supportsGmailExtensions: Bool {
+        capabilities.contains(.gmailExtensions)
+    }
+
     /// Fetches Gmail-native attributes for the given UIDs.
     ///
     /// Requires the `X-GM-EXT-1` capability; other IMAP servers answer with a

--- a/Sources/SwiftMail/IMAP/IMAPServer+Gmail.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Gmail.swift
@@ -4,13 +4,13 @@ import NIOIMAPCore
 extension IMAPServer {
     /// Whether the primary connection advertised Gmail's `X-GM-EXT-1` capability.
     public var supportsGmailExtensions: Bool {
-        capabilities.contains(.gmailExtensions)
+        capabilities.containsGmailExtensionsCapability
     }
 
     /// Fetches Gmail-native attributes for the given UIDs.
     ///
     /// Requires the `X-GM-EXT-1` capability; other IMAP servers answer with a
-    /// tagged BAD. Gate calls on `Capability.gmailExtensions` being advertised.
+    /// tagged BAD. Gate calls on `supportsGmailExtensions`.
     public func fetchGmailAttributes(
         for identifierSet: UIDSet
     ) async throws -> [UID: GmailMessageAttributes] {

--- a/Sources/SwiftMail/IMAP/Models/Capability+Gmail.swift
+++ b/Sources/SwiftMail/IMAP/Models/Capability+Gmail.swift
@@ -1,0 +1,9 @@
+import NIOIMAPCore
+
+extension Set where Element == NIOIMAPCore.Capability {
+    /// Gmail's `X-GM-EXT-1` follows the same case-insensitive token rules as MOVE
+    /// and UIDPLUS; a server or proxy may spell it `x-gm-ext-1`.
+    var containsGmailExtensionsCapability: Bool {
+        containsBareCapability(named: "x-gm-ext-1")
+    }
+}

--- a/Sources/SwiftMail/IMAP/Models/Capability+Move.swift
+++ b/Sources/SwiftMail/IMAP/Models/Capability+Move.swift
@@ -12,7 +12,9 @@ extension Set where Element == NIOIMAPCore.Capability {
         containsBareCapability(named: "uidplus")
     }
 
-    private func containsBareCapability(named expectedName: String) -> Bool {
+    /// Case-insensitive membership test for a value-less capability token,
+    /// shared by every `supports…` accessor on both connection surfaces.
+    func containsBareCapability(named expectedName: String) -> Bool {
         contains { capability in
             guard capability.value == nil else { return false }
             return capability.name.utf8.elementsEqual(expectedName.utf8) { candidate, expected in

--- a/Tests/SwiftIMAPTests/FetchGmailAttributesTests.swift
+++ b/Tests/SwiftIMAPTests/FetchGmailAttributesTests.swift
@@ -118,7 +118,7 @@ struct FetchGmailAttributesTests {
         var response = channel.allocator.buffer(capacity: 0)
         response.writeString(
             "* 1 FETCH (UID 20 X-GM-MSGID 2222222222222222 X-GM-THRID 3333333333333333 "
-                + "X-GM-LABELS (\\Inbox))\r\n"
+                + "X-GM-LABELS (\\Inbox \"Work\"))\r\n"
                 + "* 2 FETCH (UID 10 X-GM-MSGID 4444444444444444 X-GM-THRID 5555555555555555 "
                 + "X-GM-LABELS (\\Important))\r\n"
                 + "A001 OK UID FETCH completed\r\n"
@@ -126,8 +126,14 @@ struct FetchGmailAttributesTests {
         try await channel.writeInbound(response)
 
         let result = try await resultTask.value
+
         #expect(result[UID(20)]?.messageID == 2_222_222_222_222_222)
+        #expect(result[UID(20)]?.threadID == 3_333_333_333_333_333)
+        #expect(result[UID(20)]?.labels == ["\\Inbox", "Work"])
+
         #expect(result[UID(10)]?.messageID == 4_444_444_444_444_444)
+        #expect(result[UID(10)]?.threadID == 5_555_555_555_555_555)
+        #expect(result[UID(10)]?.labels == ["\\Important"])
     }
 
     // MARK: - Validation

--- a/Tests/SwiftIMAPTests/FetchGmailAttributesTests.swift
+++ b/Tests/SwiftIMAPTests/FetchGmailAttributesTests.swift
@@ -94,6 +94,42 @@ struct FetchGmailAttributesTests {
         #expect(result[UID(10)]?.labels == ["\\Important"])
     }
 
+    @Test
+    func testNamedConnectionResultsAreKeyedByReturnedUID() async throws {
+        let (server, channel) = try await makeGmailHarness()
+        let primaryConnection = await server.primaryConnection
+        let connection = IMAPNamedConnection(
+            name: "gmail-attributes-test",
+            connection: primaryConnection,
+            authenticateOnConnection: { _ in }
+        )
+
+        let resultTask = Task {
+            try await connection.fetchGmailAttributes(for: UIDSet([UID(10), UID(20)]))
+        }
+
+        guard let commandLine = try await nextOutboundLine(from: channel) else {
+            Issue.record("Expected outbound UID FETCH command")
+            return
+        }
+        #expect(commandLine.contains("UID FETCH"))
+        #expect(commandLine.contains("X-GM-MSGID"))
+
+        var response = channel.allocator.buffer(capacity: 0)
+        response.writeString(
+            "* 1 FETCH (UID 20 X-GM-MSGID 2222222222222222 X-GM-THRID 3333333333333333 "
+                + "X-GM-LABELS (\\Inbox))\r\n"
+                + "* 2 FETCH (UID 10 X-GM-MSGID 4444444444444444 X-GM-THRID 5555555555555555 "
+                + "X-GM-LABELS (\\Important))\r\n"
+                + "A001 OK UID FETCH completed\r\n"
+        )
+        try await channel.writeInbound(response)
+
+        let result = try await resultTask.value
+        #expect(result[UID(20)]?.messageID == 2_222_222_222_222_222)
+        #expect(result[UID(10)]?.messageID == 4_444_444_444_444_444)
+    }
+
     // MARK: - Validation
 
     @Test

--- a/Tests/SwiftIMAPTests/GmailExtensionsCapabilityTests.swift
+++ b/Tests/SwiftIMAPTests/GmailExtensionsCapabilityTests.swift
@@ -1,0 +1,82 @@
+import Foundation
+import NIO
+import NIOIMAPCore
+import Testing
+@testable import SwiftMail
+
+/// `supportsGmailExtensions` must honour RFC 3501's case-insensitive capability
+/// names on both surfaces. NIOIMAPCore preserves the server's spelling and
+/// synthesizes case-sensitive `Capability` equality, so a server or proxy
+/// advertising `x-gm-ext-1` was reported unsupported and callers following the
+/// documented gate skipped `fetchGmailAttributes`.
+@Suite("Gmail extensions capability detection", .serialized, .timeLimit(.minutes(1)))
+struct GmailExtensionsCapabilityTests {
+    private static let spellings: [NIOIMAPCore.Capability] = [
+        .gmailExtensions,
+        Capability("x-gm-ext-1"),
+        Capability("X-Gm-Ext-1")
+    ]
+
+    // MARK: - IMAPServer
+
+    @Test("Server reports Gmail extensions unsupported when they are not advertised")
+    func serverWithoutGmailExtensions() async {
+        let server = await makeServer(capabilities: [.idle, .move, .namespace])
+        #expect(await server.supportsGmailExtensions == false)
+    }
+
+    @Test("Server accepts every spelling of X-GM-EXT-1")
+    func serverAcceptsEverySpelling() async {
+        for spelling in Self.spellings {
+            let server = await makeServer(capabilities: [.idle, spelling])
+            #expect(await server.supportsGmailExtensions, "spelling \(spelling)")
+        }
+    }
+
+    // MARK: - IMAPNamedConnection
+
+    @Test("Named connection reports Gmail extensions unsupported when they are not advertised")
+    func namedConnectionWithoutGmailExtensions() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        let named = makeNamedConnection(capabilities: [.idle, .uidPlus], group: group)
+        #expect(await named.supportsGmailExtensions == false)
+    }
+
+    @Test("Named connection accepts every spelling of X-GM-EXT-1")
+    func namedConnectionAcceptsEverySpelling() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        for spelling in Self.spellings {
+            let named = makeNamedConnection(capabilities: [.idle, spelling], group: group)
+            #expect(await named.supportsGmailExtensions, "spelling \(spelling)")
+        }
+    }
+
+    // MARK: - Helpers
+
+    private func makeServer(capabilities: Set<NIOIMAPCore.Capability>) async -> SwiftMail.IMAPServer {
+        let server = SwiftMail.IMAPServer(host: "imap.example.com", port: 993)
+        await server.primaryConnection.replaceCapabilitiesForTesting(capabilities)
+        return server
+    }
+
+    private func makeNamedConnection(
+        capabilities: Set<NIOIMAPCore.Capability>,
+        group: MultiThreadedEventLoopGroup
+    ) -> IMAPNamedConnection {
+        let connection = IMAPConnection(
+            host: "localhost",
+            port: 1,
+            useTLS: false,
+            group: group,
+            loggerLabel: "test.imap",
+            outboundLabel: "test.imap.out",
+            inboundLabel: "test.imap.in",
+            connectionID: "test-gmail-capability",
+            connectionRole: "test"
+        )
+        connection.replaceCapabilitiesForTesting(capabilities)
+        return IMAPNamedConnection(name: "test", connection: connection, authenticateOnConnection: { _ in })
+    }
+}


### PR DESCRIPTION
## Summary

- expose Gmail extension capability state on IMAPNamedConnection
- add fetchGmailAttributes(for:) on named connections, matching the existing IMAPServer API
- preserve UID-keyed results when FETCH responses arrive out of request order

## Motivation

Consumers that select and mutate mailboxes through a named IMAP connection need to fetch Gmail-native metadata on that same session. Kestrel Mail uses this to map selected IMAP UIDs to exact X-GM-MSGID values before permanent deletion, without switching back to the primary connection.

## Validation

- swiftlint lint --strict --no-cache
- swift test --filter FetchGmailAttributesTests (5 tests passed)