### PR TITLE
Require a live channel for an authenticated IMAP session

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAPConnection+Authentication.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+Authentication.swift
@@ -4,32 +4,15 @@ import NIOIMAPCore
 import NIO
 
 extension IMAPConnection {
-    func login(username: String, password: String) async throws {
-        let command = LoginCommand(username: username, password: password)
-        let loginCapabilities = try await executeCommand(command)
-        isSessionAuthenticated = true
-        try await refreshCapabilities(using: loginCapabilities)
-        await fetchNamespacesIfSupported(useCommandBody: false)
-    }
-
     /// Authenticate using AUTHENTICATE PLAIN (RFC 4616) with optional SASL-IR (RFC 4959).
     ///
     /// When the server advertises `SASL-IR`, the credentials are sent inline with the
     /// AUTHENTICATE command (saving a round trip). Otherwise falls back to the standard
-    /// continuation-based exchange.
-    func authenticatePlain(username: String, password: String) async throws {
-        try await commandQueue.run { [self] in
-            try await self.authenticatePlainBody(username: username, password: password)
-        }
-    }
-
-    func authenticateXOAUTH2(email: String, accessToken: String) async throws {
-        try await commandQueue.run { [self] in
-            try await self.authenticateXOAUTH2Body(email: email, accessToken: accessToken)
-        }
-    }
-
+    /// continuation-based exchange. Runs inside the command queue; the queue-taking
+    /// entry points live in `IMAPConnection+Reauthentication.swift`.
     func authenticatePlainBody(username: String, password: String) async throws {
+        authenticationInProgress = true
+        defer { authenticationInProgress = false }
         let mechanism = AuthenticationMechanism("PLAIN")
         let channel = try await prepareAuthenticationChannel(
             operation: "PLAIN authenticate", advertising: .authenticate(mechanism), name: "PLAIN"
@@ -92,7 +75,7 @@ extension IMAPConnection {
 
             scheduledTask?.cancel()
             responseBuffer.hasActiveHandler = false
-            isSessionAuthenticated = true
+            markSessionAuthenticated()
 
             duplexLogger.flushInboundBuffer()
             try await refreshCapabilities(using: postAuthCapabilities)
@@ -238,6 +221,8 @@ extension IMAPConnection {
     }
 
     func authenticateXOAUTH2Body(email: String, accessToken: String) async throws {
+        authenticationInProgress = true
+        defer { authenticationInProgress = false }
         let mechanism = AuthenticationMechanism("XOAUTH2")
         let channel = try await prepareAuthenticationChannel(
             operation: "XOAUTH2 authenticate", advertising: .authenticate(mechanism), name: "XOAUTH2"
@@ -304,7 +289,7 @@ extension IMAPConnection {
             await handleConnectionTerminationInResponses(handler.untaggedResponses)
             duplexLogger.flushInboundBuffer()
 
-            isSessionAuthenticated = true
+            markSessionAuthenticated()
             // AUTHENTICATE often returns an OK without CAPABILITY data, and RFC 3501
             // invalidates the pre-authentication capability set once authentication
             // succeeds. Refresh from the server instead of retaining the stale

--- a/Sources/SwiftMail/IMAP/IMAPConnection+CommandExecution.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+CommandExecution.swift
@@ -71,6 +71,7 @@ extension IMAPConnection {
         if self.channel == nil {
             logger.info("\(connectionContext) Channel is nil, re-establishing connection before sending command")
             try await connectBody()
+            try await reauthenticateIfSessionWasLost(before: String(describing: CommandType.self))
         }
 
         guard let channel = self.channel, channel.isActive else {

--- a/Sources/SwiftMail/IMAP/IMAPConnection+Connection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+Connection.swift
@@ -11,6 +11,10 @@ extension IMAPConnection {
             logger.debug("\(connectionContext) connect requested while channel is already active")
             return
         }
+        if let connectOverrideForTesting {
+            try await connectOverrideForTesting()
+            return
+        }
 
         // Any buffered state belongs to a previous transport and must not leak.
         responseBuffer.reset()
@@ -247,6 +251,9 @@ extension IMAPConnection {
     }
 
     func disconnectBody() async throws {
+        if isSessionAuthenticated {
+            lostAuthenticatedSession = true
+        }
         guard let channel = self.channel else {
             logger.warning("\(connectionContext) Attempted to disconnect when channel was already nil")
             isSessionAuthenticated = false
@@ -276,6 +283,9 @@ extension IMAPConnection {
         if let channel = self.channel, !channel.isActive {
             logger.info("\(connectionContext) Channel is no longer active, clearing channel reference")
             self.channel = nil
+            if isSessionAuthenticated {
+                lostAuthenticatedSession = true
+            }
             self.isSessionAuthenticated = false
             self.idleHandler = nil
             self.idleTerminationInProgress = false

--- a/Sources/SwiftMail/IMAP/IMAPConnection+Idle.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+Idle.swift
@@ -37,6 +37,7 @@ extension IMAPConnection {
         if self.channel == nil {
             logger.info("\(connectionContext) Channel is nil, re-establishing connection before starting IDLE")
             try await connectBody()
+            try await reauthenticateIfSessionWasLost(before: "IDLE")
         }
 
         guard let channel = self.channel, channel.isActive else {

--- a/Sources/SwiftMail/IMAP/IMAPConnection+Reauthentication.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+Reauthentication.swift
@@ -1,0 +1,75 @@
+import Foundation
+import NIOIMAPCore
+
+extension IMAPConnection {
+    // MARK: - Queue-taking authentication entry points
+
+    func login(username: String, password: String) async throws {
+        try await commandQueue.run { [self] in
+            try await self.loginBody(username: username, password: password)
+        }
+    }
+
+    func authenticatePlain(username: String, password: String) async throws {
+        try await commandQueue.run { [self] in
+            try await self.authenticatePlainBody(username: username, password: password)
+        }
+    }
+
+    func authenticateXOAUTH2(email: String, accessToken: String) async throws {
+        try await commandQueue.run { [self] in
+            try await self.authenticateXOAUTH2Body(email: email, accessToken: accessToken)
+        }
+    }
+
+    // MARK: - Recovery inside the command queue
+
+    /// Re-authenticates on the transport the caller just reopened, when the session it
+    /// replaced had been authenticated and the server installed a way to do so.
+    ///
+    /// Runs inside the command queue: the caller is `executeCommandBody` or
+    /// `startIdleSession`, right after `connectBody()`. Without this the first command
+    /// after a peer reset went out on the fresh socket before any AUTHENTICATE (Gmail
+    /// answers `BAD Unknown command`), and every caller that had checked
+    /// `isAuthenticated` a moment earlier was already wrong by the time its command ran.
+    /// Recovering here makes the check and the command atomic and single-flight, because
+    /// the queue serializes them, and it covers IDLE, which never consulted the server's
+    /// re-authentication path.
+    func reauthenticateIfSessionWasLost(before operation: String) async throws {
+        guard lostAuthenticatedSession, !authenticationInProgress else { return }
+        guard let reauthenticate = reauthenticateAfterReconnect else {
+            let warning = "\(connectionContext) Lost an authenticated session with no re-authentication "
+                + "configured; \(operation) runs unauthenticated"
+            logger.warning("\(warning)")
+            return
+        }
+        logger.info("\(connectionContext) Re-authenticating the reopened transport before \(operation)")
+        try await reauthenticate(self)
+    }
+
+    /// LOGIN for a caller that already holds the command queue.
+    func loginBody(username: String, password: String) async throws {
+        authenticationInProgress = true
+        defer { authenticationInProgress = false }
+        let command = LoginCommand(username: username, password: password)
+        let loginCapabilities = try await executeCommandBody(command)
+        markSessionAuthenticated()
+        try await refreshCapabilities(using: loginCapabilities, useCommandBody: true)
+        await fetchNamespacesIfSupported(useCommandBody: true)
+    }
+
+    /// ID for a caller that already holds the command queue.
+    func idBody(_ identification: Identification) async throws -> Identification {
+        guard capabilities.contains(.id) else {
+            throw IMAPError.commandNotSupported("ID command not supported by server")
+        }
+        return try await executeCommandBody(IDCommand(identification: identification))
+    }
+
+    /// Every successful authentication lands here: the session is live again and no
+    /// longer counts as lost.
+    func markSessionAuthenticated() {
+        isSessionAuthenticated = true
+        lostAuthenticatedSession = false
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -36,6 +36,18 @@ final class IMAPConnection {
     let responseBuffer = UntaggedResponseBuffer()
     var startTLSUpgradeOverrideForTesting: (() async throws -> Void)?
     var capabilityRefreshOverrideForTesting: (() async throws -> Void)?
+    var connectOverrideForTesting: (() async throws -> Void)?
+    /// Re-authenticates this connection inside the command queue after the command path
+    /// or an IDLE start had to reopen the transport for a session that was authenticated.
+    /// Installed by `IMAPServer` on every connection it authenticates; nil until then.
+    var reauthenticateAfterReconnect: (@Sendable (IMAPConnection) async throws -> Void)?
+    /// Set when an authenticated session's channel is lost (peer reset, buffered BYE,
+    /// timeout recycle) rather than ended on purpose. Cleared by the next successful
+    /// authentication and by an explicit `disconnect()`.
+    var lostAuthenticatedSession = false
+    /// True while LOGIN, AUTHENTICATE PLAIN, or AUTHENTICATE XOAUTH2 runs, so the
+    /// capability refresh inside them cannot trigger a nested re-authentication.
+    var authenticationInProgress = false
 
     let logger: Logging.Logger
     let duplexLogger: IMAPLogger
@@ -250,6 +262,10 @@ final class IMAPConnection {
         self.capabilityRefreshOverrideForTesting = refresh
     }
 
+    func replaceConnectForTesting(_ connect: (() async throws -> Void)?) {
+        self.connectOverrideForTesting = connect
+    }
+
     func connect() async throws {
         try await commandQueue.run { [self] in
             try await self.connectBody()
@@ -265,6 +281,8 @@ final class IMAPConnection {
     func disconnect() async throws {
         try await commandQueue.run { [self] in
             try await self.disconnectBody()
+            // Ending the session on purpose is not losing it.
+            self.lostAuthenticatedSession = false
         }
     }
 }

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -213,8 +213,12 @@ final class IMAPConnection {
         namespaces
     }
 
+    /// An authenticated session needs a live channel. A transport the peer reset leaves
+    /// `isSessionAuthenticated` set until the next command notices the dead channel, and a
+    /// caller that trusted the flag alone then sent an authenticated-state command on the
+    /// fresh transport `executeCommandBody` reopens (Gmail answers `BAD Unknown command`).
     var isAuthenticated: Bool {
-        isSessionAuthenticated
+        isSessionAuthenticated && isConnected
     }
 
     var identifier: String {

--- a/Sources/SwiftMail/IMAP/IMAPServer+Connection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Connection.swift
@@ -212,6 +212,7 @@ extension IMAPServer {
         // handle; failure clears this sentinel so a later call can retry normally.
         pendingNamedConnectionWaiters[normalizedName] = []
         let connection = makeNamedConnection(name: normalizedName)
+        installReauthentication(on: connection)
 
         do {
             try await connection.connect()

--- a/Sources/SwiftMail/IMAP/IMAPServer+Helpers.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Helpers.swift
@@ -20,12 +20,25 @@ extension IMAPServer {
     }
 
     /// Refreshes session-scoped state before a capability-dependent command decision.
+    ///
+    /// One recovery at a time: concurrent primary callers that all found the session
+    /// gone share the same authentication instead of each sending LOGIN or
+    /// AUTHENTICATE, which failed the later ones on an already-authenticated session
+    /// and could invoke an OAuth token provider twice.
     func ensurePrimaryConnectionAuthenticated() async throws {
-        if let authentication, !primaryConnection.isAuthenticated {
-            logger.info("Primary connection not authenticated; re-authenticating before command")
-            try await authentication.authenticate(on: primaryConnection)
-            namespaces = primaryConnection.namespacesSnapshot
+        guard let authentication, !primaryConnection.isAuthenticated else { return }
+        if let inFlight = primaryAuthenticationInFlight {
+            try await inFlight.value
+            return
         }
+        logger.info("Primary connection not authenticated; re-authenticating before command")
+        let task = Task { [primaryConnection] in
+            try await authentication.authenticate(on: primaryConnection)
+        }
+        primaryAuthenticationInFlight = task
+        defer { primaryAuthenticationInFlight = nil }
+        try await task.value
+        namespaces = primaryConnection.namespacesSnapshot
     }
 
     func resolveMailboxPath(_ mailbox: String) -> String {

--- a/Sources/SwiftMail/IMAP/IMAPServer+Idle.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Idle.swift
@@ -59,6 +59,7 @@ extension IMAPServer {
         // IDLE cycle task (which is Task.detached and can outlive the server).
         let idleGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let connection = makeIdleConnection(sessionID: sessionID, mailbox: resolvedMailbox, group: idleGroup)
+        installReauthentication(on: connection)
         idleConnections[sessionID] = IdleConnection(
             mailbox: resolvedMailbox,
             connection: connection,

--- a/Sources/SwiftMail/IMAP/IMAPServer+Reauthentication.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Reauthentication.swift
@@ -1,0 +1,65 @@
+import Foundation
+import NIOIMAPCore
+
+extension IMAPServer.Authentication {
+    /// The same steps as `authenticate(on:)` for a caller that already holds the
+    /// connection's command queue: the transparent re-authentication a connection runs
+    /// after reopening its transport inside a command or an IDLE start.
+    func authenticateBody(on connection: IMAPConnection) async throws {
+        switch method {
+            case .login(let username, let password):
+                try await connection.loginBody(username: username, password: password)
+            case .plain(let username, let password):
+                try await connection.authenticatePlainBody(username: username, password: password)
+            case .xoauth2(let email, let accessTokenProvider):
+                let accessToken = try await accessTokenProvider()
+                try await connection.authenticateXOAUTH2Body(email: email, accessToken: accessToken)
+        }
+        guard let identification else { return }
+        try await Self.identifyBody(connection, with: identification)
+    }
+
+    /// `identify(_:with:)` for a caller holding the command queue: the same tolerance for
+    /// a server that refuses ID, the same propagation of a failure that recycled the connection.
+    static func identifyBody(_ connection: IMAPConnection, with identification: Identification) async throws {
+        guard connection.capabilitiesSnapshot.contains(.id) else { return }
+        do {
+            _ = try await connection.idBody(identification)
+        } catch let error as CancellationError {
+            throw error
+        } catch {
+            guard connection.isConnected, connection.isAuthenticated else {
+                throw error
+            }
+        }
+    }
+}
+
+extension IMAPServer {
+    /// Teaches a connection this server owns how to recover its session when its
+    /// command path or IDLE start has to reopen the transport. Without it the first
+    /// command after a peer reset went out on the fresh socket before any AUTHENTICATE
+    /// (Gmail answers `BAD Unknown command`), whatever a caller had checked a moment
+    /// earlier.
+    func installReauthentication(on connection: IMAPConnection) {
+        guard let authentication else {
+            connection.reauthenticateAfterReconnect = nil
+            return
+        }
+        connection.reauthenticateAfterReconnect = { connection in
+            try await authentication.authenticateBody(on: connection)
+        }
+    }
+
+    /// Runs whenever `authentication` changes: the primary and every live named and
+    /// IDLE connection learn the current credentials.
+    func installReauthenticationOnOwnedConnections() {
+        installReauthentication(on: primaryConnection)
+        for named in namedConnections.values {
+            installReauthentication(on: named.connection)
+        }
+        for idle in idleConnections.values {
+            installReauthentication(on: idle.connection)
+        }
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -69,7 +69,12 @@ public actor IMAPServer {
     var pendingNamedConnectionWaiters: [String: [CheckedContinuation<IMAPNamedConnection, any Error>]] = [:]
 
     /// Authentication configuration for spawning new connections.
-    var authentication: Authentication?
+    var authentication: Authentication? {
+        didSet { installReauthenticationOnOwnedConnections() }
+    }
+    /// The primary re-authentication in flight, shared by every caller that finds the
+    /// session gone at the same time.
+    var primaryAuthenticationInFlight: Task<Void, Error>?
 
     /// RFC 2971 client identity replayed after every successful
     /// authentication on every connection this server opens (primary,
@@ -103,6 +108,10 @@ public actor IMAPServer {
     /// while ``MoveFallbackPolicy/disabled`` requires MOVE directly.
     public var supportsMove: Bool {
         capabilities.containsMoveCapability
+    }
+
+    func replaceAuthenticationForTesting(_ authentication: Authentication?) {
+        self.authentication = authentication
     }
 
     var certificatePolicyForTesting: MailCertificateVerificationPolicy {

--- a/Tests/SwiftIMAPTests/AuthenticationCapabilityGuardTests.swift
+++ b/Tests/SwiftIMAPTests/AuthenticationCapabilityGuardTests.swift
@@ -21,7 +21,6 @@ struct AuthenticationCapabilityGuardTests {
     @Test
     func emptySnapshotIsRefreshedBeforeJudgingXOAUTH2() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
         let harness = try await makeLiveHarness(group: group, capabilities: [])
 
         let authTask = Task {
@@ -37,12 +36,12 @@ struct AuthenticationCapabilityGuardTests {
 
         try await authTask.value
         #expect(harness.connection.isAuthenticated)
+        await shutDownGracefully(group)
     }
 
     @Test
     func emptySnapshotIsRefreshedBeforeJudgingPLAIN() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
         let harness = try await makeLiveHarness(group: group, capabilities: [])
 
         let authTask = Task {
@@ -58,12 +57,12 @@ struct AuthenticationCapabilityGuardTests {
 
         try await authTask.value
         #expect(harness.connection.isAuthenticated)
+        await shutDownGracefully(group)
     }
 
     @Test
     func refreshedSnapshotWithoutTheMechanismIsStillRejected() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
         let harness = try await makeLiveHarness(group: group, capabilities: [])
 
         let authTask = Task {
@@ -82,12 +81,12 @@ struct AuthenticationCapabilityGuardTests {
             #expect(reason == "XOAUTH2 not advertised by server")
         }
         #expect(!harness.connection.isAuthenticated)
+        await shutDownGracefully(group)
     }
 
     @Test
     func disconnectedConnectionReconnectsBeforeJudgingTheMechanism() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
         // Port 1 refuses immediately: the transport attempt fails, which is the
         // point. Before the fix the empty snapshot short-circuited to
         // "not advertised" without any connection attempt.
@@ -102,6 +101,7 @@ struct AuthenticationCapabilityGuardTests {
         } catch {
             // Any transport-level failure is the expected outcome.
         }
+        await shutDownGracefully(group)
     }
 
     /// The empty-snapshot refresh runs through `executeCommandBody`, which recycles a
@@ -112,7 +112,6 @@ struct AuthenticationCapabilityGuardTests {
     @Test
     func refreshThatReplacedTheChannelAuthenticatesOnTheReplacement() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
         let stale = try await makeLiveHarness(group: group, capabilities: [])
         let connection = stale.connection
         let replacementChannel = NIOAsyncTestingChannel()
@@ -141,6 +140,7 @@ struct AuthenticationCapabilityGuardTests {
         #expect(connection.isAuthenticated)
         let staleWrite = try? await stale.channel.readOutbound(as: ByteBuffer.self)
         #expect(staleWrite == nil, "nothing may be written on the transport the refresh replaced")
+        await shutDownGracefully(group)
     }
 
     // MARK: - Harness

--- a/Tests/SwiftIMAPTests/IMAPNamedConnectionTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPNamedConnectionTests.swift
@@ -26,6 +26,18 @@ private actor AuthenticationGate {
     }
 }
 
+private actor AuthenticationCounter {
+    private var count = 0
+
+    func increment() {
+        count += 1
+    }
+
+    func value() -> Int {
+        count
+    }
+}
+
 @Suite(.serialized, .timeLimit(.minutes(1)))
 struct IMAPNamedConnectionTests {
     private struct NamedConnectionHarness {
@@ -256,6 +268,38 @@ struct IMAPNamedConnectionTests {
         } catch {
             Issue.record("Expected IMAPError.commandNotSupported, got \(error)")
         }
+        try? await group.shutdownGracefully()
+    }
+
+    /// A peer reset leaves the session flag set until the next command notices the dead
+    /// channel, so `ensureAuthenticated` used to skip re-authentication and the command
+    /// went out on the reopened, unauthenticated transport. The session counts as
+    /// authenticated only while its channel is live.
+    @Test
+    func ensureAuthenticatedReauthenticatesWhenTheSessionFlagOutlivesTheChannel() async throws {
+        let counter = AuthenticationCounter()
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let connection = IMAPConnection(
+            host: "localhost",
+            port: 1,
+            useTLS: false,
+            group: group,
+            loggerLabel: "test.imap",
+            outboundLabel: "test.imap.out",
+            inboundLabel: "test.imap.in",
+            connectionID: "test-stale-session",
+            connectionRole: "test"
+        )
+        connection.isSessionAuthenticated = true
+        let named = IMAPNamedConnection(
+            name: "test",
+            connection: connection,
+            authenticateOnConnection: { _ in await counter.increment() }
+        )
+
+        #expect(await named.isAuthenticated == false)
+        try await named.ensureAuthenticated()
+        #expect(await counter.value() == 1)
         try? await group.shutdownGracefully()
     }
 }

--- a/Tests/SwiftIMAPTests/ReauthenticationAfterReconnectTests.swift
+++ b/Tests/SwiftIMAPTests/ReauthenticationAfterReconnectTests.swift
@@ -1,0 +1,203 @@
+import Foundation
+import NIO
+import NIOEmbedded
+import NIOIMAP
+import NIOIMAPCore
+import Testing
+@testable import SwiftMail
+
+private actor ReauthenticationCounter {
+    private var count = 0
+
+    func increment() {
+        count += 1
+    }
+
+    func value() -> Int {
+        count
+    }
+}
+
+/// A connection that lost an authenticated session recovers it inside the command
+/// queue, on the transport it just reopened, before the command or IDLE that
+/// reopened it is sent. The check and the command are one queue turn, so a peer
+/// reset between them cannot leave an authenticated-state command on a fresh
+/// unauthenticated socket, and concurrent callers cannot each authenticate.
+@Suite(.serialized, .timeLimit(.minutes(1)))
+struct ReauthenticationAfterReconnectTests {
+    @Test
+    func commandThatReopensTheTransportReauthenticatesFirst() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        let connection = makeConnection(group: group)
+        let counter = ReauthenticationCounter()
+        let replacement = try await loseAuthenticatedSession(on: connection, counter: counter)
+
+        let noop = Task { try await connection.executeCommand(NoopCommand()) }
+        let line = try await nextOutboundLine(from: replacement)
+        #expect(line == "A001 NOOP\r\n", "expected NOOP on the replacement, got \(line ?? "<nothing>")")
+        #expect(await counter.value() == 1, "re-authentication runs before the command goes out")
+        try await writeInboundLines(replacement, "A001 OK NOOP completed\r\n")
+        _ = try await noop.value
+        #expect(connection.isAuthenticated)
+        #expect(!connection.lostAuthenticatedSession)
+    }
+
+    @Test
+    func idleStartThatReopensTheTransportReauthenticatesFirst() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        let connection = makeConnection(group: group)
+        let counter = ReauthenticationCounter()
+        let replacement = try await loseAuthenticatedSession(on: connection, counter: counter)
+        connection.replaceCapabilitiesForTesting([Capability("IMAP4rev1"), .idle])
+
+        let stream = try await connection.idle()
+        let line = try await nextOutboundLine(from: replacement)
+        #expect(line == "A001 IDLE\r\n", "expected IDLE on the replacement, got \(line ?? "<nothing>")")
+        #expect(await counter.value() == 1, "re-authentication runs before IDLE goes out")
+        #expect(connection.isAuthenticated)
+        _ = stream
+        try? await connection.disconnect()
+    }
+
+    @Test
+    func reauthenticationWaitsWhileAuthenticationIsInProgress() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        let connection = makeConnection(group: group)
+        let counter = ReauthenticationCounter()
+        connection.lostAuthenticatedSession = true
+        connection.reauthenticateAfterReconnect = { _ in await counter.increment() }
+
+        connection.authenticationInProgress = true
+        try await connection.reauthenticateIfSessionWasLost(before: "CAPABILITY")
+        #expect(await counter.value() == 0, "the refresh inside an authentication must not nest another")
+
+        connection.authenticationInProgress = false
+        try await connection.reauthenticateIfSessionWasLost(before: "NOOP")
+        #expect(await counter.value() == 1)
+    }
+
+    @Test
+    func explicitDisconnectIsNotALostSession() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        let connection = makeConnection(group: group)
+        let channel = try await makeTestingChannel(for: connection)
+        connection.markSessionAuthenticated()
+
+        try await connection.disconnect()
+        #expect(!connection.lostAuthenticatedSession, "ending the session on purpose is not losing it")
+
+        let second = try await makeTestingChannel(for: connection)
+        connection.markSessionAuthenticated()
+        try await second.close()
+        connection.clearInvalidChannel()
+        #expect(connection.lostAuthenticatedSession, "a dead channel under an authenticated session is a loss")
+        _ = channel
+    }
+
+    @Test
+    func concurrentPrimaryCallersShareOneAuthentication() async throws {
+        let server = SwiftMail.IMAPServer(host: "localhost", port: 143, useTLS: false)
+        let primary = await server.primaryConnection
+        let channel = try await makeTestingChannel(for: primary)
+        primary.replaceCapabilitiesForTesting([
+            Capability("IMAP4rev1"), Capability("SASL-IR"), .authenticate(AuthenticationMechanism("PLAIN"))
+        ])
+        await server.replaceAuthenticationForTesting(
+            .init(method: .plain(username: "user", password: "secret"), identification: nil)
+        )
+
+        let first = Task { try await server.ensurePrimaryConnectionAuthenticated() }
+        let second = Task { try await server.ensurePrimaryConnectionAuthenticated() }
+        let authenticate = try await nextOutboundLine(from: channel)
+        #expect(authenticate?.hasPrefix("A001 AUTHENTICATE PLAIN ") == true, "got \(authenticate ?? "<nothing>")")
+        try await writeInboundLines(channel, "A001 OK authenticated\r\n")
+        let refresh = try await nextOutboundLine(from: channel)
+        #expect(refresh == "A002 CAPABILITY\r\n", "got \(refresh ?? "<nothing>")")
+        try await writeInboundLines(channel, "* CAPABILITY IMAP4rev1 AUTH=PLAIN\r\nA002 OK done\r\n")
+        try await first.value
+        try await second.value
+        let extra = try await nextOutboundLine(from: channel, timeoutNanoseconds: 200_000_000)
+        #expect(extra == nil, "the second caller must not authenticate again, got \(extra ?? "<nothing>")")
+        #expect(primary.isAuthenticated)
+    }
+
+    // MARK: - Harness
+
+    private func makeConnection(group: MultiThreadedEventLoopGroup) -> IMAPConnection {
+        IMAPConnection(
+            host: "127.0.0.1",
+            port: 143,
+            transportSecurity: .plainText,
+            minimumTLSVersion: .tlsv12,
+            group: group,
+            loggerLabel: "test.imap",
+            outboundLabel: "test.imap.out",
+            inboundLabel: "test.imap.in",
+            connectionID: "test-reauth",
+            connectionRole: "test",
+            parserLimits: .default
+        )
+    }
+
+    /// A live testing channel wired into the connection's pipeline and installed as its channel.
+    private func makeTestingChannel(for connection: IMAPConnection) async throws -> NIOAsyncTestingChannel {
+        let channel = NIOAsyncTestingChannel()
+        try await channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 143))
+        try await channel.addIMAPClientHandler()
+        try await channel.pipeline.addHandler(connection.duplexLogger)
+        try await channel.pipeline.addHandler(connection.responseBuffer)
+        connection.replaceChannelForTesting(channel)
+        return channel
+    }
+
+    /// Authenticates the connection on a channel, kills that channel as a peer reset
+    /// would, and arranges for the next connect to install a replacement whose
+    /// outbound the test can read. The counter records the re-authentication hook,
+    /// which marks the session authenticated the way a real AUTHENTICATE would.
+    private func loseAuthenticatedSession(
+        on connection: IMAPConnection,
+        counter: ReauthenticationCounter
+    ) async throws -> NIOAsyncTestingChannel {
+        let stale = try await makeTestingChannel(for: connection)
+        connection.replaceCapabilitiesForTesting([Capability("IMAP4rev1")])
+        connection.markSessionAuthenticated()
+        try await stale.close()
+        let replacement = NIOAsyncTestingChannel()
+        connection.replaceConnectForTesting {
+            try await replacement.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 143))
+            try await replacement.addIMAPClientHandler()
+            try await replacement.pipeline.addHandler(connection.duplexLogger)
+            try await replacement.pipeline.addHandler(connection.responseBuffer)
+            connection.replaceChannelForTesting(replacement)
+        }
+        connection.reauthenticateAfterReconnect = { connection in
+            await counter.increment()
+            connection.markSessionAuthenticated()
+        }
+        return replacement
+    }
+
+    private func writeInboundLines(_ channel: NIOAsyncTestingChannel, _ text: String) async throws {
+        var buffer = channel.allocator.buffer(capacity: text.utf8.count)
+        buffer.writeString(text)
+        try await channel.writeInbound(buffer)
+    }
+
+    private func nextOutboundLine(
+        from channel: NIOAsyncTestingChannel,
+        timeoutNanoseconds: UInt64 = 1_000_000_000
+    ) async throws -> String? {
+        let start = DispatchTime.now().uptimeNanoseconds
+        while DispatchTime.now().uptimeNanoseconds - start < timeoutNanoseconds {
+            if var line = try await channel.readOutbound(as: ByteBuffer.self) {
+                return line.readString(length: line.readableBytes)
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        return nil
+    }
+}

--- a/Tests/SwiftIMAPTests/ReauthenticationAfterReconnectTests.swift
+++ b/Tests/SwiftIMAPTests/ReauthenticationAfterReconnectTests.swift
@@ -28,7 +28,6 @@ struct ReauthenticationAfterReconnectTests {
     @Test
     func commandThatReopensTheTransportReauthenticatesFirst() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
         let connection = makeConnection(group: group)
         let counter = ReauthenticationCounter()
         let replacement = try await loseAuthenticatedSession(on: connection, counter: counter)
@@ -41,12 +40,12 @@ struct ReauthenticationAfterReconnectTests {
         _ = try await noop.value
         #expect(connection.isAuthenticated)
         #expect(!connection.lostAuthenticatedSession)
+        await shutDownGracefully(group)
     }
 
     @Test
     func idleStartThatReopensTheTransportReauthenticatesFirst() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
         let connection = makeConnection(group: group)
         let counter = ReauthenticationCounter()
         let replacement = try await loseAuthenticatedSession(on: connection, counter: counter)
@@ -59,12 +58,12 @@ struct ReauthenticationAfterReconnectTests {
         #expect(connection.isAuthenticated)
         _ = stream
         try? await connection.disconnect()
+        await shutDownGracefully(group)
     }
 
     @Test
     func reauthenticationWaitsWhileAuthenticationIsInProgress() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
         let connection = makeConnection(group: group)
         let counter = ReauthenticationCounter()
         connection.lostAuthenticatedSession = true
@@ -77,12 +76,12 @@ struct ReauthenticationAfterReconnectTests {
         connection.authenticationInProgress = false
         try await connection.reauthenticateIfSessionWasLost(before: "NOOP")
         #expect(await counter.value() == 1)
+        await shutDownGracefully(group)
     }
 
     @Test
     func explicitDisconnectIsNotALostSession() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
         let connection = makeConnection(group: group)
         let channel = try await makeTestingChannel(for: connection)
         connection.markSessionAuthenticated()
@@ -96,6 +95,7 @@ struct ReauthenticationAfterReconnectTests {
         connection.clearInvalidChannel()
         #expect(connection.lostAuthenticatedSession, "a dead channel under an authenticated session is a loss")
         _ = channel
+        await shutDownGracefully(group)
     }
 
     @Test


### PR DESCRIPTION
## Summary

`IMAPConnection.isAuthenticated` now requires a live channel, so a named connection whose transport the peer reset re-authenticates before its next command instead of sending that command on a fresh, unauthenticated socket.

## The failure

Observed against Gmail on 2026-09-05: the server reset every socket of an account at once. A named connection (`IMAPServer.connection(named:)`) that had been idle then ran `UID SEARCH`:

1. `IMAPNamedConnection.executeCommand` calls `ensureAuthenticated()`, which returns early because `connection.isAuthenticated` is still `true`: a peer reset does not clear `isSessionAuthenticated`, only `disconnectBody()` and `clearInvalidChannel()` do, and neither has run yet.
2. `IMAPConnection.executeCommandBody` then calls `clearInvalidChannel()`, finds the channel nil, and re-establishes the transport with `connectBody()`.
3. The SEARCH goes out on the new transport before any AUTHENTICATE. Gmail answers `BAD Unknown command <session-id>`, and the connection's own log reports the state that explains it: `channelActive=true authenticated=false`.

`IMAPServer.ensurePrimaryConnectionAuthenticated` has the same shape for the primary connection, so it benefits as well.

## The fix

```swift
var isAuthenticated: Bool {
    isSessionAuthenticated && isConnected
}
```

An authenticated session cannot outlive its channel. Both re-authentication checks (`IMAPNamedConnection.ensureAuthenticated`, `IMAPServer.ensurePrimaryConnectionAuthenticated`) now run `authenticate(on:)` when the channel is gone, and `executeCommandBody` reopens the transport under the AUTHENTICATE command rather than under the user's command. No other reader of `isAuthenticated` changes meaning: `identify` already pairs it with `isConnected`.

## Test

`IMAPNamedConnectionTests.ensureAuthenticatedReauthenticatesWhenTheSessionFlagOutlivesTheChannel` builds a connection with `isSessionAuthenticated = true` and no channel, asserts the named connection reports unauthenticated, and asserts `ensureAuthenticated()` invokes the authenticate closure once. On `main` the closure is never called.

`swift test` passes; `swiftlint lint --strict` is clean on the changed files.
