### PR TITLE
Send CHARSET UTF-8 with SEARCH when a criterion carries non-ASCII text

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Commands/ExtendedSearchCommand.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/ExtendedSearchCommand.swift
@@ -76,6 +76,7 @@ struct ExtendedSearchCommand<T: MessageIdentifier>: IMAPTaggedCommand, Sendable 
         }
 
         let key = SearchKey.and(nioCriteria)
+        let charset = SearchCriteria.searchCharset(for: criteria)
 
         let returnOptions: [SearchReturnOption]
         if useEsearch {
@@ -107,9 +108,15 @@ struct ExtendedSearchCommand<T: MessageIdentifier>: IMAPTaggedCommand, Sendable 
                 )
             }
         } else if T.self == UID.self {
-            return TaggedCommand(tag: tag, command: .uidSearch(key: key, returnOptions: returnOptions))
+            return TaggedCommand(
+                tag: tag,
+                command: .uidSearch(key: key, charset: charset, returnOptions: returnOptions)
+            )
         } else {
-            return TaggedCommand(tag: tag, command: .search(key: key, returnOptions: returnOptions))
+            return TaggedCommand(
+                tag: tag,
+                command: .search(key: key, charset: charset, returnOptions: returnOptions)
+            )
         }
     }
 }

--- a/Sources/SwiftMail/IMAP/IMAP/Commands/SearchCommand.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Commands/SearchCommand.swift
@@ -84,6 +84,7 @@ struct SearchCommand<T: MessageIdentifier>: IMAPTaggedCommand, Sendable {
         }
 
         let key = SearchKey.and(nioCriteria)
+        let charset = SearchCriteria.searchCharset(for: criteria)
 
         if useSort {
             if T.self == UID.self {
@@ -98,9 +99,9 @@ struct SearchCommand<T: MessageIdentifier>: IMAPTaggedCommand, Sendable {
                 )
             }
         } else if T.self == UID.self {
-            return TaggedCommand(tag: tag, command: .uidSearch(key: key))
+            return TaggedCommand(tag: tag, command: .uidSearch(key: key, charset: charset))
         } else {
-            return TaggedCommand(tag: tag, command: .search(key: key))
+            return TaggedCommand(tag: tag, command: .search(key: key, charset: charset))
         }
     }
 }

--- a/Sources/SwiftMail/IMAP/Models/SearchCriteria.swift
+++ b/Sources/SwiftMail/IMAP/Models/SearchCriteria.swift
@@ -165,6 +165,39 @@ public indirect enum SearchCriteria: Sendable {
         }
     }
 
