### PR TITLE
Judge the SASL mechanism after the channel is prepared, not against a cleared snapshot

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAPConnection+Authentication.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+Authentication.swift
@@ -31,10 +31,9 @@ extension IMAPConnection {
 
     func authenticatePlainBody(username: String, password: String) async throws {
         let mechanism = AuthenticationMechanism("PLAIN")
-        let plainCapability = Capability.authenticate(mechanism)
-
-        let channel = try await prepareAuthenticationChannel(operation: "PLAIN authenticate")
-        try await requireAdvertisedAuthenticationMechanism(plainCapability, name: "PLAIN")
+        let channel = try await prepareAuthenticationChannel(
+            operation: "PLAIN authenticate", advertising: .authenticate(mechanism), name: "PLAIN"
+        )
         let tag = generateCommandTag()
 
         let handlerPromise = channel.eventLoop.makePromise(of: [Capability].self)
@@ -143,24 +142,38 @@ extension IMAPConnection {
         try await channel.writeAndFlush(wrapped)
     }
 
-    /// Judges the mechanism against a live capability snapshot.
-    ///
-    /// Must run after `prepareAuthenticationChannel`: a disconnect (explicit,
-    /// or a recycle after a timeout or buffered BYE) clears the snapshot along
-    /// with the channel, and the reconnect refreshes it. Checking the stale
-    /// empty set first turned every re-authentication on a dropped connection
-    /// into "not advertised by server" without ever contacting the server. When
-    /// the snapshot is empty on a live channel, ask the server before deciding.
-    private func requireAdvertisedAuthenticationMechanism(
-        _ capability: Capability,
+    /// Returns the channel to authenticate on, judged against a capability snapshot
+    /// taken on that same channel. The check runs after the channel is prepared: a
+    /// disconnect clears the snapshot with the channel, and judging the stale empty
+    /// set first turned every re-authentication on a dropped connection into "not
+    /// advertised by server" without contacting the server. An empty snapshot on a
+    /// live channel is refreshed with an explicit CAPABILITY; that refresh runs through
+    /// `executeCommandBody`, which may recycle or reconnect the transport, so the
+    /// channel is prepared again afterwards and the caller authenticates on the
+    /// transport that is live now, never on one the refresh replaced.
+    private func prepareAuthenticationChannel(
+        operation: String,
+        advertising capability: Capability,
         name: String
-    ) async throws {
-        if capabilities.isEmpty {
-            try await refreshCapabilities(using: [], useCommandBody: true)
+    ) async throws -> Channel {
+        var channel = try await prepareAuthenticationChannel(operation: operation)
+        var refreshes = 0
+        while capabilities.isEmpty {
+            guard refreshes < 2 else {
+                throw IMAPError.connectionFailed("\(operation): capability snapshot stayed empty across reconnects")
+            }
+            refreshes += 1
+            if let override = capabilityRefreshOverrideForTesting {
+                try await override()
+            } else {
+                try await refreshCapabilities(using: [], useCommandBody: true)
+            }
+            channel = try await prepareAuthenticationChannel(operation: operation)
         }
         guard capabilities.contains(capability) else {
             throw IMAPError.unsupportedAuthMechanism("\(name) not advertised by server")
         }
+        return channel
     }
 
     private func prepareAuthenticationChannel(operation: String) async throws -> Channel {
@@ -226,10 +239,9 @@ extension IMAPConnection {
 
     func authenticateXOAUTH2Body(email: String, accessToken: String) async throws {
         let mechanism = AuthenticationMechanism("XOAUTH2")
-        let xoauthCapability = Capability.authenticate(mechanism)
-
-        let channel = try await prepareAuthenticationChannel(operation: "XOAUTH2 authenticate")
-        try await requireAdvertisedAuthenticationMechanism(xoauthCapability, name: "XOAUTH2")
+        let channel = try await prepareAuthenticationChannel(
+            operation: "XOAUTH2 authenticate", advertising: .authenticate(mechanism), name: "XOAUTH2"
+        )
         let tag = generateCommandTag()
 
         let handlerPromise = channel.eventLoop.makePromise(of: [Capability].self)

--- a/Sources/SwiftMail/IMAP/IMAPConnection+Authentication.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+Authentication.swift
@@ -33,11 +33,8 @@ extension IMAPConnection {
         let mechanism = AuthenticationMechanism("PLAIN")
         let plainCapability = Capability.authenticate(mechanism)
 
-        guard capabilities.contains(plainCapability) else {
-            throw IMAPError.unsupportedAuthMechanism("PLAIN not advertised by server")
-        }
-
         let channel = try await prepareAuthenticationChannel(operation: "PLAIN authenticate")
+        try await requireAdvertisedAuthenticationMechanism(plainCapability, name: "PLAIN")
         let tag = generateCommandTag()
 
         let handlerPromise = channel.eventLoop.makePromise(of: [Capability].self)
@@ -146,6 +143,26 @@ extension IMAPConnection {
         try await channel.writeAndFlush(wrapped)
     }
 
+    /// Judges the mechanism against a live capability snapshot.
+    ///
+    /// Must run after `prepareAuthenticationChannel`: a disconnect (explicit,
+    /// or a recycle after a timeout or buffered BYE) clears the snapshot along
+    /// with the channel, and the reconnect refreshes it. Checking the stale
+    /// empty set first turned every re-authentication on a dropped connection
+    /// into "not advertised by server" without ever contacting the server. When
+    /// the snapshot is empty on a live channel, ask the server before deciding.
+    private func requireAdvertisedAuthenticationMechanism(
+        _ capability: Capability,
+        name: String
+    ) async throws {
+        if capabilities.isEmpty {
+            try await refreshCapabilities(using: [], useCommandBody: true)
+        }
+        guard capabilities.contains(capability) else {
+            throw IMAPError.unsupportedAuthMechanism("\(name) not advertised by server")
+        }
+    }
+
     private func prepareAuthenticationChannel(operation: String) async throws -> Channel {
         try await waitForIdleCompletionIfNeeded()
         try await recycleConnectionIfBufferedTerminationIfNeeded(operation: operation)
@@ -211,11 +228,8 @@ extension IMAPConnection {
         let mechanism = AuthenticationMechanism("XOAUTH2")
         let xoauthCapability = Capability.authenticate(mechanism)
 
-        guard capabilities.contains(xoauthCapability) else {
-            throw IMAPError.unsupportedAuthMechanism("XOAUTH2 not advertised by server")
-        }
-
         let channel = try await prepareAuthenticationChannel(operation: "XOAUTH2 authenticate")
+        try await requireAdvertisedAuthenticationMechanism(xoauthCapability, name: "XOAUTH2")
         let tag = generateCommandTag()
 
         let handlerPromise = channel.eventLoop.makePromise(of: [Capability].self)

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -35,6 +35,7 @@ final class IMAPConnection {
     let commandQueue = IMAPCommandQueue()
     let responseBuffer = UntaggedResponseBuffer()
     var startTLSUpgradeOverrideForTesting: (() async throws -> Void)?
+    var capabilityRefreshOverrideForTesting: (() async throws -> Void)?
 
     let logger: Logging.Logger
     let duplexLogger: IMAPLogger
@@ -239,6 +240,10 @@ final class IMAPConnection {
 
     func replaceStartTLSUpgradeForTesting(_ upgrade: (() async throws -> Void)?) {
         self.startTLSUpgradeOverrideForTesting = upgrade
+    }
+
+    func replaceCapabilityRefreshForTesting(_ refresh: (() async throws -> Void)?) {
+        self.capabilityRefreshOverrideForTesting = refresh
     }
 
     func connect() async throws {

--- a/Tests/SwiftIMAPTests/AuthenticationCapabilityGuardTests.swift
+++ b/Tests/SwiftIMAPTests/AuthenticationCapabilityGuardTests.swift
@@ -1,0 +1,177 @@
+import Foundation
+import NIO
+import NIOEmbedded
+import NIOIMAP
+import NIOIMAPCore
+import Testing
+@testable import SwiftMail
+
+/// The pre-authentication mechanism guard must judge a live capability
+/// snapshot. A disconnect clears the snapshot with the channel, so checking
+/// it before `prepareAuthenticationChannel` reported every re-authentication
+/// on a dropped connection as "not advertised by server" without contacting
+/// the server, and the connection never recovered on its own.
+@Suite(.serialized, .timeLimit(.minutes(1)))
+struct AuthenticationCapabilityGuardTests {
+    private struct Harness {
+        let connection: IMAPConnection
+        let channel: NIOAsyncTestingChannel
+    }
+
+    @Test
+    func emptySnapshotIsRefreshedBeforeJudgingXOAUTH2() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        let harness = try await makeLiveHarness(group: group, capabilities: [])
+
+        let authTask = Task {
+            try await harness.connection.authenticateXOAUTH2(email: "user@example.com", accessToken: "token")
+        }
+        try await answerCapabilityRefresh(
+            harness,
+            tag: "A001",
+            capabilities: "IMAP4rev1 SASL-IR AUTH=XOAUTH2"
+        )
+        try await answerAuthenticate(harness, tag: "A002", mechanism: "XOAUTH2")
+        try await answerCapabilityRefresh(harness, tag: "A003", capabilities: "IMAP4rev1 AUTH=XOAUTH2")
+
+        try await authTask.value
+        #expect(harness.connection.isAuthenticated)
+    }
+
+    @Test
+    func emptySnapshotIsRefreshedBeforeJudgingPLAIN() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        let harness = try await makeLiveHarness(group: group, capabilities: [])
+
+        let authTask = Task {
+            try await harness.connection.authenticatePlain(username: "user", password: "secret")
+        }
+        try await answerCapabilityRefresh(
+            harness,
+            tag: "A001",
+            capabilities: "IMAP4rev1 SASL-IR AUTH=PLAIN"
+        )
+        try await answerAuthenticate(harness, tag: "A002", mechanism: "PLAIN")
+        try await answerCapabilityRefresh(harness, tag: "A003", capabilities: "IMAP4rev1 AUTH=PLAIN")
+
+        try await authTask.value
+        #expect(harness.connection.isAuthenticated)
+    }
+
+    @Test
+    func refreshedSnapshotWithoutTheMechanismIsStillRejected() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        let harness = try await makeLiveHarness(group: group, capabilities: [])
+
+        let authTask = Task {
+            try await harness.connection.authenticateXOAUTH2(email: "user@example.com", accessToken: "token")
+        }
+        try await answerCapabilityRefresh(harness, tag: "A001", capabilities: "IMAP4rev1 AUTH=PLAIN")
+
+        do {
+            try await authTask.value
+            Issue.record("Expected XOAUTH2 to be rejected after the refresh")
+        } catch let error as IMAPError {
+            guard case .unsupportedAuthMechanism(let reason) = error else {
+                Issue.record("Unexpected IMAP error: \(error)")
+                return
+            }
+            #expect(reason == "XOAUTH2 not advertised by server")
+        }
+        #expect(!harness.connection.isAuthenticated)
+    }
+
+    @Test
+    func disconnectedConnectionReconnectsBeforeJudgingTheMechanism() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        // Port 1 refuses immediately: the transport attempt fails, which is the
+        // point. Before the fix the empty snapshot short-circuited to
+        // "not advertised" without any connection attempt.
+        let connection = makeConnection(group: group, port: 1)
+
+        do {
+            try await connection.authenticateXOAUTH2(email: "user@example.com", accessToken: "token")
+            Issue.record("Expected the transport attempt to fail")
+        } catch let error as IMAPError {
+            guard case .unsupportedAuthMechanism = error else { return }
+            Issue.record("Disconnected connection judged the mechanism instead of reconnecting: \(error)")
+        } catch {
+            // Any transport-level failure is the expected outcome.
+        }
+    }
+
+    // MARK: - Harness
+
+    private func makeConnection(group: MultiThreadedEventLoopGroup, port: Int) -> IMAPConnection {
+        IMAPConnection(
+            host: "127.0.0.1",
+            port: port,
+            transportSecurity: .plainText,
+            minimumTLSVersion: .tlsv12,
+            group: group,
+            loggerLabel: "test.imap",
+            outboundLabel: "test.imap.out",
+            inboundLabel: "test.imap.in",
+            connectionID: "test-auth-guard",
+            connectionRole: "test",
+            parserLimits: .default
+        )
+    }
+
+    private func makeLiveHarness(
+        group: MultiThreadedEventLoopGroup,
+        capabilities: Set<NIOIMAPCore.Capability>
+    ) async throws -> Harness {
+        let connection = makeConnection(group: group, port: 143)
+        let channel = NIOAsyncTestingChannel()
+        try await channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 143))
+        try await channel.addIMAPClientHandler()
+        try await channel.pipeline.addHandler(connection.duplexLogger)
+        try await channel.pipeline.addHandler(connection.responseBuffer)
+        connection.replaceChannelForTesting(channel)
+        connection.replaceCapabilitiesForTesting(capabilities)
+        return Harness(connection: connection, channel: channel)
+    }
+
+    private func answerCapabilityRefresh(_ harness: Harness, tag: String, capabilities: String) async throws {
+        let line = try await nextOutboundLine(from: harness.channel)
+        #expect(line == "\(tag) CAPABILITY\r\n", "expected a CAPABILITY refresh, got \(line ?? "<nothing>")")
+        try await writeInboundLines(
+            harness.channel,
+            "* CAPABILITY \(capabilities)\r\n\(tag) OK CAPABILITY completed\r\n"
+        )
+    }
+
+    private func answerAuthenticate(_ harness: Harness, tag: String, mechanism: String) async throws {
+        let line = try await nextOutboundLine(from: harness.channel)
+        #expect(
+            line?.hasPrefix("\(tag) AUTHENTICATE \(mechanism) ") == true,
+            "expected an AUTHENTICATE \(mechanism) with SASL-IR, got \(line ?? "<nothing>")"
+        )
+        try await writeInboundLines(harness.channel, "\(tag) OK authenticated\r\n")
+    }
+
+    private func writeInboundLines(_ channel: NIOAsyncTestingChannel, _ text: String) async throws {
+        var buffer = channel.allocator.buffer(capacity: text.utf8.count)
+        buffer.writeString(text)
+        try await channel.writeInbound(buffer)
+    }
+
+    private func nextOutboundLine(
+        from channel: NIOAsyncTestingChannel,
+        timeoutNanoseconds: UInt64 = 1_000_000_000
+    ) async throws -> String? {
+        let start = DispatchTime.now().uptimeNanoseconds
+        while DispatchTime.now().uptimeNanoseconds - start < timeoutNanoseconds {
+            if var line = try await channel.readOutbound(as: ByteBuffer.self) {
+                return line.readString(length: line.readableBytes)
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        return nil
+    }
+}

--- a/Tests/SwiftIMAPTests/AuthenticationCapabilityGuardTests.swift
+++ b/Tests/SwiftIMAPTests/AuthenticationCapabilityGuardTests.swift
@@ -104,6 +104,45 @@ struct AuthenticationCapabilityGuardTests {
         }
     }
 
+    /// The empty-snapshot refresh runs through `executeCommandBody`, which recycles a
+    /// buffered BYE or reconnects a dead transport. Authentication must then use the
+    /// replacement, not the channel captured before the refresh: writing on the stale
+    /// one failed, and that failure's `disconnectBody()` closed the healthy replacement
+    /// too (review on #221).
+    @Test
+    func refreshThatReplacedTheChannelAuthenticatesOnTheReplacement() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        let stale = try await makeLiveHarness(group: group, capabilities: [])
+        let connection = stale.connection
+        let replacementChannel = NIOAsyncTestingChannel()
+        connection.replaceCapabilityRefreshForTesting {
+            // The transport died under the refresh; the connection reconnected and
+            // took its capabilities from the new channel.
+            try await stale.channel.close()
+            try await replacementChannel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 143))
+            try await replacementChannel.addIMAPClientHandler()
+            try await replacementChannel.pipeline.addHandler(connection.duplexLogger)
+            try await replacementChannel.pipeline.addHandler(connection.responseBuffer)
+            connection.replaceChannelForTesting(replacementChannel)
+            connection.replaceCapabilitiesForTesting([
+                Capability("IMAP4rev1"),
+                Capability("SASL-IR"),
+                .authenticate(AuthenticationMechanism("PLAIN"))
+            ])
+        }
+        let replacement = Harness(connection: connection, channel: replacementChannel)
+        let authTask = Task {
+            try await connection.authenticatePlain(username: "user", password: "secret")
+        }
+        try await answerAuthenticate(replacement, tag: "A001", mechanism: "PLAIN")
+        try await answerCapabilityRefresh(replacement, tag: "A002", capabilities: "IMAP4rev1 AUTH=PLAIN")
+        try await authTask.value
+        #expect(connection.isAuthenticated)
+        let staleWrite = try? await stale.channel.readOutbound(as: ByteBuffer.self)
+        #expect(staleWrite == nil, "nothing may be written on the transport the refresh replaced")
+    }
+
     // MARK: - Harness
 
     private func makeConnection(group: MultiThreadedEventLoopGroup, port: Int) -> IMAPConnection {


### PR DESCRIPTION
## Problem

`authenticatePlainBody` and `authenticateXOAUTH2Body` check the cached `capabilities` set for the mechanism **before** calling `prepareAuthenticationChannel`. `disconnectBody` clears that set together with the channel, and a recycle after a timeout or a buffered BYE goes through `disconnectBody`. The next authentication on that connection therefore throws `unsupportedAuthMechanism("XOAUTH2 not advertised by server")` without contacting the server, even though the reconnect that would refresh the snapshot is one line further down inside `prepareAuthenticationChannel`. A named connection or IDLE connection that was dropped once cannot recover on its own: every `ensureAuthenticated` fails the same way.

Observed against Gmail on 2026-09-04: a slow AUTHENTICATE hit the 10 s timeout, the connection was recycled, and every later use of that connection reported "XOAUTH2 not advertised by server" for half an hour while Gmail was advertising `AUTH=XOAUTH2` the whole time.

## Change

- Run the mechanism guard after `prepareAuthenticationChannel`, so a nil channel reconnects (and refreshes capabilities) first.
- When the snapshot is empty on a live channel, refresh it with a `CAPABILITY` command (`useCommandBody: true`, the command queue is already held) before deciding.
- A server that genuinely does not advertise the mechanism is still rejected with the same `unsupportedAuthMechanism` error.

## Tests

`AuthenticationCapabilityGuardTests` (testing channel, no network):
- an empty snapshot triggers a `CAPABILITY` refresh before `AUTHENTICATE` for XOAUTH2 and for PLAIN;
- a refreshed snapshot that lacks the mechanism is still rejected;
- a disconnected connection attempts the transport instead of judging the mechanism.

`swiftlint lint --strict` is clean; `ClientIdentificationReplayTests`, `IMAPNamedConnectionTests`, `XOAUTH2AuthenticationHandlerTests`, and `IMAPConnectionTLSModeTests` still pass.
