### PR TITLE
Require a live channel for an authenticated IMAP session

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAPConnection+Authentication.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+Authentication.swift
@@ -4,32 +4,15 @@ import NIOIMAPCore
 import NIO
 
 extension IMAPConnection {
-    func login(username: String, password: String) async throws {
-        let command = LoginCommand(username: username, password: password)
-        let loginCapabilities = try await executeCommand(command)
-        isSessionAuthenticated = true
-        try await refreshCapabilities(using: loginCapabilities)
-        await fetchNamespacesIfSupported(useCommandBody: false)
-    }
-
     /// Authenticate using AUTHENTICATE PLAIN (RFC 4616) with optional SASL-IR (RFC 4959).
     ///
     /// When the server advertises `SASL-IR`, the credentials are sent inline with the
     /// AUTHENTICATE command (saving a round trip). Otherwise falls back to the standard
-    /// continuation-based exchange.
-    func authenticatePlain(username: String, password: String) async throws {
-        try await commandQueue.run { [self] in
-            try await self.authenticatePlainBody(username: username, password: password)
-        }
-    }
-
-    func authenticateXOAUTH2(email: String, accessToken: String) async throws {
-        try await commandQueue.run { [self] in
-            try await self.authenticateXOAUTH2Body(email: email, accessToken: accessToken)
-        }
-    }
-
+    /// continuation-based exchange. Runs inside the command queue; the queue-taking
+    /// entry points live in `IMAPConnection+Reauthentication.swift`.
     func authenticatePlainBody(username: String, password: String) async throws {
+        authenticationInProgress = true
+        defer { authenticationInProgress = false }
         let mechanism = AuthenticationMechanism("PLAIN")
         let channel = try await prepareAuthenticationChannel(
             operation: "PLAIN authenticate", advertising: .authenticate(mechanism), name: "PLAIN"
@@ -92,7 +75,7 @@ extension IMAPConnection {
 
             scheduledTask?.cancel()
             responseBuffer.hasActiveHandler = false
-            isSessionAuthenticated = true
+            markSessionAuthenticated()
 
             duplexLogger.flushInboundBuffer()
             try await refreshCapabilities(using: postAuthCapabilities)
@@ -238,6 +221,8 @@ extension IMAPConnection {
     }
 
     func authenticateXOAUTH2Body(email: String, accessToken: String) async throws {
+        authenticationInProgress = true
+        defer { authenticationInProgress = false }
         let mechanism = AuthenticationMechanism("XOAUTH2")
         let channel = try await prepareAuthenticationChannel(
             operation: "XOAUTH2 authenticate", advertising: .authenticate(mechanism), name: "XOAUTH2"
@@ -304,7 +289,7 @@ extension IMAPConnection {
             await handleConnectionTerminationInResponses(handler.untaggedResponses)
             duplexLogger.flushInboundBuffer()
 
-            isSessionAuthenticated = true
+            markSessionAuthenticated()
             // AUTHENTICATE often returns an OK without CAPABILITY data, and RFC 3501
             // invalidates the pre-authentication capability set once authentication
             // succeeds. Refresh from the server instead of retaining the stale

--- a/Sources/SwiftMail/IMAP/IMAPConnection+Authentication.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+Authentication.swift
@@ -11,35 +11,36 @@ extension IMAPConnection {
     /// continuation-based exchange. Runs inside the command queue; the queue-taking
     /// entry points live in `IMAPConnection+Reauthentication.swift`.
     func authenticatePlainBody(username: String, password: String) async throws {
-        authenticationInProgress = true
-        defer { authenticationInProgress = false }
-        let mechanism = AuthenticationMechanism("PLAIN")
-        let channel = try await prepareAuthenticationChannel(
-            operation: "PLAIN authenticate", advertising: .authenticate(mechanism), name: "PLAIN"
-        )
-        let tag = generateCommandTag()
-
-        let handlerPromise = channel.eventLoop.makePromise(of: [Capability].self)
-        let credentialBuffer = makePlainCredentialBuffer(username: username, password: password)
-        let (initialResponse, expectsChallenge) = resolveSASLIR(credentials: credentialBuffer)
-
-        let handler = PlainAuthenticationHandler(
-            commandTag: tag,
-            promise: handlerPromise,
-            credentials: credentialBuffer,
-            expectsChallenge: expectsChallenge
-        )
-
-        try await runPlainAuthentication(
-            PlainAuthenticationRun(
-                channel: channel,
-                tag: tag,
-                mechanism: mechanism,
-                initialResponse: initialResponse,
-                handler: handler,
-                handlerPromise: handlerPromise
+        try await authenticateUntilTransportIsStable(operation: "PLAIN authentication") { [self] in
+            let mechanism = AuthenticationMechanism("PLAIN")
+            let channel = try await prepareAuthenticationChannel(
+                operation: "PLAIN authenticate", advertising: .authenticate(mechanism), name: "PLAIN"
             )
-        )
+            let tag = generateCommandTag()
+
+            let handlerPromise = channel.eventLoop.makePromise(of: [Capability].self)
+            let credentialBuffer = makePlainCredentialBuffer(username: username, password: password)
+            let (initialResponse, expectsChallenge) = resolveSASLIR(credentials: credentialBuffer)
+
+            let handler = PlainAuthenticationHandler(
+                commandTag: tag,
+                promise: handlerPromise,
+                credentials: credentialBuffer,
+                expectsChallenge: expectsChallenge
+            )
+
+            let capabilities = try await runPlainAuthentication(
+                PlainAuthenticationRun(
+                    channel: channel,
+                    tag: tag,
+                    mechanism: mechanism,
+                    initialResponse: initialResponse,
+                    handler: handler,
+                    handlerPromise: handlerPromise
+                )
+            )
+            return (channel, capabilities)
+        }
     }
 
     private struct PlainAuthenticationRun {
@@ -51,7 +52,7 @@ extension IMAPConnection {
         let handlerPromise: EventLoopPromise<[Capability]>
     }
 
-    private func runPlainAuthentication(_ run: PlainAuthenticationRun) async throws {
+    private func runPlainAuthentication(_ run: PlainAuthenticationRun) async throws -> [Capability] {
         let channel = run.channel
         let tag = run.tag
         let mechanism = run.mechanism
@@ -75,11 +76,9 @@ extension IMAPConnection {
 
             scheduledTask?.cancel()
             responseBuffer.hasActiveHandler = false
-            markSessionAuthenticated()
 
             duplexLogger.flushInboundBuffer()
-            try await refreshCapabilities(using: postAuthCapabilities)
-            await fetchNamespacesIfSupported(useCommandBody: true)
+            return postAuthCapabilities
         } catch {
             scheduledTask?.cancel()
             responseBuffer.hasActiveHandler = false
@@ -221,36 +220,40 @@ extension IMAPConnection {
     }
 
     func authenticateXOAUTH2Body(email: String, accessToken: String) async throws {
-        authenticationInProgress = true
-        defer { authenticationInProgress = false }
-        let mechanism = AuthenticationMechanism("XOAUTH2")
-        let channel = try await prepareAuthenticationChannel(
-            operation: "XOAUTH2 authenticate", advertising: .authenticate(mechanism), name: "XOAUTH2"
-        )
-        let tag = generateCommandTag()
-
-        let handlerPromise = channel.eventLoop.makePromise(of: [Capability].self)
-        let credentialBuffer = makeXOAUTH2InitialResponseBuffer(email: email, accessToken: accessToken)
-        let (initialResponse, expectsChallenge) = resolveSASLIR(credentials: credentialBuffer, maxInlineBytes: 1024)
-
-        let handler = XOAUTH2AuthenticationHandler(
-            commandTag: tag,
-            promise: handlerPromise,
-            credentials: credentialBuffer,
-            expectsChallenge: expectsChallenge,
-            logger: logger
-        )
-
-        try await runXOAUTH2Authentication(
-            XOAUTH2AuthenticationRun(
-                channel: channel,
-                tag: tag,
-                mechanism: mechanism,
-                initialResponse: initialResponse,
-                handler: handler,
-                handlerPromise: handlerPromise
+        try await authenticateUntilTransportIsStable(operation: "XOAUTH2 authentication") { [self] in
+            let mechanism = AuthenticationMechanism("XOAUTH2")
+            let channel = try await prepareAuthenticationChannel(
+                operation: "XOAUTH2 authenticate", advertising: .authenticate(mechanism), name: "XOAUTH2"
             )
-        )
+            let tag = generateCommandTag()
+
+            let handlerPromise = channel.eventLoop.makePromise(of: [Capability].self)
+            let credentialBuffer = makeXOAUTH2InitialResponseBuffer(email: email, accessToken: accessToken)
+            let (initialResponse, expectsChallenge) = resolveSASLIR(
+                credentials: credentialBuffer,
+                maxInlineBytes: 1024
+            )
+
+            let handler = XOAUTH2AuthenticationHandler(
+                commandTag: tag,
+                promise: handlerPromise,
+                credentials: credentialBuffer,
+                expectsChallenge: expectsChallenge,
+                logger: logger
+            )
+
+            let capabilities = try await runXOAUTH2Authentication(
+                XOAUTH2AuthenticationRun(
+                    channel: channel,
+                    tag: tag,
+                    mechanism: mechanism,
+                    initialResponse: initialResponse,
+                    handler: handler,
+                    handlerPromise: handlerPromise
+                )
+            )
+            return (channel, capabilities)
+        }
     }
 
     private struct XOAUTH2AuthenticationRun {
@@ -262,7 +265,7 @@ extension IMAPConnection {
         let handlerPromise: EventLoopPromise<[Capability]>
     }
 
-    private func runXOAUTH2Authentication(_ run: XOAUTH2AuthenticationRun) async throws {
+    private func runXOAUTH2Authentication(_ run: XOAUTH2AuthenticationRun) async throws -> [Capability] {
         let channel = run.channel
         let tag = run.tag
         let mechanism = run.mechanism
@@ -289,16 +292,7 @@ extension IMAPConnection {
             await handleConnectionTerminationInResponses(handler.untaggedResponses)
             duplexLogger.flushInboundBuffer()
 
-            markSessionAuthenticated()
-            // AUTHENTICATE often returns an OK without CAPABILITY data, and RFC 3501
-            // invalidates the pre-authentication capability set once authentication
-            // succeeds. Refresh from the server instead of retaining the stale
-            // snapshot — capability-gated features (like the RFC 2971 ID replay)
-            // would otherwise miss capabilities the server only advertises after
-            // authentication. useCommandBody avoids re-entering the command queue
-            // this method already holds, like the namespace fetch below.
-            try await refreshCapabilities(using: refreshedCapabilities, useCommandBody: true)
-            await fetchNamespacesIfSupported(useCommandBody: true)
+            return refreshedCapabilities
         } catch {
             await handleXOAUTH2Failure(
                 error: error,

--- a/Sources/SwiftMail/IMAP/IMAPConnection+CommandExecution.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+CommandExecution.swift
@@ -71,6 +71,7 @@ extension IMAPConnection {
         if self.channel == nil {
             logger.info("\(connectionContext) Channel is nil, re-establishing connection before sending command")
             try await connectBody()
+            try await reauthenticateIfSessionWasLost(before: String(describing: CommandType.self))
         }
 
         guard let channel = self.channel, channel.isActive else {

--- a/Sources/SwiftMail/IMAP/IMAPConnection+Connection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+Connection.swift
@@ -11,6 +11,10 @@ extension IMAPConnection {
             logger.debug("\(connectionContext) connect requested while channel is already active")
             return
         }
+        if let connectOverrideForTesting {
+            try await connectOverrideForTesting()
+            return
+        }
 
         // Any buffered state belongs to a previous transport and must not leak.
         responseBuffer.reset()
@@ -247,6 +251,9 @@ extension IMAPConnection {
     }
 
     func disconnectBody() async throws {
+        if isSessionAuthenticated {
+            lostAuthenticatedSession = true
+        }
         guard let channel = self.channel else {
             logger.warning("\(connectionContext) Attempted to disconnect when channel was already nil")
             isSessionAuthenticated = false
@@ -276,6 +283,9 @@ extension IMAPConnection {
         if let channel = self.channel, !channel.isActive {
             logger.info("\(connectionContext) Channel is no longer active, clearing channel reference")
             self.channel = nil
+            if isSessionAuthenticated {
+                lostAuthenticatedSession = true
+            }
             self.isSessionAuthenticated = false
             self.idleHandler = nil
             self.idleTerminationInProgress = false

--- a/Sources/SwiftMail/IMAP/IMAPConnection+Idle.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+Idle.swift
@@ -37,6 +37,7 @@ extension IMAPConnection {
         if self.channel == nil {
             logger.info("\(connectionContext) Channel is nil, re-establishing connection before starting IDLE")
             try await connectBody()
+            try await reauthenticateIfSessionWasLost(before: "IDLE")
         }
 
         guard let channel = self.channel, channel.isActive else {

--- a/Sources/SwiftMail/IMAP/IMAPConnection+Reauthentication.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+Reauthentication.swift
@@ -1,0 +1,75 @@
+import Foundation
+import NIOIMAPCore
+
+extension IMAPConnection {
+    // MARK: - Queue-taking authentication entry points
+
+    func login(username: String, password: String) async throws {
+        try await commandQueue.run { [self] in
+            try await self.loginBody(username: username, password: password)
+        }
+    }
+
+    func authenticatePlain(username: String, password: String) async throws {
+        try await commandQueue.run { [self] in
+            try await self.authenticatePlainBody(username: username, password: password)
+        }
+    }
+
+    func authenticateXOAUTH2(email: String, accessToken: String) async throws {
+        try await commandQueue.run { [self] in
+            try await self.authenticateXOAUTH2Body(email: email, accessToken: accessToken)
+        }
+    }
+
+    // MARK: - Recovery inside the command queue
+
+    /// Re-authenticates on the transport the caller just reopened, when the session it
+    /// replaced had been authenticated and the server installed a way to do so.
+    ///
+    /// Runs inside the command queue: the caller is `executeCommandBody` or
+    /// `startIdleSession`, right after `connectBody()`. Without this the first command
+    /// after a peer reset went out on the fresh socket before any AUTHENTICATE (Gmail
+    /// answers `BAD Unknown command`), and every caller that had checked
+    /// `isAuthenticated` a moment earlier was already wrong by the time its command ran.
+    /// Recovering here makes the check and the command atomic and single-flight, because
+    /// the queue serializes them, and it covers IDLE, which never consulted the server's
+    /// re-authentication path.
+    func reauthenticateIfSessionWasLost(before operation: String) async throws {
+        guard lostAuthenticatedSession, !authenticationInProgress else { return }
+        guard let reauthenticate = reauthenticateAfterReconnect else {
+            let warning = "\(connectionContext) Lost an authenticated session with no re-authentication "
+                + "configured; \(operation) runs unauthenticated"
+            logger.warning("\(warning)")
+            return
+        }
+        logger.info("\(connectionContext) Re-authenticating the reopened transport before \(operation)")
+        try await reauthenticate(self)
+    }
+
+    /// LOGIN for a caller that already holds the command queue.
+    func loginBody(username: String, password: String) async throws {
+        authenticationInProgress = true
+        defer { authenticationInProgress = false }
+        let command = LoginCommand(username: username, password: password)
+        let loginCapabilities = try await executeCommandBody(command)
+        markSessionAuthenticated()
+        try await refreshCapabilities(using: loginCapabilities, useCommandBody: true)
+        await fetchNamespacesIfSupported(useCommandBody: true)
+    }
+
+    /// ID for a caller that already holds the command queue.
+    func idBody(_ identification: Identification) async throws -> Identification {
+        guard capabilities.contains(.id) else {
+            throw IMAPError.commandNotSupported("ID command not supported by server")
+        }
+        return try await executeCommandBody(IDCommand(identification: identification))
+    }
+
+    /// Every successful authentication lands here: the session is live again and no
+    /// longer counts as lost.
+    func markSessionAuthenticated() {
+        isSessionAuthenticated = true
+        lostAuthenticatedSession = false
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAPConnection+Reauthentication.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection+Reauthentication.swift
@@ -1,4 +1,5 @@
 import Foundation
+import NIO
 import NIOIMAPCore
 
 extension IMAPConnection {
@@ -49,13 +50,14 @@ extension IMAPConnection {
 
     /// LOGIN for a caller that already holds the command queue.
     func loginBody(username: String, password: String) async throws {
-        authenticationInProgress = true
-        defer { authenticationInProgress = false }
-        let command = LoginCommand(username: username, password: password)
-        let loginCapabilities = try await executeCommandBody(command)
-        markSessionAuthenticated()
-        try await refreshCapabilities(using: loginCapabilities, useCommandBody: true)
-        await fetchNamespacesIfSupported(useCommandBody: true)
+        try await authenticateUntilTransportIsStable(operation: "LOGIN") { [self] in
+            let command = LoginCommand(username: username, password: password)
+            let loginCapabilities = try await executeCommandBody(command)
+            guard let authenticatedChannel = channel, authenticatedChannel.isActive else {
+                throw IMAPError.connectionFailed("LOGIN completed after its transport closed")
+            }
+            return (authenticatedChannel, loginCapabilities)
+        }
     }
 
     /// ID for a caller that already holds the command queue.
@@ -71,5 +73,55 @@ extension IMAPConnection {
     func markSessionAuthenticated() {
         isSessionAuthenticated = true
         lostAuthenticatedSession = false
+    }
+
+    /// Authentication is not complete until its post-authentication discovery ran on
+    /// the transport that accepted the credentials. A dead authenticated channel can
+    /// be replaced by CAPABILITY or NAMESPACE while `authenticationInProgress` blocks
+    /// nested re-authentication. In that case the discovery command may succeed on the
+    /// replacement even though it is unauthenticated, so repeat the entire flow there.
+    func authenticateUntilTransportIsStable(
+        operation: String,
+        authenticate: () async throws -> (channel: Channel, capabilities: [Capability])
+    ) async throws {
+        authenticationInProgress = true
+        defer { authenticationInProgress = false }
+
+        let maximumAttempts = 2
+        for attempt in 1...maximumAttempts {
+            let result = try await authenticate()
+
+            guard channel === result.channel, result.channel.isActive else {
+                if attempt < maximumAttempts {
+                    logger.info(
+                        "\(connectionContext) \(operation) transport closed after authentication; retrying"
+                    )
+                    continue
+                }
+                throw IMAPError.connectionFailed(
+                    "\(operation) transport repeatedly closed after authentication"
+                )
+            }
+
+            markSessionAuthenticated()
+            try await authenticationFollowUpOverrideForTesting?()
+            try await refreshCapabilities(using: result.capabilities, useCommandBody: true)
+            await fetchNamespacesIfSupported(useCommandBody: true)
+            clearInvalidChannel()
+
+            if channel === result.channel, result.channel.isActive, !lostAuthenticatedSession {
+                return
+            }
+
+            if attempt < maximumAttempts {
+                logger.info(
+                    "\(connectionContext) \(operation) follow-up replaced the authenticated transport; retrying"
+                )
+                continue
+            }
+            throw IMAPError.connectionFailed(
+                "\(operation) follow-up repeatedly replaced the authenticated transport"
+            )
+        }
     }
 }

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -36,6 +36,18 @@ final class IMAPConnection {
     let responseBuffer = UntaggedResponseBuffer()
     var startTLSUpgradeOverrideForTesting: (() async throws -> Void)?
     var capabilityRefreshOverrideForTesting: (() async throws -> Void)?
+    var connectOverrideForTesting: (() async throws -> Void)?
+    /// Re-authenticates this connection inside the command queue after the command path
+    /// or an IDLE start had to reopen the transport for a session that was authenticated.
+    /// Installed by `IMAPServer` on every connection it authenticates; nil until then.
+    var reauthenticateAfterReconnect: (@Sendable (IMAPConnection) async throws -> Void)?
+    /// Set when an authenticated session's channel is lost (peer reset, buffered BYE,
+    /// timeout recycle) rather than ended on purpose. Cleared by the next successful
+    /// authentication and by an explicit `disconnect()`.
+    var lostAuthenticatedSession = false
+    /// True while LOGIN, AUTHENTICATE PLAIN, or AUTHENTICATE XOAUTH2 runs, so the
+    /// capability refresh inside them cannot trigger a nested re-authentication.
+    var authenticationInProgress = false
 
     let logger: Logging.Logger
     let duplexLogger: IMAPLogger
@@ -250,6 +262,10 @@ final class IMAPConnection {
         self.capabilityRefreshOverrideForTesting = refresh
     }
 
+    func replaceConnectForTesting(_ connect: (() async throws -> Void)?) {
+        self.connectOverrideForTesting = connect
+    }
+
     func connect() async throws {
         try await commandQueue.run { [self] in
             try await self.connectBody()
@@ -265,6 +281,8 @@ final class IMAPConnection {
     func disconnect() async throws {
         try await commandQueue.run { [self] in
             try await self.disconnectBody()
+            // Ending the session on purpose is not losing it.
+            self.lostAuthenticatedSession = false
         }
     }
 }

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -213,8 +213,12 @@ final class IMAPConnection {
         namespaces
     }
 
+    /// An authenticated session needs a live channel. A transport the peer reset leaves
+    /// `isSessionAuthenticated` set until the next command notices the dead channel, and a
+    /// caller that trusted the flag alone then sent an authenticated-state command on the
+    /// fresh transport `executeCommandBody` reopens (Gmail answers `BAD Unknown command`).
     var isAuthenticated: Bool {
-        isSessionAuthenticated
+        isSessionAuthenticated && isConnected
     }
 
     var identifier: String {

--- a/Sources/SwiftMail/IMAP/IMAPConnection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPConnection.swift
@@ -36,6 +36,7 @@ final class IMAPConnection {
     let responseBuffer = UntaggedResponseBuffer()
     var startTLSUpgradeOverrideForTesting: (() async throws -> Void)?
     var capabilityRefreshOverrideForTesting: (() async throws -> Void)?
+    var authenticationFollowUpOverrideForTesting: (() async throws -> Void)?
     var connectOverrideForTesting: (() async throws -> Void)?
     /// Re-authenticates this connection inside the command queue after the command path
     /// or an IDLE start had to reopen the transport for a session that was authenticated.
@@ -46,7 +47,8 @@ final class IMAPConnection {
     /// authentication and by an explicit `disconnect()`.
     var lostAuthenticatedSession = false
     /// True while LOGIN, AUTHENTICATE PLAIN, or AUTHENTICATE XOAUTH2 runs, so the
-    /// capability refresh inside them cannot trigger a nested re-authentication.
+    /// capability and namespace refreshes inside it cannot recursively authenticate.
+    /// The outer authentication flow detects a replaced transport and retries itself.
     var authenticationInProgress = false
 
     let logger: Logging.Logger

--- a/Sources/SwiftMail/IMAP/IMAPServer+Connection.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Connection.swift
@@ -212,6 +212,7 @@ extension IMAPServer {
         // handle; failure clears this sentinel so a later call can retry normally.
         pendingNamedConnectionWaiters[normalizedName] = []
         let connection = makeNamedConnection(name: normalizedName)
+        installReauthentication(on: connection)
 
         do {
             try await connection.connect()

--- a/Sources/SwiftMail/IMAP/IMAPServer+Helpers.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Helpers.swift
@@ -20,12 +20,25 @@ extension IMAPServer {
     }
 
     /// Refreshes session-scoped state before a capability-dependent command decision.
+    ///
+    /// One recovery at a time: concurrent primary callers that all found the session
+    /// gone share the same authentication instead of each sending LOGIN or
+    /// AUTHENTICATE, which failed the later ones on an already-authenticated session
+    /// and could invoke an OAuth token provider twice.
     func ensurePrimaryConnectionAuthenticated() async throws {
-        if let authentication, !primaryConnection.isAuthenticated {
-            logger.info("Primary connection not authenticated; re-authenticating before command")
-            try await authentication.authenticate(on: primaryConnection)
-            namespaces = primaryConnection.namespacesSnapshot
+        guard let authentication, !primaryConnection.isAuthenticated else { return }
+        if let inFlight = primaryAuthenticationInFlight {
+            try await inFlight.value
+            return
         }
+        logger.info("Primary connection not authenticated; re-authenticating before command")
+        let task = Task { [primaryConnection] in
+            try await authentication.authenticate(on: primaryConnection)
+        }
+        primaryAuthenticationInFlight = task
+        defer { primaryAuthenticationInFlight = nil }
+        try await task.value
+        namespaces = primaryConnection.namespacesSnapshot
     }
 
     func resolveMailboxPath(_ mailbox: String) -> String {

--- a/Sources/SwiftMail/IMAP/IMAPServer+Idle.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Idle.swift
@@ -59,6 +59,7 @@ extension IMAPServer {
         // IDLE cycle task (which is Task.detached and can outlive the server).
         let idleGroup = MultiThreadedEventLoopGroup(numberOfThreads: 1)
         let connection = makeIdleConnection(sessionID: sessionID, mailbox: resolvedMailbox, group: idleGroup)
+        installReauthentication(on: connection)
         idleConnections[sessionID] = IdleConnection(
             mailbox: resolvedMailbox,
             connection: connection,

--- a/Sources/SwiftMail/IMAP/IMAPServer+Reauthentication.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer+Reauthentication.swift
@@ -1,0 +1,65 @@
+import Foundation
+import NIOIMAPCore
+
+extension IMAPServer.Authentication {
+    /// The same steps as `authenticate(on:)` for a caller that already holds the
+    /// connection's command queue: the transparent re-authentication a connection runs
+    /// after reopening its transport inside a command or an IDLE start.
+    func authenticateBody(on connection: IMAPConnection) async throws {
+        switch method {
+            case .login(let username, let password):
+                try await connection.loginBody(username: username, password: password)
+            case .plain(let username, let password):
+                try await connection.authenticatePlainBody(username: username, password: password)
+            case .xoauth2(let email, let accessTokenProvider):
+                let accessToken = try await accessTokenProvider()
+                try await connection.authenticateXOAUTH2Body(email: email, accessToken: accessToken)
+        }
+        guard let identification else { return }
+        try await Self.identifyBody(connection, with: identification)
+    }
+
+    /// `identify(_:with:)` for a caller holding the command queue: the same tolerance for
+    /// a server that refuses ID, the same propagation of a failure that recycled the connection.
+    static func identifyBody(_ connection: IMAPConnection, with identification: Identification) async throws {
+        guard connection.capabilitiesSnapshot.contains(.id) else { return }
+        do {
+            _ = try await connection.idBody(identification)
+        } catch let error as CancellationError {
+            throw error
+        } catch {
+            guard connection.isConnected, connection.isAuthenticated else {
+                throw error
+            }
+        }
+    }
+}
+
+extension IMAPServer {
+    /// Teaches a connection this server owns how to recover its session when its
+    /// command path or IDLE start has to reopen the transport. Without it the first
+    /// command after a peer reset went out on the fresh socket before any AUTHENTICATE
+    /// (Gmail answers `BAD Unknown command`), whatever a caller had checked a moment
+    /// earlier.
+    func installReauthentication(on connection: IMAPConnection) {
+        guard let authentication else {
+            connection.reauthenticateAfterReconnect = nil
+            return
+        }
+        connection.reauthenticateAfterReconnect = { connection in
+            try await authentication.authenticateBody(on: connection)
+        }
+    }
+
+    /// Runs whenever `authentication` changes: the primary and every live named and
+    /// IDLE connection learn the current credentials.
+    func installReauthenticationOnOwnedConnections() {
+        installReauthentication(on: primaryConnection)
+        for named in namedConnections.values {
+            installReauthentication(on: named.connection)
+        }
+        for idle in idleConnections.values {
+            installReauthentication(on: idle.connection)
+        }
+    }
+}

--- a/Sources/SwiftMail/IMAP/IMAPServer.swift
+++ b/Sources/SwiftMail/IMAP/IMAPServer.swift
@@ -69,7 +69,12 @@ public actor IMAPServer {
     var pendingNamedConnectionWaiters: [String: [CheckedContinuation<IMAPNamedConnection, any Error>]] = [:]
 
     /// Authentication configuration for spawning new connections.
-    var authentication: Authentication?
+    var authentication: Authentication? {
+        didSet { installReauthenticationOnOwnedConnections() }
+    }
+    /// The primary re-authentication in flight, shared by every caller that finds the
+    /// session gone at the same time.
+    var primaryAuthenticationInFlight: Task<Void, Error>?
 
     /// RFC 2971 client identity replayed after every successful
     /// authentication on every connection this server opens (primary,
@@ -103,6 +108,10 @@ public actor IMAPServer {
     /// while ``MoveFallbackPolicy/disabled`` requires MOVE directly.
     public var supportsMove: Bool {
         capabilities.containsMoveCapability
+    }
+
+    func replaceAuthenticationForTesting(_ authentication: Authentication?) {
+        self.authentication = authentication
     }
 
     var certificatePolicyForTesting: MailCertificateVerificationPolicy {

--- a/Tests/SwiftIMAPTests/AuthenticationCapabilityGuardTests.swift
+++ b/Tests/SwiftIMAPTests/AuthenticationCapabilityGuardTests.swift
@@ -21,7 +21,6 @@ struct AuthenticationCapabilityGuardTests {
     @Test
     func emptySnapshotIsRefreshedBeforeJudgingXOAUTH2() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
         let harness = try await makeLiveHarness(group: group, capabilities: [])
 
         let authTask = Task {
@@ -37,12 +36,12 @@ struct AuthenticationCapabilityGuardTests {
 
         try await authTask.value
         #expect(harness.connection.isAuthenticated)
+        await shutDownGracefully(group)
     }
 
     @Test
     func emptySnapshotIsRefreshedBeforeJudgingPLAIN() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
         let harness = try await makeLiveHarness(group: group, capabilities: [])
 
         let authTask = Task {
@@ -58,12 +57,12 @@ struct AuthenticationCapabilityGuardTests {
 
         try await authTask.value
         #expect(harness.connection.isAuthenticated)
+        await shutDownGracefully(group)
     }
 
     @Test
     func refreshedSnapshotWithoutTheMechanismIsStillRejected() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
         let harness = try await makeLiveHarness(group: group, capabilities: [])
 
         let authTask = Task {
@@ -82,12 +81,12 @@ struct AuthenticationCapabilityGuardTests {
             #expect(reason == "XOAUTH2 not advertised by server")
         }
         #expect(!harness.connection.isAuthenticated)
+        await shutDownGracefully(group)
     }
 
     @Test
     func disconnectedConnectionReconnectsBeforeJudgingTheMechanism() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
         // Port 1 refuses immediately: the transport attempt fails, which is the
         // point. Before the fix the empty snapshot short-circuited to
         // "not advertised" without any connection attempt.
@@ -102,6 +101,7 @@ struct AuthenticationCapabilityGuardTests {
         } catch {
             // Any transport-level failure is the expected outcome.
         }
+        await shutDownGracefully(group)
     }
 
     /// The empty-snapshot refresh runs through `executeCommandBody`, which recycles a
@@ -112,7 +112,6 @@ struct AuthenticationCapabilityGuardTests {
     @Test
     func refreshThatReplacedTheChannelAuthenticatesOnTheReplacement() async throws {
         let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
         let stale = try await makeLiveHarness(group: group, capabilities: [])
         let connection = stale.connection
         let replacementChannel = NIOAsyncTestingChannel()
@@ -141,6 +140,7 @@ struct AuthenticationCapabilityGuardTests {
         #expect(connection.isAuthenticated)
         let staleWrite = try? await stale.channel.readOutbound(as: ByteBuffer.self)
         #expect(staleWrite == nil, "nothing may be written on the transport the refresh replaced")
+        await shutDownGracefully(group)
     }
 
     // MARK: - Harness

--- a/Tests/SwiftIMAPTests/AuthenticationCapabilityGuardTests.swift
+++ b/Tests/SwiftIMAPTests/AuthenticationCapabilityGuardTests.swift
@@ -20,88 +20,88 @@ struct AuthenticationCapabilityGuardTests {
 
     @Test
     func emptySnapshotIsRefreshedBeforeJudgingXOAUTH2() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        let harness = try await makeLiveHarness(group: group, capabilities: [])
+        try await withEventLoopGroup { group in
+            let harness = try await makeLiveHarness(group: group, capabilities: [])
 
-        let authTask = Task {
-            try await harness.connection.authenticateXOAUTH2(email: "user@example.com", accessToken: "token")
+            let authTask = Task {
+                try await harness.connection.authenticateXOAUTH2(email: "user@example.com", accessToken: "token")
+            }
+            try await answerCapabilityRefresh(
+                harness,
+                tag: "A001",
+                capabilities: "IMAP4rev1 SASL-IR AUTH=XOAUTH2"
+            )
+            try await answerAuthenticate(harness, tag: "A002", mechanism: "XOAUTH2")
+            try await answerCapabilityRefresh(harness, tag: "A003", capabilities: "IMAP4rev1 AUTH=XOAUTH2")
+
+            try await authTask.value
+            #expect(harness.connection.isAuthenticated)
         }
-        try await answerCapabilityRefresh(
-            harness,
-            tag: "A001",
-            capabilities: "IMAP4rev1 SASL-IR AUTH=XOAUTH2"
-        )
-        try await answerAuthenticate(harness, tag: "A002", mechanism: "XOAUTH2")
-        try await answerCapabilityRefresh(harness, tag: "A003", capabilities: "IMAP4rev1 AUTH=XOAUTH2")
-
-        try await authTask.value
-        #expect(harness.connection.isAuthenticated)
-        await shutDownGracefully(group)
     }
 
     @Test
     func emptySnapshotIsRefreshedBeforeJudgingPLAIN() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        let harness = try await makeLiveHarness(group: group, capabilities: [])
+        try await withEventLoopGroup { group in
+            let harness = try await makeLiveHarness(group: group, capabilities: [])
 
-        let authTask = Task {
-            try await harness.connection.authenticatePlain(username: "user", password: "secret")
+            let authTask = Task {
+                try await harness.connection.authenticatePlain(username: "user", password: "secret")
+            }
+            try await answerCapabilityRefresh(
+                harness,
+                tag: "A001",
+                capabilities: "IMAP4rev1 SASL-IR AUTH=PLAIN"
+            )
+            try await answerAuthenticate(harness, tag: "A002", mechanism: "PLAIN")
+            try await answerCapabilityRefresh(harness, tag: "A003", capabilities: "IMAP4rev1 AUTH=PLAIN")
+
+            try await authTask.value
+            #expect(harness.connection.isAuthenticated)
         }
-        try await answerCapabilityRefresh(
-            harness,
-            tag: "A001",
-            capabilities: "IMAP4rev1 SASL-IR AUTH=PLAIN"
-        )
-        try await answerAuthenticate(harness, tag: "A002", mechanism: "PLAIN")
-        try await answerCapabilityRefresh(harness, tag: "A003", capabilities: "IMAP4rev1 AUTH=PLAIN")
-
-        try await authTask.value
-        #expect(harness.connection.isAuthenticated)
-        await shutDownGracefully(group)
     }
 
     @Test
     func refreshedSnapshotWithoutTheMechanismIsStillRejected() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        let harness = try await makeLiveHarness(group: group, capabilities: [])
+        try await withEventLoopGroup { group in
+            let harness = try await makeLiveHarness(group: group, capabilities: [])
 
-        let authTask = Task {
-            try await harness.connection.authenticateXOAUTH2(email: "user@example.com", accessToken: "token")
-        }
-        try await answerCapabilityRefresh(harness, tag: "A001", capabilities: "IMAP4rev1 AUTH=PLAIN")
-
-        do {
-            try await authTask.value
-            Issue.record("Expected XOAUTH2 to be rejected after the refresh")
-        } catch let error as IMAPError {
-            guard case .unsupportedAuthMechanism(let reason) = error else {
-                Issue.record("Unexpected IMAP error: \(error)")
-                return
+            let authTask = Task {
+                try await harness.connection.authenticateXOAUTH2(email: "user@example.com", accessToken: "token")
             }
-            #expect(reason == "XOAUTH2 not advertised by server")
+            try await answerCapabilityRefresh(harness, tag: "A001", capabilities: "IMAP4rev1 AUTH=PLAIN")
+
+            do {
+                try await authTask.value
+                Issue.record("Expected XOAUTH2 to be rejected after the refresh")
+            } catch let error as IMAPError {
+                guard case .unsupportedAuthMechanism(let reason) = error else {
+                    Issue.record("Unexpected IMAP error: \(error)")
+                    return
+                }
+                #expect(reason == "XOAUTH2 not advertised by server")
+            }
+            #expect(!harness.connection.isAuthenticated)
         }
-        #expect(!harness.connection.isAuthenticated)
-        await shutDownGracefully(group)
     }
 
     @Test
     func disconnectedConnectionReconnectsBeforeJudgingTheMechanism() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        // Port 1 refuses immediately: the transport attempt fails, which is the
-        // point. Before the fix the empty snapshot short-circuited to
-        // "not advertised" without any connection attempt.
-        let connection = makeConnection(group: group, port: 1)
+        try await withEventLoopGroup { group in
+            // Port 1 refuses immediately: the transport attempt fails, which is the
+            // point. Before the fix the empty snapshot short-circuited to
+            // "not advertised" without any connection attempt.
+            let connection = makeConnection(group: group, port: 1)
 
-        do {
-            try await connection.authenticateXOAUTH2(email: "user@example.com", accessToken: "token")
-            Issue.record("Expected the transport attempt to fail")
-        } catch let error as IMAPError {
-            guard case .unsupportedAuthMechanism = error else { return }
-            Issue.record("Disconnected connection judged the mechanism instead of reconnecting: \(error)")
-        } catch {
-            // Any transport-level failure is the expected outcome.
+            do {
+                try await connection.authenticateXOAUTH2(email: "user@example.com", accessToken: "token")
+                Issue.record("Expected the transport attempt to fail")
+            } catch let error as IMAPError {
+                guard case .unsupportedAuthMechanism = error else { return }
+                Issue.record("Disconnected connection judged the mechanism instead of reconnecting: \(error)")
+            } catch {
+                // Any transport-level failure is the expected outcome.
+            }
         }
-        await shutDownGracefully(group)
     }
 
     /// The empty-snapshot refresh runs through `executeCommandBody`, which recycles a
@@ -111,39 +111,59 @@ struct AuthenticationCapabilityGuardTests {
     /// too (review on #221).
     @Test
     func refreshThatReplacedTheChannelAuthenticatesOnTheReplacement() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        let stale = try await makeLiveHarness(group: group, capabilities: [])
-        let connection = stale.connection
-        let replacementChannel = NIOAsyncTestingChannel()
-        connection.replaceCapabilityRefreshForTesting {
-            // The transport died under the refresh; the connection reconnected and
-            // took its capabilities from the new channel.
-            try await stale.channel.close()
-            try await replacementChannel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 143))
-            try await replacementChannel.addIMAPClientHandler()
-            try await replacementChannel.pipeline.addHandler(connection.duplexLogger)
-            try await replacementChannel.pipeline.addHandler(connection.responseBuffer)
-            connection.replaceChannelForTesting(replacementChannel)
-            connection.replaceCapabilitiesForTesting([
-                Capability("IMAP4rev1"),
-                Capability("SASL-IR"),
-                .authenticate(AuthenticationMechanism("PLAIN"))
-            ])
+        try await withEventLoopGroup { group in
+            let stale = try await makeLiveHarness(group: group, capabilities: [])
+            let connection = stale.connection
+            let replacementChannel = NIOAsyncTestingChannel()
+            connection.replaceCapabilityRefreshForTesting {
+                // The transport died under the refresh; the connection reconnected and
+                // took its capabilities from the new channel.
+                try await stale.channel.close()
+                try await replacementChannel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 143))
+                try await replacementChannel.addIMAPClientHandler()
+                try await replacementChannel.pipeline.addHandler(connection.duplexLogger)
+                try await replacementChannel.pipeline.addHandler(connection.responseBuffer)
+                connection.replaceChannelForTesting(replacementChannel)
+                connection.replaceCapabilitiesForTesting([
+                    Capability("IMAP4rev1"),
+                    Capability("SASL-IR"),
+                    .authenticate(AuthenticationMechanism("PLAIN"))
+                ])
+            }
+            let replacement = Harness(connection: connection, channel: replacementChannel)
+            let authTask = Task {
+                try await connection.authenticatePlain(username: "user", password: "secret")
+            }
+            try await answerAuthenticate(replacement, tag: "A001", mechanism: "PLAIN")
+            try await answerCapabilityRefresh(replacement, tag: "A002", capabilities: "IMAP4rev1 AUTH=PLAIN")
+            try await authTask.value
+            #expect(connection.isAuthenticated)
+            let staleWrite = try? await stale.channel.readOutbound(as: ByteBuffer.self)
+            #expect(staleWrite == nil, "nothing may be written on the transport the refresh replaced")
         }
-        let replacement = Harness(connection: connection, channel: replacementChannel)
-        let authTask = Task {
-            try await connection.authenticatePlain(username: "user", password: "secret")
-        }
-        try await answerAuthenticate(replacement, tag: "A001", mechanism: "PLAIN")
-        try await answerCapabilityRefresh(replacement, tag: "A002", capabilities: "IMAP4rev1 AUTH=PLAIN")
-        try await authTask.value
-        #expect(connection.isAuthenticated)
-        let staleWrite = try? await stale.channel.readOutbound(as: ByteBuffer.self)
-        #expect(staleWrite == nil, "nothing may be written on the transport the refresh replaced")
-        await shutDownGracefully(group)
     }
 
     // MARK: - Harness
+
+    /// Runs `body` with a fresh group and shuts that group down on every exit path.
+    ///
+    /// A trailing `await shutDownGracefully(group)` is skipped when a test throws or
+    /// returns early, leaving the group running; `defer` cannot hold the call because
+    /// the shutdown is async. See `EventLoopGroupTestSupport.swift` for why the
+    /// synchronous shutdown is not an option here.
+    private func withEventLoopGroup(
+        _ body: (MultiThreadedEventLoopGroup) async throws -> Void
+    ) async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+
+        do {
+            try await body(group)
+            await shutDownGracefully(group)
+        } catch {
+            await shutDownGracefully(group)
+            throw error
+        }
+    }
 
     private func makeConnection(group: MultiThreadedEventLoopGroup, port: Int) -> IMAPConnection {
         IMAPConnection(

--- a/Tests/SwiftIMAPTests/AuthenticationCapabilityGuardTests.swift
+++ b/Tests/SwiftIMAPTests/AuthenticationCapabilityGuardTests.swift
@@ -145,26 +145,6 @@ struct AuthenticationCapabilityGuardTests {
 
     // MARK: - Harness
 
-    /// Runs `body` with a fresh group and shuts that group down on every exit path.
-    ///
-    /// A trailing `await shutDownGracefully(group)` is skipped when a test throws or
-    /// returns early, leaving the group running; `defer` cannot hold the call because
-    /// the shutdown is async. See `EventLoopGroupTestSupport.swift` for why the
-    /// synchronous shutdown is not an option here.
-    private func withEventLoopGroup(
-        _ body: (MultiThreadedEventLoopGroup) async throws -> Void
-    ) async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-
-        do {
-            try await body(group)
-            await shutDownGracefully(group)
-        } catch {
-            await shutDownGracefully(group)
-            throw error
-        }
-    }
-
     private func makeConnection(group: MultiThreadedEventLoopGroup, port: Int) -> IMAPConnection {
         IMAPConnection(
             host: "127.0.0.1",

--- a/Tests/SwiftIMAPTests/EventLoopGroupTestSupport.swift
+++ b/Tests/SwiftIMAPTests/EventLoopGroupTestSupport.swift
@@ -25,3 +25,24 @@ func shutDownGracefully(_ group: MultiThreadedEventLoopGroup) async {
         }
     }
 }
+
+/// Runs `body` with a fresh group and shuts that group down on every exit path.
+///
+/// A trailing `await shutDownGracefully(group)` is skipped whenever the body throws or
+/// returns early, leaving the group running for the rest of the test run; `defer` cannot
+/// hold the call because the shutdown is async. This wrapper is the only shape that
+/// covers the success, early-return and throwing paths alike.
+func withEventLoopGroup(
+    numberOfThreads: Int = 1,
+    _ body: (MultiThreadedEventLoopGroup) async throws -> Void
+) async throws {
+    let group = MultiThreadedEventLoopGroup(numberOfThreads: numberOfThreads)
+
+    do {
+        try await body(group)
+        await shutDownGracefully(group)
+    } catch {
+        await shutDownGracefully(group)
+        throw error
+    }
+}

--- a/Tests/SwiftIMAPTests/GmailExtensionsCapabilityTests.swift
+++ b/Tests/SwiftIMAPTests/GmailExtensionsCapabilityTests.swift
@@ -37,19 +37,19 @@ struct GmailExtensionsCapabilityTests {
 
     @Test("Named connection reports Gmail extensions unsupported when they are not advertised")
     func namedConnectionWithoutGmailExtensions() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
-        let named = makeNamedConnection(capabilities: [.idle, .uidPlus], group: group)
-        #expect(await named.supportsGmailExtensions == false)
+        try await withEventLoopGroup { group in
+            let named = makeNamedConnection(capabilities: [.idle, .uidPlus], group: group)
+            #expect(await named.supportsGmailExtensions == false)
+        }
     }
 
     @Test("Named connection accepts every spelling of X-GM-EXT-1")
     func namedConnectionAcceptsEverySpelling() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
-        for spelling in Self.spellings {
-            let named = makeNamedConnection(capabilities: [.idle, spelling], group: group)
-            #expect(await named.supportsGmailExtensions, "spelling \(spelling)")
+        try await withEventLoopGroup { group in
+            for spelling in Self.spellings {
+                let named = makeNamedConnection(capabilities: [.idle, spelling], group: group)
+                #expect(await named.supportsGmailExtensions, "spelling \(spelling)")
+            }
         }
     }
 

--- a/Tests/SwiftIMAPTests/IMAPNamedConnectionTests.swift
+++ b/Tests/SwiftIMAPTests/IMAPNamedConnectionTests.swift
@@ -26,6 +26,18 @@ private actor AuthenticationGate {
     }
 }
 
+private actor AuthenticationCounter {
+    private var count = 0
+
+    func increment() {
+        count += 1
+    }
+
+    func value() -> Int {
+        count
+    }
+}
+
 @Suite(.serialized, .timeLimit(.minutes(1)))
 struct IMAPNamedConnectionTests {
     private struct NamedConnectionHarness {
@@ -256,6 +268,38 @@ struct IMAPNamedConnectionTests {
         } catch {
             Issue.record("Expected IMAPError.commandNotSupported, got \(error)")
         }
+        try? await group.shutdownGracefully()
+    }
+
+    /// A peer reset leaves the session flag set until the next command notices the dead
+    /// channel, so `ensureAuthenticated` used to skip re-authentication and the command
+    /// went out on the reopened, unauthenticated transport. The session counts as
+    /// authenticated only while its channel is live.
+    @Test
+    func ensureAuthenticatedReauthenticatesWhenTheSessionFlagOutlivesTheChannel() async throws {
+        let counter = AuthenticationCounter()
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        let connection = IMAPConnection(
+            host: "localhost",
+            port: 1,
+            useTLS: false,
+            group: group,
+            loggerLabel: "test.imap",
+            outboundLabel: "test.imap.out",
+            inboundLabel: "test.imap.in",
+            connectionID: "test-stale-session",
+            connectionRole: "test"
+        )
+        connection.isSessionAuthenticated = true
+        let named = IMAPNamedConnection(
+            name: "test",
+            connection: connection,
+            authenticateOnConnection: { _ in await counter.increment() }
+        )
+
+        #expect(await named.isAuthenticated == false)
+        try await named.ensureAuthenticated()
+        #expect(await counter.value() == 1)
         try? await group.shutdownGracefully()
     }
 }

--- a/Tests/SwiftIMAPTests/ReauthenticationAfterReconnectTests.swift
+++ b/Tests/SwiftIMAPTests/ReauthenticationAfterReconnectTests.swift
@@ -1,0 +1,203 @@
+import Foundation
+import NIO
+import NIOEmbedded
+import NIOIMAP
+import NIOIMAPCore
+import Testing
+@testable import SwiftMail
+
+private actor ReauthenticationCounter {
+    private var count = 0
+
+    func increment() {
+        count += 1
+    }
+
+    func value() -> Int {
+        count
+    }
+}
+
+/// A connection that lost an authenticated session recovers it inside the command
+/// queue, on the transport it just reopened, before the command or IDLE that
+/// reopened it is sent. The check and the command are one queue turn, so a peer
+/// reset between them cannot leave an authenticated-state command on a fresh
+/// unauthenticated socket, and concurrent callers cannot each authenticate.
+@Suite(.serialized, .timeLimit(.minutes(1)))
+struct ReauthenticationAfterReconnectTests {
+    @Test
+    func commandThatReopensTheTransportReauthenticatesFirst() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        let connection = makeConnection(group: group)
+        let counter = ReauthenticationCounter()
+        let replacement = try await loseAuthenticatedSession(on: connection, counter: counter)
+
+        let noop = Task { try await connection.executeCommand(NoopCommand()) }
+        let line = try await nextOutboundLine(from: replacement)
+        #expect(line == "A001 NOOP\r\n", "expected NOOP on the replacement, got \(line ?? "<nothing>")")
+        #expect(await counter.value() == 1, "re-authentication runs before the command goes out")
+        try await writeInboundLines(replacement, "A001 OK NOOP completed\r\n")
+        _ = try await noop.value
+        #expect(connection.isAuthenticated)
+        #expect(!connection.lostAuthenticatedSession)
+    }
+
+    @Test
+    func idleStartThatReopensTheTransportReauthenticatesFirst() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        let connection = makeConnection(group: group)
+        let counter = ReauthenticationCounter()
+        let replacement = try await loseAuthenticatedSession(on: connection, counter: counter)
+        connection.replaceCapabilitiesForTesting([Capability("IMAP4rev1"), .idle])
+
+        let stream = try await connection.idle()
+        let line = try await nextOutboundLine(from: replacement)
+        #expect(line == "A001 IDLE\r\n", "expected IDLE on the replacement, got \(line ?? "<nothing>")")
+        #expect(await counter.value() == 1, "re-authentication runs before IDLE goes out")
+        #expect(connection.isAuthenticated)
+        _ = stream
+        try? await connection.disconnect()
+    }
+
+    @Test
+    func reauthenticationWaitsWhileAuthenticationIsInProgress() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        let connection = makeConnection(group: group)
+        let counter = ReauthenticationCounter()
+        connection.lostAuthenticatedSession = true
+        connection.reauthenticateAfterReconnect = { _ in await counter.increment() }
+
+        connection.authenticationInProgress = true
+        try await connection.reauthenticateIfSessionWasLost(before: "CAPABILITY")
+        #expect(await counter.value() == 0, "the refresh inside an authentication must not nest another")
+
+        connection.authenticationInProgress = false
+        try await connection.reauthenticateIfSessionWasLost(before: "NOOP")
+        #expect(await counter.value() == 1)
+    }
+
+    @Test
+    func explicitDisconnectIsNotALostSession() async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+        defer { try? group.syncShutdownGracefully() }
+        let connection = makeConnection(group: group)
+        let channel = try await makeTestingChannel(for: connection)
+        connection.markSessionAuthenticated()
+
+        try await connection.disconnect()
+        #expect(!connection.lostAuthenticatedSession, "ending the session on purpose is not losing it")
+
+        let second = try await makeTestingChannel(for: connection)
+        connection.markSessionAuthenticated()
+        try await second.close()
+        connection.clearInvalidChannel()
+        #expect(connection.lostAuthenticatedSession, "a dead channel under an authenticated session is a loss")
+        _ = channel
+    }
+
+    @Test
+    func concurrentPrimaryCallersShareOneAuthentication() async throws {
+        let server = SwiftMail.IMAPServer(host: "localhost", port: 143, useTLS: false)
+        let primary = await server.primaryConnection
+        let channel = try await makeTestingChannel(for: primary)
+        primary.replaceCapabilitiesForTesting([
+            Capability("IMAP4rev1"), Capability("SASL-IR"), .authenticate(AuthenticationMechanism("PLAIN"))
+        ])
+        await server.replaceAuthenticationForTesting(
+            .init(method: .plain(username: "user", password: "secret"), identification: nil)
+        )
+
+        let first = Task { try await server.ensurePrimaryConnectionAuthenticated() }
+        let second = Task { try await server.ensurePrimaryConnectionAuthenticated() }
+        let authenticate = try await nextOutboundLine(from: channel)
+        #expect(authenticate?.hasPrefix("A001 AUTHENTICATE PLAIN ") == true, "got \(authenticate ?? "<nothing>")")
+        try await writeInboundLines(channel, "A001 OK authenticated\r\n")
+        let refresh = try await nextOutboundLine(from: channel)
+        #expect(refresh == "A002 CAPABILITY\r\n", "got \(refresh ?? "<nothing>")")
+        try await writeInboundLines(channel, "* CAPABILITY IMAP4rev1 AUTH=PLAIN\r\nA002 OK done\r\n")
+        try await first.value
+        try await second.value
+        let extra = try await nextOutboundLine(from: channel, timeoutNanoseconds: 200_000_000)
+        #expect(extra == nil, "the second caller must not authenticate again, got \(extra ?? "<nothing>")")
+        #expect(primary.isAuthenticated)
+    }
+
+    // MARK: - Harness
+
+    private func makeConnection(group: MultiThreadedEventLoopGroup) -> IMAPConnection {
+        IMAPConnection(
+            host: "127.0.0.1",
+            port: 143,
+            transportSecurity: .plainText,
+            minimumTLSVersion: .tlsv12,
+            group: group,
+            loggerLabel: "test.imap",
+            outboundLabel: "test.imap.out",
+            inboundLabel: "test.imap.in",
+            connectionID: "test-reauth",
+            connectionRole: "test",
+            parserLimits: .default
+        )
+    }
+
+    /// A live testing channel wired into the connection's pipeline and installed as its channel.
+    private func makeTestingChannel(for connection: IMAPConnection) async throws -> NIOAsyncTestingChannel {
+        let channel = NIOAsyncTestingChannel()
+        try await channel.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 143))
+        try await channel.addIMAPClientHandler()
+        try await channel.pipeline.addHandler(connection.duplexLogger)
+        try await channel.pipeline.addHandler(connection.responseBuffer)
+        connection.replaceChannelForTesting(channel)
+        return channel
+    }
+
+    /// Authenticates the connection on a channel, kills that channel as a peer reset
+    /// would, and arranges for the next connect to install a replacement whose
+    /// outbound the test can read. The counter records the re-authentication hook,
+    /// which marks the session authenticated the way a real AUTHENTICATE would.
+    private func loseAuthenticatedSession(
+        on connection: IMAPConnection,
+        counter: ReauthenticationCounter
+    ) async throws -> NIOAsyncTestingChannel {
+        let stale = try await makeTestingChannel(for: connection)
+        connection.replaceCapabilitiesForTesting([Capability("IMAP4rev1")])
+        connection.markSessionAuthenticated()
+        try await stale.close()
+        let replacement = NIOAsyncTestingChannel()
+        connection.replaceConnectForTesting {
+            try await replacement.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 143))
+            try await replacement.addIMAPClientHandler()
+            try await replacement.pipeline.addHandler(connection.duplexLogger)
+            try await replacement.pipeline.addHandler(connection.responseBuffer)
+            connection.replaceChannelForTesting(replacement)
+        }
+        connection.reauthenticateAfterReconnect = { connection in
+            await counter.increment()
+            connection.markSessionAuthenticated()
+        }
+        return replacement
+    }
+
+    private func writeInboundLines(_ channel: NIOAsyncTestingChannel, _ text: String) async throws {
+        var buffer = channel.allocator.buffer(capacity: text.utf8.count)
+        buffer.writeString(text)
+        try await channel.writeInbound(buffer)
+    }
+
+    private func nextOutboundLine(
+        from channel: NIOAsyncTestingChannel,
+        timeoutNanoseconds: UInt64 = 1_000_000_000
+    ) async throws -> String? {
+        let start = DispatchTime.now().uptimeNanoseconds
+        while DispatchTime.now().uptimeNanoseconds - start < timeoutNanoseconds {
+            if var line = try await channel.readOutbound(as: ByteBuffer.self) {
+                return line.readString(length: line.readableBytes)
+            }
+            try await Task.sleep(nanoseconds: 5_000_000)
+        }
+        return nil
+    }
+}

--- a/Tests/SwiftIMAPTests/ReauthenticationAfterReconnectTests.swift
+++ b/Tests/SwiftIMAPTests/ReauthenticationAfterReconnectTests.swift
@@ -80,6 +80,54 @@ struct ReauthenticationAfterReconnectTests {
     }
 
     @Test
+    func authenticationFollowUpThatReopensTransportReauthenticatesBeforeReturning() async throws {
+        try await withEventLoopGroup { group in
+            let connection = makeConnection(group: group)
+            let stale = try await makeTestingChannel(for: connection)
+            let replacement = NIOAsyncTestingChannel()
+            connection.replaceConnectForTesting {
+                try await replacement.connect(to: SocketAddress(ipAddress: "127.0.0.1", port: 143))
+                try await replacement.addIMAPClientHandler()
+                try await replacement.pipeline.addHandler(connection.duplexLogger)
+                try await replacement.pipeline.addHandler(connection.responseBuffer)
+                connection.replaceChannelForTesting(replacement)
+            }
+            connection.authenticationFollowUpOverrideForTesting = {
+                connection.authenticationFollowUpOverrideForTesting = nil
+                try await stale.close()
+            }
+
+            let login = Task { try await connection.login(username: "user", password: "secret") }
+            let firstLogin = try await nextOutboundLine(from: stale)
+            #expect(firstLogin?.hasPrefix("A001 LOGIN ") == true, "got \(firstLogin ?? "<nothing>")")
+            try await writeInboundLines(stale, "A001 OK LOGIN completed\r\n")
+
+            let preAuthCapability = try await nextOutboundLine(from: replacement)
+            #expect(
+                preAuthCapability == "A002 CAPABILITY\r\n",
+                "expected CAPABILITY on the replacement, got \(preAuthCapability ?? "<nothing>")"
+            )
+            try await writeInboundLines(
+                replacement,
+                "* CAPABILITY IMAP4rev1\r\nA002 OK CAPABILITY completed\r\n"
+            )
+
+            let retriedLogin = try await nextOutboundLine(from: replacement)
+            #expect(
+                retriedLogin?.hasPrefix("A003 LOGIN ") == true,
+                "authentication must be retried on the replacement, got \(retriedLogin ?? "<nothing>")"
+            )
+            try await writeInboundLines(
+                replacement,
+                "A003 OK [CAPABILITY IMAP4rev1] LOGIN completed\r\n"
+            )
+            try await login.value
+            #expect(connection.isAuthenticated)
+            #expect(!connection.lostAuthenticatedSession)
+        }
+    }
+
+    @Test
     func explicitDisconnectIsNotALostSession() async throws {
         try await withEventLoopGroup { group in
             let connection = makeConnection(group: group)

--- a/Tests/SwiftIMAPTests/ReauthenticationAfterReconnectTests.swift
+++ b/Tests/SwiftIMAPTests/ReauthenticationAfterReconnectTests.swift
@@ -175,20 +175,6 @@ struct ReauthenticationAfterReconnectTests {
 
     // MARK: - Harness
 
-    private func withEventLoopGroup(
-        _ body: (MultiThreadedEventLoopGroup) async throws -> Void
-    ) async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-
-        do {
-            try await body(group)
-            await shutDownGracefully(group)
-        } catch {
-            await shutDownGracefully(group)
-            throw error
-        }
-    }
-
     private func makeConnection(group: MultiThreadedEventLoopGroup) -> IMAPConnection {
         IMAPConnection(
             host: "127.0.0.1",

--- a/Tests/SwiftIMAPTests/ReauthenticationAfterReconnectTests.swift
+++ b/Tests/SwiftIMAPTests/ReauthenticationAfterReconnectTests.swift
@@ -27,75 +27,75 @@ private actor ReauthenticationCounter {
 struct ReauthenticationAfterReconnectTests {
     @Test
     func commandThatReopensTheTransportReauthenticatesFirst() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
-        let connection = makeConnection(group: group)
-        let counter = ReauthenticationCounter()
-        let replacement = try await loseAuthenticatedSession(on: connection, counter: counter)
+        try await withEventLoopGroup { group in
+            let connection = makeConnection(group: group)
+            let counter = ReauthenticationCounter()
+            let replacement = try await loseAuthenticatedSession(on: connection, counter: counter)
 
-        let noop = Task { try await connection.executeCommand(NoopCommand()) }
-        let line = try await nextOutboundLine(from: replacement)
-        #expect(line == "A001 NOOP\r\n", "expected NOOP on the replacement, got \(line ?? "<nothing>")")
-        #expect(await counter.value() == 1, "re-authentication runs before the command goes out")
-        try await writeInboundLines(replacement, "A001 OK NOOP completed\r\n")
-        _ = try await noop.value
-        #expect(connection.isAuthenticated)
-        #expect(!connection.lostAuthenticatedSession)
+            let noop = Task { try await connection.executeCommand(NoopCommand()) }
+            let line = try await nextOutboundLine(from: replacement)
+            #expect(line == "A001 NOOP\r\n", "expected NOOP on the replacement, got \(line ?? "<nothing>")")
+            #expect(await counter.value() == 1, "re-authentication runs before the command goes out")
+            try await writeInboundLines(replacement, "A001 OK NOOP completed\r\n")
+            _ = try await noop.value
+            #expect(connection.isAuthenticated)
+            #expect(!connection.lostAuthenticatedSession)
+        }
     }
 
     @Test
     func idleStartThatReopensTheTransportReauthenticatesFirst() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
-        let connection = makeConnection(group: group)
-        let counter = ReauthenticationCounter()
-        let replacement = try await loseAuthenticatedSession(on: connection, counter: counter)
-        connection.replaceCapabilitiesForTesting([Capability("IMAP4rev1"), .idle])
+        try await withEventLoopGroup { group in
+            let connection = makeConnection(group: group)
+            let counter = ReauthenticationCounter()
+            let replacement = try await loseAuthenticatedSession(on: connection, counter: counter)
+            connection.replaceCapabilitiesForTesting([Capability("IMAP4rev1"), .idle])
 
-        let stream = try await connection.idle()
-        let line = try await nextOutboundLine(from: replacement)
-        #expect(line == "A001 IDLE\r\n", "expected IDLE on the replacement, got \(line ?? "<nothing>")")
-        #expect(await counter.value() == 1, "re-authentication runs before IDLE goes out")
-        #expect(connection.isAuthenticated)
-        _ = stream
-        try? await connection.disconnect()
+            let stream = try await connection.idle()
+            let line = try await nextOutboundLine(from: replacement)
+            #expect(line == "A001 IDLE\r\n", "expected IDLE on the replacement, got \(line ?? "<nothing>")")
+            #expect(await counter.value() == 1, "re-authentication runs before IDLE goes out")
+            #expect(connection.isAuthenticated)
+            _ = stream
+            try? await connection.disconnect()
+        }
     }
 
     @Test
     func reauthenticationWaitsWhileAuthenticationIsInProgress() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
-        let connection = makeConnection(group: group)
-        let counter = ReauthenticationCounter()
-        connection.lostAuthenticatedSession = true
-        connection.reauthenticateAfterReconnect = { _ in await counter.increment() }
+        try await withEventLoopGroup { group in
+            let connection = makeConnection(group: group)
+            let counter = ReauthenticationCounter()
+            connection.lostAuthenticatedSession = true
+            connection.reauthenticateAfterReconnect = { _ in await counter.increment() }
 
-        connection.authenticationInProgress = true
-        try await connection.reauthenticateIfSessionWasLost(before: "CAPABILITY")
-        #expect(await counter.value() == 0, "the refresh inside an authentication must not nest another")
+            connection.authenticationInProgress = true
+            try await connection.reauthenticateIfSessionWasLost(before: "CAPABILITY")
+            #expect(await counter.value() == 0, "the refresh inside an authentication must not nest another")
 
-        connection.authenticationInProgress = false
-        try await connection.reauthenticateIfSessionWasLost(before: "NOOP")
-        #expect(await counter.value() == 1)
+            connection.authenticationInProgress = false
+            try await connection.reauthenticateIfSessionWasLost(before: "NOOP")
+            #expect(await counter.value() == 1)
+        }
     }
 
     @Test
     func explicitDisconnectIsNotALostSession() async throws {
-        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
-        defer { try? group.syncShutdownGracefully() }
-        let connection = makeConnection(group: group)
-        let channel = try await makeTestingChannel(for: connection)
-        connection.markSessionAuthenticated()
+        try await withEventLoopGroup { group in
+            let connection = makeConnection(group: group)
+            let channel = try await makeTestingChannel(for: connection)
+            connection.markSessionAuthenticated()
 
-        try await connection.disconnect()
-        #expect(!connection.lostAuthenticatedSession, "ending the session on purpose is not losing it")
+            try await connection.disconnect()
+            #expect(!connection.lostAuthenticatedSession, "ending the session on purpose is not losing it")
 
-        let second = try await makeTestingChannel(for: connection)
-        connection.markSessionAuthenticated()
-        try await second.close()
-        connection.clearInvalidChannel()
-        #expect(connection.lostAuthenticatedSession, "a dead channel under an authenticated session is a loss")
-        _ = channel
+            let second = try await makeTestingChannel(for: connection)
+            connection.markSessionAuthenticated()
+            try await second.close()
+            connection.clearInvalidChannel()
+            #expect(connection.lostAuthenticatedSession, "a dead channel under an authenticated session is a loss")
+            _ = channel
+        }
     }
 
     @Test
@@ -126,6 +126,20 @@ struct ReauthenticationAfterReconnectTests {
     }
 
     // MARK: - Harness
+
+    private func withEventLoopGroup(
+        _ body: (MultiThreadedEventLoopGroup) async throws -> Void
+    ) async throws {
+        let group = MultiThreadedEventLoopGroup(numberOfThreads: 1)
+
+        do {
+            try await body(group)
+            await shutDownGracefully(group)
+        } catch {
+            await shutDownGracefully(group)
+            throw error
+        }
+    }
 
     private func makeConnection(group: MultiThreadedEventLoopGroup) -> IMAPConnection {
         IMAPConnection(


### PR DESCRIPTION
Supersedes #223, keeping its original commits and adding the fixes requested there.

## The failure

`IMAPConnection.isAuthenticated` reported an authenticated session whose transport the peer had already reset. Observed against Gmail on 2026-09-05, when the server reset every socket of an account at once and a named connection (`IMAPServer.connection(named:)`) then ran `UID SEARCH`:

1. `IMAPNamedConnection.executeCommand` calls `ensureAuthenticated()`, which returns early because `connection.isAuthenticated` is still `true` — a peer reset does not clear `isSessionAuthenticated`, only `disconnectBody()` and `clearInvalidChannel()` do, and neither has run yet.
2. `IMAPConnection.executeCommandBody` then calls `clearInvalidChannel()`, finds the channel nil, and re-establishes the transport with `connectBody()`.
3. The SEARCH goes out on the new transport before any AUTHENTICATE. Gmail answers `BAD Unknown command <session-id>`, and the connection's own log reports the state that explains it: `channelActive=true authenticated=false`.

## The fix

`isAuthenticated` now also requires `isConnected`, so an authenticated session cannot outlive its channel. That alone left recovery racy, so the connection additionally tracks a **lost authenticated session** — a dead channel, or a recycle under an authenticated session, but not an explicit disconnect — and re-authenticates on the replacement socket inside the same queue turn before the user's command is written. `IMAPServer` installs the hook on the primary connection and on every named and IDLE connection it creates, driven by queue-level LOGIN, PLAIN, XOAUTH2 and ID variants so recovery never re-enters the queue. `startIdleSession` runs the same recovery after its own reconnect, so classic IDLE cannot write `IDLE` unauthenticated. A flag set for the duration of any authentication keeps the capability refresh inside it from nesting another, and `ensurePrimaryConnectionAuthenticated` shares one in-flight authentication among concurrent callers.

## Review fixes on top of #223

- **Codex P1, authentication follow-up reconnects** (a725fc7) — when the transport died after LOGIN/AUTHENTICATE succeeded but before its CAPABILITY or NAMESPACE follow-up, the follow-up reconnected while `authenticationInProgress` suppressed the recovery hook, and the outer recovery reported success on an unauthenticated socket. LOGIN, PLAIN and XOAUTH2 now keep post-auth discovery inside a bounded stable-transport flow and retry the full authentication on a replacement channel before returning.
- **Cooperative-pool deadlock in the tests** (61934f3, cherry-picked from #223, plus d6e9978 and 12a96de) — the macOS job was killed at exit 137 in kqueue. `syncShutdownGracefully()` from a swift-testing test parks a cooperative-pool thread on a semaphore whose signal needs those same threads, so a few concurrent shutdowns deadlock a core-constrained runner; `EventLoopGroupTestSupport.swift` documents the trap. All eleven remaining uses now go through `shutDownGracefully(_:)`: four in the new file, five in `AuthenticationCapabilityGuardTests` (from #221) and two in `GmailExtensionsCapabilityTests` (from #220). They share a `withEventLoopGroup` wrapper, which lives beside `shutDownGracefully(_:)` in the support file rather than being copied per suite, and which shuts the group down on the throwing and early-return paths that a trailing call and an async-incompatible `defer` both miss.

## Tests

`ReauthenticationAfterReconnectTests` covers a command and an IDLE start that reopen the transport and re-authenticate before writing, the nesting guard, an explicit disconnect not counting as a loss, two concurrent primary callers producing a single AUTHENTICATE, and a LOGIN whose follow-up reconnects — the last one drops the channel immediately before the follow-up, observes the pre-auth CAPABILITY, and requires a second LOGIN on the replacement. `IMAPNamedConnectionTests.ensureAuthenticatedReauthenticatesWhenTheSessionFlagOutlivesTheChannel` builds a connection with `isSessionAuthenticated = true` and no channel and asserts `ensureAuthenticated()` invokes the authenticate closure once; on `main` the closure is never called.

517 tests in 66 suites pass; `swiftlint lint --strict` is clean.

Credit to @jdudley for the original diagnosis and fix in #223.

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)