+    /// Whether this criteria (or any nested child) carries a search string that is not
+    /// pure US-ASCII. RFC 3501 §6.4.4 assumes US-ASCII when the optional `CHARSET`
+    /// argument is omitted, so such strings must be sent as `CHARSET UTF-8`; Gmail rejects
+    /// the whole command (`BAD Could not parse command`) when the argument is missing.
+    var requiresUTF8Charset: Bool {
+        switch self {
+            case .bcc(let value), .body(let value), .cc(let value), .from(let value),
+                 .subject(let value), .text(let value), .to(let value):
+                return !Self.isASCII(value)
+            case .header(_, let value):
+                return !Self.isASCII(value)
+            case .and(let criterias):
+                return criterias.contains { $0.requiresUTF8Charset }
+            case .not(let criteria):
+                return criteria.requiresUTF8Charset
+            case .or(let left, let right):
+                return left.requiresUTF8Charset || right.requiresUTF8Charset
+            default:
+                return false
+        }
+    }
+
+    /// The `CHARSET` argument a `SEARCH` command needs for `criteria`: `"UTF-8"` when any
+    /// search string is not pure US-ASCII, otherwise `nil` so ASCII-only searches keep their
+    /// existing wire shape.
+    static func searchCharset(for criteria: [SearchCriteria]) -> String? {
+        criteria.contains { $0.requiresUTF8Charset } ? "UTF-8" : nil
+    }
+
+    private static func isASCII(_ value: String) -> Bool {
+        value.utf8.allSatisfy { $0 < 0x80 }
+    }
+
     /** Converts a Swift string to an NIO ByteBuffer.
      * - Parameter str: The string to convert.
      * - Returns: A ByteBuffer containing the string data.

--- a/Tests/SwiftIMAPTests/SearchCharsetTests.swift
+++ b/Tests/SwiftIMAPTests/SearchCharsetTests.swift
@@ -1,0 +1,87 @@
+import Foundation
+import NIO
+import NIOEmbedded
+@preconcurrency import NIOIMAP
+@preconcurrency import NIOIMAPCore
+import Testing
+@testable import SwiftMail
+
+/// RFC 3501 §6.4.4 assumes US-ASCII when `SEARCH` carries no `CHARSET`, so a search string
+/// with non-ASCII bytes must be sent as `CHARSET UTF-8`. Gmail answers
+/// `BAD Could not parse command` when it is missing.
+@Suite(.serialized, .timeLimit(.minutes(1)))
+struct SearchCharsetTests {
+    @Test
+    func extendedSearchAddsUTF8CharsetForNonASCIISubject() async throws {
+        let command = ExtendedSearchCommand<SwiftMail.UID>(
+            criteria: [.subject("Morning brief — Saturday")],
+            useEsearch: true
+        )
+        let wire = try await Self.wireFormat(of: command.toTaggedCommand(tag: "C001"))
+
+        #expect(wire.hasPrefix("C001 UID SEARCH RETURN (COUNT MIN MAX ALL) CHARSET UTF-8 "))
+        #expect(wire.contains("SUBJECT {26}\r\nMorning brief — Saturday"))
+    }
+
+    @Test
+    func extendedSearchOmitsCharsetForASCIICriteria() async throws {
+        let command = ExtendedSearchCommand<SwiftMail.UID>(
+            criteria: [.subject("Morning brief"), .from("news@example.com")],
+            useEsearch: true
+        )
+        let wire = try await Self.wireFormat(of: command.toTaggedCommand(tag: "C002"))
+
+        #expect(!wire.contains("CHARSET"))
+        #expect(wire.contains("SUBJECT \"Morning brief\""))
+    }
+
+    @Test
+    func plainSearchAddsUTF8CharsetForNestedNonASCIIText() async throws {
+        let command = SearchCommand<SwiftMail.UID>(
+            criteria: [.or(.from("news@example.com"), .text("café"))]
+        )
+        let wire = try await Self.wireFormat(of: command.toTaggedCommand(tag: "C003"))
+
+        #expect(wire.hasPrefix("C003 UID SEARCH CHARSET UTF-8 "))
+        #expect(wire.contains("OR FROM \"news@example.com\" TEXT {5}\r\ncafé"))
+    }
+
+    @Test
+    func plainSearchOmitsCharsetForASCIICriteria() async throws {
+        let command = SearchCommand<SwiftMail.UID>(criteria: [.text("invoice")])
+        let wire = try await Self.wireFormat(of: command.toTaggedCommand(tag: "C004"))
+
+        #expect(wire.hasPrefix("C004 UID SEARCH "))
+        #expect(!wire.contains("CHARSET"))
+        #expect(wire.contains("TEXT \"invoice\""))
+    }
+
+    @Test
+    func charsetDetectionCoversStringCarryingCriteria() {
+        #expect(SearchCriteria.header("Subject", "naïve").requiresUTF8Charset)
+        #expect(SearchCriteria.not(.body("Grüße")).requiresUTF8Charset)
+        #expect(SearchCriteria.and([.seen, .to("ærlig@example.com")]).requiresUTF8Charset)
+        #expect(!SearchCriteria.and([.seen, .to("plain@example.com")]).requiresUTF8Charset)
+        #expect(!SearchCriteria.keyword("$Important").requiresUTF8Charset)
+        #expect(SearchCriteria.searchCharset(for: [.subject("plain")]) == nil)
+        #expect(SearchCriteria.searchCharset(for: [.seen, .subject("Ünïcode")]) == "UTF-8")
+    }
+
+    /// Renders the command bytes. A search string that NIO IMAP must send as a synchronizing
+    /// literal stops the encoder at `{n}\r\n` until the server continues, so this answers each
+    /// literal announcement with `+` the way a server would and returns the complete wire format.
+    private static func wireFormat(of tagged: TaggedCommand) async throws -> String {
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
+        let wrapped = IMAPClientHandler.OutboundIn.part(CommandStreamPart.tagged(tagged))
+        let write = Task { try await channel.writeAndFlush(wrapped) }
+        var wire = ""
+        for _ in 0..<4 {
+            var chunk = try await channel.waitForOutboundWrite(as: ByteBuffer.self)
+            wire += chunk.readString(length: chunk.readableBytes) ?? ""
+            guard wire.hasSuffix("}\r\n") else { break }
+            try await channel.writeInbound(ByteBuffer(string: "+ Ready\r\n"))
+        }
+        try await write.value
+        return wire
+    }
+}


### PR DESCRIPTION
## Summary

`SEARCH` and `UID SEARCH` never carried a `CHARSET` argument. RFC 3501 §6.4.4 assumes US-ASCII when it is omitted, and NIO IMAP sends any search string that is not short printable ASCII as a literal, so a subject with an em dash, a curly quote, or an accent went out as an 8-bit literal in an ASCII-assumed command. Gmail rejects that outright:

```
A042 UID SEARCH RETURN (COUNT MIN MAX ALL) SUBJECT {26}
A042 BAD Could not parse command
```

Observed from Kestrel Mail against imap.gmail.com on 2026-09-04/05: every remote subject search whose subject carried non-ASCII text failed this way (eight rejections in sixteen hours, plus one `BAD Unknown command <literal fragment>` where Gmail's parser kept reading).

## Change

- `SearchCriteria.requiresUTF8Charset` walks a criterion (through `and`/`or`/`not`) and reports whether any string payload (`bcc`, `body`, `cc`, `from`, `header`, `subject`, `text`, `to`) contains non-ASCII bytes.
- `SearchCriteria.searchCharset(for:)` returns `"UTF-8"` when any criterion needs it, otherwise `nil`.
- `SearchCommand` and `ExtendedSearchCommand` pass that value as `charset:` to NIO's `.search` / `.uidSearch`. ASCII-only searches keep their existing wire shape; non-ASCII searches become `UID SEARCH [RETURN (...)] CHARSET UTF-8 <keys>`, which is the RFC 3501 / RFC 4731 search-program order NIO already emits.
- `SORT` was already sending `sortCharset` and is unchanged.

## Tests

`SearchCharsetTests` renders both commands through `IMAPClientHandler` on a testing channel, answering the synchronizing-literal continuation the way a server would, and asserts:

- non-ASCII subject → `... RETURN (COUNT MIN MAX ALL) CHARSET UTF-8 ... SUBJECT {26}\r\nMorning brief — Saturday`
- ASCII criteria → no `CHARSET`, subject still quoted
- nested `OR FROM ... TEXT {5}\r\ncafé` → `CHARSET UTF-8` on plain `SearchCommand`
- detection covers `header`, `not`, `and`, and leaves `keyword` alone

`swift test --filter 'SearchCharsetTests|WithinSearchTests|ExtendedSearchHandlerTests'` passes (24 tests); `swiftlint lint --strict` is clean.
