### PR TITLE
Encode header values and display names that cannot be written literally

### DIFF
--- a/Sources/SwiftMail/Extensions/EmailAddress+StringConversion.swift
+++ b/Sources/SwiftMail/Extensions/EmailAddress+StringConversion.swift
@@ -8,6 +8,15 @@ import Foundation
 extension EmailAddress: LosslessStringConvertible {
     /**
      Initialize an email address from a string representation
+
+     A *bare* encoded-word display name is RFC 2047-decoded — that is how a
+     non-ASCII name written by ``description``, or read off the wire, arrives —
+     so the round trip yields the name the recipient actually sees, the same
+     treatment the IMAP `ENVELOPE` path gives a `personName`. A display name
+     inside a *quoted-string* is taken literally: RFC 2047 §5 forbids reading an
+     encoded-word there, so text that merely looks like `=?…?=` is returned
+     verbatim, not decoded.
+
      - Parameter description: The string representation of the email address
      */
     public init?(_ description: String) {
@@ -34,14 +43,21 @@ extension EmailAddress: LosslessStringConvertible {
 
                 // Check if we have a quoted name or a regular name
                 if nameRange1.location != NSNotFound {
-                    // Quoted name (with special characters)
+                    // Quoted name (with special characters). A quoted-string
+                    // always carries a LITERAL display name: RFC 2047 §5 forbids
+                    // reading an encoded-word inside a quoted-string, so a name
+                    // that merely *looks* like `=?UTF-8?B?…?=` is exactly that
+                    // text and must be handed back verbatim, never MIME-decoded.
+                    // A non-ASCII name never reaches this branch — `headerString`
+                    // emits it as a *bare* encoded-word, which the unquoted
+                    // branch below decodes.
                     let name = nsString.substring(with: nameRange1)
                     self.init(name: name, address: email)
                     return
                 } else if nameRange2.location != NSNotFound {
                     // Regular name
                     let name = nsString.substring(with: nameRange2).trimmingCharacters(in: .whitespaces)
-                    self.init(name: name, address: email)
+                    self.init(name: name.decodeMIMEHeader(), address: email)
                     return
                 } else {
                     // Just the email
@@ -56,20 +72,17 @@ extension EmailAddress: LosslessStringConvertible {
 
     /**
      Get the string representation of the email address
-     This uses the formatted representation which includes the name if available
+
+     This is the RFC 5322 address string, including the display name if there is
+     one — the same text ``headerString()`` writes into a header field, and the
+     text ``init(_:)`` reads back. It has always produced address syntax rather
+     than free text (a name with a comma comes back quoted), so a name that
+     syntax cannot carry literally is RFC 2047-encoded here too; see
+     ``headerString()`` for which names those are and why. Emitting a name raw
+     when it holds a CR or LF is what let a `Message` built from an `Email` grow
+     a header field its author never wrote.
      */
-    public var description: String {
-        if let name = name, !name.isEmpty {
-            // Use quotes if the name contains special characters
-            if name.contains(where: { !$0.isLetter && !$0.isNumber && !$0.isWhitespace }) {
-                return "\"\(name)\" <\(address)>"
-            } else {
-                return "\(name) <\(address)>"
-            }
-        } else {
-            return address
-        }
-    }
+    public var description: String { headerString() }
 
     /**
      RFC 5322 address string for use in a header field (`From`/`To`/`Cc`/…).
@@ -90,7 +103,9 @@ extension EmailAddress: LosslessStringConvertible {
      removes the escape. Encoded-words must not appear inside a quoted-string, so
      an encoded name is emitted bare (never quoted).
 
-     Use this — not ``description`` — when writing an address into a header.
+     ``description`` returns this, so every caller that formats an address gets a
+     value a header field can hold. ``init(_:)`` decodes the name again, so the
+     round trip still yields the original text.
      */
     func headerString() -> String {
         guard let name = name, !name.isEmpty else { return address }

--- a/Sources/SwiftMail/Extensions/EmailAddress+StringConversion.swift
+++ b/Sources/SwiftMail/Extensions/EmailAddress+StringConversion.swift
@@ -20,54 +20,43 @@ extension EmailAddress: LosslessStringConvertible {
      - Parameter description: The string representation of the email address
      */
     public init?(_ description: String) {
+        let trimmed = description.trimmingCharacters(in: .whitespaces)
+
         // Simple email address without a name
-        if description.contains("@") && !description.contains("<") {
-            self.init(address: description)
+        if trimmed.contains("@") && !trimmed.contains("<") && !trimmed.contains(">") {
+            self.init(address: trimmed)
             return
         }
 
         // Email address with a name
         // Format: "Name <email@example.com>" or "\"Name with, special chars\" <email@example.com>"
-        let namePattern = "(?:\"([^\"]+)\"|([^<]*))\\s*<([^>]+)>"
-        let nameRegex = try? NSRegularExpression(pattern: namePattern, options: [])
-
-        let descriptionRange = NSRange(location: 0, length: description.count)
-        if let match = nameRegex?.firstMatch(in: description, options: [], range: descriptionRange) {
-            let nameRange1 = match.range(at: 1)
-            let nameRange2 = match.range(at: 2)
-            let emailRange = match.range(at: 3)
-
-            if emailRange.location != NSNotFound {
-                let nsString = description as NSString
-                let email = nsString.substring(with: emailRange)
-
-                // Check if we have a quoted name or a regular name
-                if nameRange1.location != NSNotFound {
-                    // Quoted name (with special characters). A quoted-string
-                    // always carries a LITERAL display name: RFC 2047 §5 forbids
-                    // reading an encoded-word inside a quoted-string, so a name
-                    // that merely *looks* like `=?UTF-8?B?…?=` is exactly that
-                    // text and must be handed back verbatim, never MIME-decoded.
-                    // A non-ASCII name never reaches this branch — `headerString`
-                    // emits it as a *bare* encoded-word, which the unquoted
-                    // branch below decodes.
-                    let name = nsString.substring(with: nameRange1)
-                    self.init(name: name, address: email)
-                    return
-                } else if nameRange2.location != NSNotFound {
-                    // Regular name
-                    let name = nsString.substring(with: nameRange2).trimmingCharacters(in: .whitespaces)
-                    self.init(name: name.decodeMIMEHeader(), address: email)
-                    return
-                } else {
-                    // Just the email
-                    self.init(address: email)
-                    return
-                }
-            }
+        guard trimmed.last == ">",
+              let addressStart = trimmed.dropLast().lastIndex(of: "<") else {
+            return nil
         }
 
-        return nil
+        let address = trimmed[trimmed.index(after: addressStart)..<trimmed.index(before: trimmed.endIndex)]
+        guard !address.isEmpty, !address.contains("<"), !address.contains(">") else {
+            return nil
+        }
+
+        let phrase = trimmed[..<addressStart].trimmingCharacters(in: .whitespaces)
+        guard !phrase.isEmpty else {
+            self.init(address: String(address))
+            return
+        }
+
+        if phrase.first == "\"" {
+            // A quoted-string always carries a literal display name: RFC 2047
+            // §5 forbids reading an encoded-word inside one.
+            guard phrase.last == "\"", phrase.count >= 2 else { return nil }
+            self.init(name: String(phrase.dropFirst().dropLast()), address: String(address))
+        } else {
+            // Decode only complete encoded-word tokens. Decoding the `=?…?=`
+            // substring of an ordinary atom would corrupt the phrase and can
+            // even manufacture control characters that were not on the wire.
+            self.init(name: phrase.decodingRFC2047Phrase(), address: String(address))
+        }
     }
 
     /**
@@ -117,5 +106,52 @@ extension EmailAddress: LosslessStringConvertible {
             return "\"\(name)\" <\(address)>"
         }
         return "\(name) <\(address)>"
+    }
+}
+
+private extension StringProtocol {
+    /// Decode encoded-words only when each occupies a complete phrase token.
+    /// RFC 2047 whitespace between adjacent encoded-words is not displayed.
+    func decodingRFC2047Phrase() -> String {
+        var result = ""
+        var pendingWhitespace = ""
+        var token = ""
+        var previousWasEncoded = false
+
+        func appendToken() {
+            guard !token.isEmpty else { return }
+            let decoded = token.decodeMIMEHeader()
+            let isEncoded = decoded != token && token.isCompleteRFC2047EncodedWord
+
+            if !(previousWasEncoded && isEncoded) {
+                result += pendingWhitespace
+            }
+            result += isEncoded ? decoded : token
+            pendingWhitespace = ""
+            previousWasEncoded = isEncoded
+            token = ""
+        }
+
+        for character in self {
+            let isWhitespace = character.unicodeScalars.allSatisfy { scalar in
+                scalar == " " || scalar == "\t" || scalar == "\r" || scalar == "\n"
+            }
+            if isWhitespace {
+                appendToken()
+                pendingWhitespace.append(character)
+            } else {
+                token.append(character)
+            }
+        }
+        appendToken()
+        result += pendingWhitespace
+        return result
+    }
+}
+
+private extension String {
+    var isCompleteRFC2047EncodedWord: Bool {
+        let pattern = #"^=\?[^?]+\?[bBqQ]\?[^?]*\?=$"#
+        return range(of: pattern, options: .regularExpression) == startIndex..<endIndex
     }
 }

--- a/Sources/SwiftMail/Extensions/EmailAddress+StringConversion.swift
+++ b/Sources/SwiftMail/Extensions/EmailAddress+StringConversion.swift
@@ -13,9 +13,9 @@ extension EmailAddress: LosslessStringConvertible {
      non-ASCII name written by ``description``, or read off the wire, arrives —
      so the round trip yields the name the recipient actually sees, the same
      treatment the IMAP `ENVELOPE` path gives a `personName`. A display name
-     inside a *quoted-string* is taken literally: RFC 2047 §5 forbids reading an
-     encoded-word there, so text that merely looks like `=?…?=` is returned
-     verbatim, not decoded.
+     inside a *quoted-string* is not RFC 2047-decoded: text that merely looks
+     like `=?…?=` is returned verbatim. RFC 5322 quoted-pair escapes are still
+     syntax and are removed to recover the literal display-name characters.
 
      - Parameter description: The string representation of the email address
      */
@@ -30,12 +30,15 @@ extension EmailAddress: LosslessStringConvertible {
 
         // Email address with a name
         // Format: "Name <email@example.com>" or "\"Name with, special chars\" <email@example.com>"
-        guard trimmed.last == ">",
-              let addressStart = trimmed.dropLast().lastIndex(of: "<") else {
-            return nil
+        let addressEnd = trimmed.indices.reversed().first { index in
+            trimmed[index] == ">" && trimmed[trimmed.index(after: index)...].isTrailingRFC5322CFWS
         }
+        guard let addressEnd else { return nil }
 
-        let address = trimmed[trimmed.index(after: addressStart)..<trimmed.index(before: trimmed.endIndex)]
+        let mailbox = trimmed[...addressEnd]
+        guard let addressStart = mailbox.dropLast().lastIndex(of: "<") else { return nil }
+
+        let address = mailbox[mailbox.index(after: addressStart)..<addressEnd]
         guard !address.isEmpty, !address.contains("<"), !address.contains(">") else {
             return nil
         }
@@ -48,9 +51,12 @@ extension EmailAddress: LosslessStringConvertible {
 
         if phrase.first == "\"" {
             // A quoted-string always carries a literal display name: RFC 2047
-            // §5 forbids reading an encoded-word inside one.
-            guard phrase.last == "\"", phrase.count >= 2 else { return nil }
-            self.init(name: String(phrase.dropFirst().dropLast()), address: String(address))
+            // §5 forbids reading an encoded-word inside one. RFC 5322
+            // quoted-pairs are syntax, though, so remove their escape character
+            // before storing the logical display name.
+            guard phrase.last == "\"", phrase.count >= 2,
+                  let name = phrase.dropFirst().dropLast().unescapingRFC5322QuotedPairs() else { return nil }
+            self.init(name: name, address: String(address))
         } else {
             // Decode only complete encoded-word tokens. Decoding the `=?…?=`
             // substring of an ordinary atom would corrupt the phrase and can
@@ -110,6 +116,56 @@ extension EmailAddress: LosslessStringConvertible {
 }
 
 private extension StringProtocol {
+    /// Remove quoted-pair escape characters and reject an unescaped quote or a
+    /// dangling escape inside an RFC 5322 quoted-string.
+    func unescapingRFC5322QuotedPairs() -> String? {
+        var result = ""
+        var isEscaped = false
+
+        for character in self {
+            if isEscaped {
+                result.append(character)
+                isEscaped = false
+            } else if character == "\\" {
+                isEscaped = true
+            } else if character == "\"" {
+                return nil
+            } else {
+                result.append(character)
+            }
+        }
+        return isEscaped ? nil : result
+    }
+
+    /// Whether the suffix after an angle-addr consists only of balanced RFC
+    /// 5322 comments and horizontal whitespace. Header unfolding has already
+    /// replaced legal folding whitespace with SP before this parser is called.
+    var isTrailingRFC5322CFWS: Bool {
+        var commentDepth = 0
+        var isEscaped = false
+
+        for character in self {
+            if commentDepth > 0 {
+                if isEscaped {
+                    isEscaped = false
+                } else if character == "\\" {
+                    isEscaped = true
+                } else if character == "(" {
+                    commentDepth += 1
+                } else if character == ")" {
+                    commentDepth -= 1
+                } else if character.unicodeScalars.contains(where: { $0 == "\r" || $0 == "\n" }) {
+                    return false
+                }
+            } else if character == "(" {
+                commentDepth = 1
+            } else if character != " " && character != "\t" {
+                return false
+            }
+        }
+        return commentDepth == 0 && !isEscaped
+    }
+
     /// Decode encoded-words only when each occupies a complete phrase token.
     /// RFC 2047 whitespace between adjacent encoded-words is not displayed.
     func decodingRFC2047Phrase() -> String {

--- a/Sources/SwiftMail/Extensions/EmailAddress+StringConversion.swift
+++ b/Sources/SwiftMail/Extensions/EmailAddress+StringConversion.swift
@@ -74,18 +74,30 @@ extension EmailAddress: LosslessStringConvertible {
     /**
      RFC 5322 address string for use in a header field (`From`/`To`/`Cc`/…).
 
-     Identical to ``description`` for ASCII display names, but a non-ASCII name
-     is RFC 2047-encoded. Encoded-words must not appear inside a quoted-string,
-     so an encoded name is emitted bare (never quoted). Use this — not
-     ``description`` — when writing an address into a header so that non-ASCII
-     names survive transport instead of being mojibake'd.
+     A display name that cannot be written literally is RFC 2047-encoded. That
+     covers two cases:
+
+     - The name is not a valid field body — it holds non-ASCII text or a control
+       character. A CR or LF here *ends the header field*, so an unencoded name
+       turns the rest of the value into new header lines.
+     - The name holds a `"` or a `\`, the two characters that would escape the
+       quoted-string it would otherwise be wrapped in. An embedded `"` closes the
+       string early and lets the remainder be read as further address syntax; a
+       `\` is read as a quoted-pair, so the literal text is lost.
+
+     An encoded-word may replace a word inside a phrase (RFC 2047 §5) and its
+     output is bare printable ASCII, so encoding both carries the name intact and
+     removes the escape. Encoded-words must not appear inside a quoted-string, so
+     an encoded name is emitted bare (never quoted).
+
+     Use this — not ``description`` — when writing an address into a header.
      */
     func headerString() -> String {
         guard let name = name, !name.isEmpty else { return address }
-        if name.contains(where: { !$0.isASCII }) {
-            return "\(name.rfc2047EncodedHeader()) <\(address)>"
+        if name.rfc2047RequiresEncodingAsDisplayName {
+            return "\(name.rfc2047EncodedWords()) <\(address)>"
         }
-        // Use quotes if the (ASCII) name contains special characters
+        // Use quotes if the (plain ASCII) name contains special characters
         if name.contains(where: { !$0.isLetter && !$0.isNumber && !$0.isWhitespace }) {
             return "\"\(name)\" <\(address)>"
         }

--- a/Sources/SwiftMail/Extensions/String+RFC2047Encode.swift
+++ b/Sources/SwiftMail/Extensions/String+RFC2047Encode.swift
@@ -40,6 +40,40 @@ extension String {
         return scalar.value < 0x20 || scalar.value >= 0x7F
     }
 
+    /// Whether the receiver contains a scalar that cannot be written literally
+    /// in an unstructured header field body. A CRLF pair is allowed only when
+    /// followed by whitespace: that is RFC 5322 folding whitespace, not a new
+    /// header field. This preserves already-folded encoded-words supplied by a
+    /// caller while bare or malformed line breaks still trigger encoding.
+    private var rfc2047ContainsUnsafeHeaderScalar: Bool {
+        let scalars = unicodeScalars
+        var index = scalars.startIndex
+
+        while index != scalars.endIndex {
+            let scalar = scalars[index]
+            if scalar == "\r" {
+                let lineFeed = scalars.index(after: index)
+                guard lineFeed != scalars.endIndex, scalars[lineFeed] == "\n" else { return true }
+                let whitespace = scalars.index(after: lineFeed)
+                guard whitespace != scalars.endIndex,
+                      scalars[whitespace] == " " || scalars[whitespace] == "\t" else { return true }
+
+                var visible = whitespace
+                while visible != scalars.endIndex,
+                      scalars[visible] == " " || scalars[visible] == "\t" {
+                    visible = scalars.index(after: visible)
+                }
+                guard visible != scalars.endIndex,
+                      (0x21...0x7E).contains(scalars[visible].value) else { return true }
+                index = whitespace
+            } else if scalar == "\n" || Self.rfc2047RequiresEncoding(scalar) {
+                return true
+            }
+            index = scalars.index(after: index)
+        }
+        return false
+    }
+
     /// Encode the receiver as one or more RFC 2047 Base64 encoded-words when it
     /// contains anything a header field body cannot carry literally — non-ASCII
     /// text, a C0 control, DEL, or a C1 control. A value made only of printable
@@ -57,7 +91,7 @@ extension String {
     /// that decode each word in isolation). Round-trips through
     /// ``decodeMIMEHeader()``.
     public func rfc2047EncodedHeader() -> String {
-        guard self.unicodeScalars.contains(where: Self.rfc2047RequiresEncoding) else { return self }
+        guard rfc2047ContainsUnsafeHeaderScalar else { return self }
         return rfc2047EncodedWords()
     }
 

--- a/Sources/SwiftMail/Extensions/String+RFC2047Encode.swift
+++ b/Sources/SwiftMail/Extensions/String+RFC2047Encode.swift
@@ -18,9 +18,38 @@ extension String {
     /// per-encoded-word ceiling.
     private static let rfc2047MaxBytesPerWord = 45
 
+    /// Whether `scalar` is one that a header field body cannot carry literally.
+    ///
+    /// RFC 5322 §2.2 limits a field body to printable US-ASCII (0x21–0x7E) plus
+    /// SP and HTAB, so everything below SP and everything from DEL upwards —
+    /// the C0 controls, DEL, the C1 range, and all non-ASCII text — needs an
+    /// encoded-word. CR and LF are the dangerous members: they *end the field*,
+    /// so a value carrying them silently becomes additional header lines when it
+    /// is interpolated into one.
+    ///
+    /// Membership is decided on the Unicode SCALAR, never on `Character`. A
+    /// `Character` is an extended grapheme cluster and CR-LF is a single one, so
+    /// `Character.isASCII` answers `true` for a whole `\r\n` pair and a
+    /// `Character`-based test cannot see it.
+    ///
+    /// HTAB is excluded deliberately: it is WSP, which RFC 5322 §3.2.5 allows
+    /// literally in an unstructured field body, so encoding it would change the
+    /// output of ordinary values for no benefit.
+    private static func rfc2047RequiresEncoding(_ scalar: Unicode.Scalar) -> Bool {
+        if scalar.value == 0x09 { return false } // HTAB is legal WSP
+        return scalar.value < 0x20 || scalar.value >= 0x7F
+    }
+
     /// Encode the receiver as one or more RFC 2047 Base64 encoded-words when it
-    /// contains any non-ASCII character. Pure-ASCII input is returned unchanged
-    /// (it is already a valid header value).
+    /// contains anything a header field body cannot carry literally — non-ASCII
+    /// text, a C0 control, DEL, or a C1 control. A value made only of printable
+    /// US-ASCII, SP and HTAB is already a valid header value and is returned
+    /// unchanged.
+    ///
+    /// Encoding rather than rejecting keeps the library non-throwing and loses
+    /// nothing: an encoded-word is the standard carrier for octets a header
+    /// cannot hold literally, so the recipient still sees exactly what the
+    /// caller wrote.
     ///
     /// Multiple encoded-words are folded with `CRLF SPACE` so each stays within
     /// the 75-octet limit; a character's UTF-8 bytes are never split across two
@@ -28,8 +57,16 @@ extension String {
     /// that decode each word in isolation). Round-trips through
     /// ``decodeMIMEHeader()``.
     public func rfc2047EncodedHeader() -> String {
-        guard self.contains(where: { !$0.isASCII }) else { return self }
+        guard self.unicodeScalars.contains(where: Self.rfc2047RequiresEncoding) else { return self }
+        return rfc2047EncodedWords()
+    }
 
+    /// Encode the receiver as RFC 2047 encoded-word(s) unconditionally.
+    ///
+    /// Used by callers that apply their own trigger — a display name also has to
+    /// be encoded when it carries the `"` or `\` that would otherwise escape the
+    /// quoted-string around it, although both are ordinary text elsewhere.
+    func rfc2047EncodedWords() -> String {
         var words: [String] = []
         var chunk: [UInt8] = []
 
@@ -39,17 +76,53 @@ extension String {
             chunk.removeAll(keepingCapacity: true)
         }
 
-        for character in self {
-            let bytes = Array(String(character).utf8)
+        func append(_ bytes: [UInt8]) {
             if !chunk.isEmpty, chunk.count + bytes.count > Self.rfc2047MaxBytesPerWord {
                 flush()
             }
             chunk.append(contentsOf: bytes)
+        }
+
+        // Split between `Character`s — extended grapheme clusters — so a word
+        // boundary never lands in the middle of one. That is the right unit
+        // whenever a cluster can fit in a word at all, and it is what keeps the
+        // output of ordinary text byte-identical to the pre-existing behaviour.
+        //
+        // The one case it cannot handle is a cluster wider than
+        // `rfc2047MaxBytesPerWord` on its own: there is no boundary inside it to
+        // flush at, so it lands alone in an oversized word. "a" followed by 23
+        // combining marks is 47 UTF-8 bytes, giving a 12 + 4*ceil(47/3) =
+        // 76-octet word, over RFC 2047 §2's ceiling. Only there do we descend to
+        // Unicode scalars: a scalar is at most 4 bytes, so the chunks built from
+        // one never exceed 45 bytes and the widest word is
+        // 12 + 4*ceil(45/3) = 72 octets. Splitting between scalars still leaves
+        // every word independently valid UTF-8, which is the property the
+        // `!chunk.isEmpty` guard exists to protect; only the grapheme cluster
+        // itself is divided, and only because it cannot be carried whole.
+        for character in self {
+            let bytes = Array(String(character).utf8)
+            if bytes.count <= Self.rfc2047MaxBytesPerWord {
+                append(bytes)
+                continue
+            }
+            flush()
+            for scalar in character.unicodeScalars {
+                append(Array(String(scalar).utf8))
+            }
         }
         flush()
 
         // CRLF+SPACE between adjacent encoded-words: the linear whitespace is
         // dropped on decode (RFC 2047 §2), reassembling the original text.
         return words.joined(separator: "\r\n ")
+    }
+
+    /// Whether the receiver has to be RFC 2047-encoded to appear as the display
+    /// name of an address, i.e. it is not a valid field body literally *or* it
+    /// carries a character that would escape the surrounding quoted-string.
+    var rfc2047RequiresEncodingAsDisplayName: Bool {
+        unicodeScalars.contains { scalar in
+            Self.rfc2047RequiresEncoding(scalar) || scalar == "\"" || scalar == "\\"
+        }
     }
 }

--- a/Sources/SwiftMail/MIME/EMLParser+AddressAndDate.swift
+++ b/Sources/SwiftMail/MIME/EMLParser+AddressAndDate.swift
@@ -31,7 +31,10 @@ extension EMLParser {
                 case "," where !inQuotes && !inAngle:
                     let trimmed = current.trimmingCharacters(in: .whitespaces)
                     if !trimmed.isEmpty {
-                        addresses.append(decodeRFC2047(trimmed) ?? trimmed)
+                        // Keep the structured address in wire form. Decoding the
+                        // whole value can turn display-name text into address
+                        // syntax before the real addr-spec has been identified.
+                        addresses.append(trimmed)
                     }
                     current = ""
                 default:
@@ -41,7 +44,7 @@ extension EMLParser {
 
         let trimmed = current.trimmingCharacters(in: .whitespaces)
         if !trimmed.isEmpty {
-            addresses.append(decodeRFC2047(trimmed) ?? trimmed)
+            addresses.append(trimmed)
         }
 
         return addresses

--- a/Sources/SwiftMail/MIME/EMLParser+Headers.swift
+++ b/Sources/SwiftMail/MIME/EMLParser+Headers.swift
@@ -159,7 +159,10 @@ extension EMLParser {
     // MARK: - MessageInfo Construction
 
     static func buildMessageInfo(from headers: [String: String]) -> MessageInfo {
-        let from = headers["from"].flatMap { decodeRFC2047($0) } ?? headers["from"]
+        // Address fields remain structured wire values. Display names are
+        // decoded only after EmailAddress has isolated the real addr-spec.
+        let parsedFrom = parseAddressList(headers["from"])
+        let from = parsedFrom.isEmpty ? headers["from"] : parsedFrom.joined(separator: ", ")
         let subject = headers["subject"].flatMap { decodeRFC2047($0) } ?? headers["subject"]
         let messageId = headers["message-id"].flatMap { MessageID($0) }
 

--- a/Sources/SwiftMail/MIME/EMLParser+RFC2047.swift
+++ b/Sources/SwiftMail/MIME/EMLParser+RFC2047.swift
@@ -1,7 +1,5 @@
 // EMLParser+RFC2047.swift
-// RFC 2047 encoded word decoding plus the small String.Encoding charset map.
-
-import Foundation
+// RFC 2047 encoded-word decoding for parsed EML headers.
 
 extension EMLParser {
 
@@ -9,112 +7,6 @@ extension EMLParser {
 
     /// Decode RFC 2047 encoded words (=?charset?encoding?text?=).
     static func decodeRFC2047(_ input: String) -> String? {
-        let pattern = "=\\?([^?]+)\\?([BbQq])\\?([^?]*)\\?="
-
-        guard let regex = try? NSRegularExpression(pattern: pattern) else {
-            return input
-        }
-
-        let nsInput = input as NSString
-        let matches = regex.matches(in: input, range: NSRange(location: 0, length: nsInput.length))
-
-        if matches.isEmpty {
-            return input
-        }
-
-        var result = input
-        // Process matches in reverse to preserve indices
-        for match in matches.reversed() {
-            guard match.numberOfRanges >= 4 else { continue }
-
-            let fullMatch = nsInput.substring(with: match.range)
-            let charset = nsInput.substring(with: match.range(at: 1))
-            let encodingChar = nsInput.substring(with: match.range(at: 2)).uppercased()
-            let encodedText = nsInput.substring(with: match.range(at: 3))
-
-            let encoding = String.Encoding.fromCharsetName(charset) ?? .utf8
-
-            if let decoded = decodeEncodedWord(text: encodedText, encodingChar: encodingChar, encoding: encoding) {
-                result = result.replacingOccurrences(of: fullMatch, with: decoded)
-            }
-        }
-
-        return result
-    }
-
-    /// Decode a single encoded word body using Base64 or Quoted-Printable.
-    private static func decodeEncodedWord(text: String, encodingChar: String, encoding: String.Encoding) -> String? {
-        switch encodingChar {
-            case "B":
-                // Base64
-                if let data = Data(base64Encoded: text) {
-                    return String(data: data, encoding: encoding)
-                }
-                return nil
-            case "Q":
-                // Quoted-printable (underscore = space)
-                let qpString = text.replacingOccurrences(of: "_", with: " ")
-                return decodeQP(qpString, encoding: encoding)
-            default:
-                return nil
-        }
-    }
-
-    /// Decode a quoted-printable string with a specific encoding.
-    static func decodeQP(_ input: String, encoding: String.Encoding) -> String? {
-        var bytes: [UInt8] = []
-        var index = input.startIndex
-
-        while index < input.endIndex {
-            let char = input[index]
-            if char == "=" {
-                let next1 = input.index(index, offsetBy: 1, limitedBy: input.endIndex)
-                let next2 = next1.flatMap { input.index($0, offsetBy: 1, limitedBy: input.endIndex) }
-
-                if let firstHexIndex = next1, next2 != nil {
-                    // Decode two hex chars after "=" into a single byte.
-                    let hexStr = String(input[firstHexIndex]) + String(input[input.index(after: firstHexIndex)])
-                    if let byte = UInt8(hexStr, radix: 16) {
-                        bytes.append(byte)
-                        index = input.index(index, offsetBy: 3)
-                        continue
-                    }
-                }
-            }
-
-            // Regular character
-            for byte in String(char).utf8 {
-                bytes.append(byte)
-            }
-            index = input.index(after: index)
-        }
-
-        return String(data: Data(bytes), encoding: encoding)
-    }
-}
-
-// MARK: - String.Encoding helper
-
-extension String.Encoding {
-    /// Map a charset name to a String.Encoding.
-    static func fromCharsetName(_ name: String) -> String.Encoding? {
-        switch name.lowercased() {
-            case "utf-8", "utf8":
-                return .utf8
-            case "iso-8859-1", "latin1", "iso_8859-1":
-                return .isoLatin1
-            case "iso-8859-2", "latin2", "iso_8859-2":
-                return .isoLatin2
-            case "us-ascii", "ascii":
-                return .ascii
-            case "windows-1252", "cp1252":
-                return .windowsCP1252
-            case "windows-1250", "cp1250":
-                return .windowsCP1250
-            case "iso-8859-15", "latin9", "iso_8859-15":
-                return .isoLatin1 // Close enough
-            default:
-                return nil
-        }
+        input.decodeMIMEHeader()
     }
 }

--- a/Sources/SwiftMail/MIME/EMLSerializer.swift
+++ b/Sources/SwiftMail/MIME/EMLSerializer.swift
@@ -43,13 +43,12 @@ public struct EMLSerializer {
 
     /// Emit the RFC 822 header block (`From:`, `To:`, …) and then `MIME-Version`.
     private static func writeHeaders(_ header: MessageInfo, into output: inout String) {
-        appendHeaderIfPresent("From", header.from, into: &output)
-        appendListHeader("To", header.to, into: &output)
-        appendListHeader("Cc", header.cc, into: &output)
-        appendListHeader("Bcc", header.bcc, into: &output)
-        // Subject is free text — RFC 2047-encode it if non-ASCII. (From/To/Cc here
-        // are already-formatted address strings, so they are left as-is; per-name
-        // encoding of those would require re-parsing each address.)
+        appendHeaderIfPresent("From", header.from.map(headerSafeAddress), into: &output)
+        appendListHeader("To", header.to.map(headerSafeAddress), into: &output)
+        appendListHeader("Cc", header.cc.map(headerSafeAddress), into: &output)
+        appendListHeader("Bcc", header.bcc.map(headerSafeAddress), into: &output)
+        // Subject is free text; address display names were re-encoded above
+        // without treating their surrounding address syntax as unstructured text.
         appendHeaderIfPresent("Subject", header.subject?.rfc2047EncodedHeader(), into: &output)
         if let date = header.date {
             output += "Date: \(formatRFC2822Date(date))\r\n"
@@ -72,6 +71,19 @@ public struct EMLSerializer {
     private static func appendListHeader(_ name: String, _ values: [String], into output: inout String) {
         guard !values.isEmpty else { return }
         output += "\(name): \(values.joined(separator: ", "))\r\n"
+    }
+
+    /// Re-encode display names whenever a MessageInfo value is serialized.
+    /// Parsed EML keeps addresses in wire form, while callers may also provide a
+    /// decoded display name directly; both paths must produce safe field bytes.
+    private static func headerSafeAddress(_ value: String) -> String {
+        guard let parsed = EmailAddress(value) else {
+            return value.rfc2047EncodedHeader()
+        }
+        if parsed.name?.rfc2047RequiresEncodingAsDisplayName == true {
+            return parsed.headerString()
+        }
+        return value.rfc2047EncodedHeader()
     }
 
     /// Emit the body: empty placeholder, single-part inline, or multipart.

--- a/Tests/SwiftSMTPTests/RFC2047AddressHeaderTests.swift
+++ b/Tests/SwiftSMTPTests/RFC2047AddressHeaderTests.swift
@@ -1,0 +1,198 @@
+// RFC2047AddressHeaderTests.swift
+// An address formatted for a header — by `headerString()`, by `description`, or
+// through `Message(email:).emlData()` — must carry its display name in a form
+// the field body can actually hold, and must read back as the address it was
+// built from.
+
+import Foundation
+import Testing
+@testable import SwiftMail
+
+@Suite("RFC 2047 address header formatting", .serialized, .timeLimit(.minutes(1)))
+struct RFC2047AddressHeaderTests {
+
+    /// Display names a header field body cannot carry literally: a CRLF pair,
+    /// which *ends the field*; an embedded `"`, which closes the quoted-string
+    /// and lets the rest be read as further address syntax; a `\`, which a
+    /// conforming reader takes as a quoted-pair and drops; and ordinary
+    /// non-ASCII text, which a header field must not carry as raw 8-bit.
+    private static let unwritableNames = [
+        "Bob\r\nBcc: attacker@example.com",
+        #"Alice "The Boss" Smith"#,
+        #"Team\Ops"#,
+        "홍길동"
+    ]
+
+    /// Display names that are *literally* encoded-word-shaped — a user who typed
+    /// `=?…?=` as their own name, not a name the library encoded. They are plain
+    /// printable ASCII, so `headerString()` wraps them in a quoted-string rather
+    /// than encoding them, and a quoted-string always carries a LITERAL: RFC 2047
+    /// §5 forbids reading an encoded-word inside one. `init(_:)` must hand the
+    /// literal back verbatim; MIME-decoding it silently corrupts the name and —
+    /// for the third case — smuggles a CRLF the decode manufactures.
+    private static let quotedEncodedWordShapedLiterals = [
+        "=?UTF-8?B?SGVsbG8=?=",              // would decode to "Hello"
+        "=?ISO-8859-1?Q?Caf=E9?=",          // would decode to "Café"
+        "=?UTF-8?B?Qg0KQmNjOiBhQGIuY29t?="  // would decode to "B\r\nBcc: a@b.com"
+    ]
+
+    // MARK: - An encoded name is emitted bare
+
+    @Test("An encoded display name is emitted bare, never inside a quoted-string")
+    func encodedDisplayNameIsNeverQuoted() {
+        for name in Self.unwritableNames {
+            let header = EmailAddress(name: name, address: "bob@example.com").headerString()
+
+            #expect(header.hasPrefix("=?UTF-8?B?"), "not encoded: \(header)")
+            // RFC 2047 §5: an encoded-word MUST NOT appear inside a
+            // quoted-string. Wrapping one in quotes is not a cosmetic slip — a
+            // reader that honours the rule hands the literal `=?UTF-8?B?…?=`
+            // back to the user instead of the name.
+            #expect(!header.hasPrefix("\""), "encoded-word inside a quoted-string: \(header)")
+            #expect(!header.contains("\"=?"), "encoded-word inside a quoted-string: \(header)")
+            #expect(header.hasSuffix(" <bob@example.com>"))
+        }
+    }
+
+    @Test("description formats an address the same way a header field needs it")
+    func descriptionIsHeaderSafe() {
+        for name in Self.unwritableNames {
+            let address = EmailAddress(name: name, address: "bob@example.com")
+
+            #expect(address.description == address.headerString())
+            #expect(address.description.allSatisfy { $0.isASCII }, "8-bit in a header: \(address.description)")
+            #expect(!address.description.unicodeScalars.contains { $0 == "\r" || $0 == "\n" })
+        }
+    }
+
+    @Test("An address survives the round trip through its own string form")
+    func addressStringRoundTrips() {
+        let addresses = Self.unwritableNames.map { EmailAddress(name: $0, address: "bob@example.com") } + [
+            EmailAddress(name: "Smith, Alice", address: "alice@example.com"),
+            EmailAddress(name: "Alice", address: "alice@example.com"),
+            // A quoted encoded-word-shaped literal must round-trip too — the
+            // quoted branch must not decode it.
+            EmailAddress(name: "=?UTF-8?B?SGVsbG8=?=", address: "literal@example.com"),
+            EmailAddress(address: "plain@example.com")
+        ]
+
+        for address in addresses {
+            let restored = EmailAddress(address.description)
+            #expect(restored?.address == address.address, "address lost: \(address.description)")
+            #expect(restored?.name == address.name, "name lost: \(address.description)")
+        }
+    }
+
+    // MARK: - A quoted-string always carries a literal (RFC 2047 §5)
+
+    @Test("An encoded-word-shaped literal in a quoted display name is preserved, never decoded")
+    func quotedLiteralEncodedWordIsNotDecoded() {
+        for literal in Self.quotedEncodedWordShapedLiterals {
+            let address = EmailAddress(name: literal, address: "bob@example.com")
+
+            // A plain-ASCII special-char name is wrapped in a quoted-string, not
+            // encoded — so the literal is carried inside the quotes.
+            #expect(address.description.hasPrefix("\""), "expected a quoted-string: \(address.description)")
+
+            let restored = EmailAddress(address.description)
+            #expect(restored?.name == literal, "literal decoded or lost: \(String(describing: restored?.name))")
+            #expect(restored?.address == "bob@example.com")
+            // The third case decodes to a CRLF-bearing string; if the branch ever
+            // decoded again, the reconstructed name would carry that CRLF.
+            #expect(!(restored?.name?.unicodeScalars.contains { $0 == "\r" || $0 == "\n" } ?? false),
+                    "decode reintroduced a CRLF: \(String(describing: restored?.name))")
+        }
+
+        // Two-sided pin: a BARE encoded-word (the wire form of a non-ASCII name)
+        // MUST still decode — the quoted-literal rule must not disarm it.
+        let korean = EmailAddress(name: "홍길동", address: "bob@example.com")
+        #expect(!korean.description.hasPrefix("\""), "a non-ASCII name must be bare: \(korean.description)")
+        #expect(EmailAddress(korean.description)?.name == "홍길동")
+    }
+
+    // MARK: - Message(email:) → emlData()
+
+    @Test("A display name cannot forge a header field in the serialized EML")
+    func emlHeaderBlockCannotBeForged() throws {
+        let benign = try Self.headerFieldNames(senderNamed: "Bob")
+        #expect(benign.contains("From"))
+
+        for name in Self.unwritableNames {
+            let fields = try Self.headerFieldNames(senderNamed: name)
+            // A hostile display name changes the *value* of `From:` and nothing
+            // else: same fields, same order, still one `From:`.
+            #expect(fields == benign, "header block changed for \(name.debugDescription): \(fields)")
+            #expect(!fields.contains { $0.lowercased() == "bcc" })
+        }
+    }
+
+    @Test("The serialized From: value re-parses to exactly the address it was built from")
+    func emlFromValueReparsesToOneAddress() throws {
+        for name in Self.unwritableNames {
+            let fromFieldBody = try Self.fromFieldBody(senderNamed: name)
+            let value = try #require(fromFieldBody, "no From: line for \(name.debugDescription)")
+
+            // Exactly one addr-spec — a smuggled second address brings its own `@`.
+            #expect(value.filter { $0 == "@" }.count == 1, "more than one address in From: \(value)")
+            #expect(value.allSatisfy { $0.isASCII }, "8-bit in a header: \(value)")
+            #expect(!value.hasPrefix("\""), "name carried in a quoted-string: \(value)")
+
+            let parsed = try #require(EmailAddress(value), "unparsable From: \(value)")
+            #expect(parsed.address == "bob@example.com")
+            #expect(parsed.name == name, "name lost: \(String(describing: parsed.name))")
+        }
+    }
+
+    @Test("Email → Message → Email keeps a non-ASCII display name")
+    func conversionRoundTripKeepsTheName() throws {
+        let email = Email(
+            sender: EmailAddress(name: "홍길동", address: "hong@example.com"),
+            recipients: [EmailAddress(name: #"Kim "Chul" Soo"#, address: "kim@example.com")],
+            subject: "안녕하세요",
+            textBody: "body"
+        )
+
+        let restored = try Email(message: Message(email: email))
+
+        #expect(restored.sender.name == "홍길동")
+        #expect(restored.sender.address == "hong@example.com")
+        #expect(restored.recipients.first?.name == #"Kim "Chul" Soo"#)
+        #expect(restored.recipients.first?.address == "kim@example.com")
+    }
+
+    // MARK: - Helpers
+
+    private static func eml(senderNamed name: String) throws -> String {
+        let email = Email(
+            sender: EmailAddress(name: name, address: "bob@example.com"),
+            recipients: [EmailAddress(address: "you@example.com")],
+            subject: "Hello",
+            textBody: "body"
+        )
+        let data = try Message(email: email).emlData()
+        // Failable on purpose: a header field body has to be 7-bit ASCII, so
+        // anything that is not valid UTF-8 is a defect, not something to paper
+        // over with replacement characters.
+        return try #require(String(bytes: data, encoding: .utf8), "EML is not valid UTF-8")
+    }
+
+    /// The field names of the EML's header block, in order — every line up to
+    /// the blank line that ends it, minus folded continuations.
+    private static func headerFieldNames(senderNamed name: String) throws -> [String] {
+        try eml(senderNamed: name)
+            .components(separatedBy: "\r\n")
+            .prefix { !$0.isEmpty }
+            .compactMap { line in
+                guard !line.hasPrefix(" "), !line.hasPrefix("\t"),
+                      let colon = line.firstIndex(of: ":") else { return nil }
+                return String(line[..<colon])
+            }
+    }
+
+    private static func fromFieldBody(senderNamed name: String) throws -> String? {
+        try eml(senderNamed: name)
+            .components(separatedBy: "\r\n")
+            .first { $0.hasPrefix("From: ") }
+            .map { String($0.dropFirst("From: ".count)) }
+    }
+}

--- a/Tests/SwiftSMTPTests/RFC2047AddressRoundTripTests.swift
+++ b/Tests/SwiftSMTPTests/RFC2047AddressRoundTripTests.swift
@@ -9,6 +9,41 @@ import Testing
 @Suite("RFC 2047 address parse and serialization", .serialized, .timeLimit(.minutes(1)))
 struct RFC2047AddressRoundTripTests {
 
+    @Test("Quoted-pairs recover their literal display-name characters")
+    func quotedPairsRoundTripThroughEML() throws {
+        let cases = [
+            (#""Alice \"Boss\"" <alice@example.com>"#, #"Alice "Boss""#),
+            (#""Team\\Ops" <alice@example.com>"#, #"Team\Ops"#)
+        ]
+
+        for (from, expectedName) in cases {
+            let eml = "From: \(from)\r\nContent-Type: text/plain\r\n\r\nbody\r\n"
+            let parsed = try Message(emlData: Data(eml.utf8))
+            let firstEmail = try Email(message: parsed)
+            let reparsed = try Message(emlData: parsed.emlData())
+            let secondEmail = try Email(message: reparsed)
+
+            #expect(firstEmail.sender.name == expectedName)
+            #expect(secondEmail.sender.name == expectedName)
+            #expect(secondEmail.sender.address == "alice@example.com")
+        }
+    }
+
+    @Test("Trailing comments after an angle address remain convertible")
+    func trailingCFWSIsAccepted() throws {
+        let header = MessageInfo(
+            sequenceNumber: SequenceNumber(0),
+            from: "Alice <alice@example.com> (work)"
+        )
+        let restored = try Email(message: Message(header: header, parts: []))
+
+        #expect(restored.sender.name == "Alice")
+        #expect(restored.sender.address == "alice@example.com")
+        #expect(EmailAddress("Alice <alice@example.com> (outer (nested))") != nil)
+        #expect(EmailAddress("Alice <alice@example.com> (work > remote)") != nil)
+        #expect(EmailAddress("Alice <alice@example.com> arbitrary") == nil)
+    }
+
     @Test("A decoded display name cannot inject a field on a second serialization")
     func parsedMessageCannotInjectOnReserialization() throws {
         let name = "Bob\r\nBcc: attacker@example.com\r\nX-Ignore:"

--- a/Tests/SwiftSMTPTests/RFC2047AddressRoundTripTests.swift
+++ b/Tests/SwiftSMTPTests/RFC2047AddressRoundTripTests.swift
@@ -1,0 +1,128 @@
+// RFC2047AddressRoundTripTests.swift
+// Regression coverage for parsing and repeatedly serializing structured address
+// fields that contain encoded display names.
+
+import Foundation
+import Testing
+@testable import SwiftMail
+
+@Suite("RFC 2047 address parse and serialization", .serialized, .timeLimit(.minutes(1)))
+struct RFC2047AddressRoundTripTests {
+
+    @Test("A decoded display name cannot inject a field on a second serialization")
+    func parsedMessageCannotInjectOnReserialization() throws {
+        let name = "Bob\r\nBcc: attacker@example.com\r\nX-Ignore:"
+        let original = Self.email(senderName: name)
+        let firstData = try Message(email: original).emlData()
+        let parsed = try Message(emlData: firstData)
+        let secondData = try parsed.emlData()
+
+        let firstNames = Self.headerNames(in: firstData)
+        let secondNames = Self.headerNames(in: secondData)
+        #expect(firstNames.filter { $0 == "From" }.count == 1)
+        #expect(secondNames.filter { $0 == "From" }.count == 1)
+        #expect(!firstNames.contains("Bcc"))
+        #expect(!secondNames.contains("Bcc"))
+        #expect(!secondNames.contains("X-Ignore"))
+
+        let restored = try Email(message: try Message(emlData: secondData))
+        #expect(restored.sender.name == name)
+        #expect(restored.sender.address == "real@example.com")
+    }
+
+    @Test("Display-name angle brackets cannot replace the real sender")
+    func displayNameCannotReplaceAddrSpec() throws {
+        let name = "홍<evil@example.com>"
+        let original = Self.email(senderName: name)
+        let parsed = try Message(emlData: Message(email: original).emlData())
+        let restored = try Email(message: parsed)
+
+        #expect(restored.sender.name == name)
+        #expect(restored.sender.address == "real@example.com")
+    }
+
+    @Test("Long folded display names survive direct and EML round trips")
+    func longDisplayNamesRoundTrip() throws {
+        let name = String(repeating: "한", count: 16)
+        let address = EmailAddress(name: name, address: "long@example.com")
+        let direct = try #require(EmailAddress(address.description))
+
+        #expect(direct == address)
+
+        let original = Email(
+            sender: address,
+            recipients: [address],
+            ccRecipients: [address],
+            bccRecipients: [address],
+            subject: "Long name",
+            textBody: "body"
+        )
+        let parsed = try Message(emlData: Message(email: original).emlData())
+        let restored = try Email(message: parsed)
+
+        #expect(restored.sender == address)
+        #expect(restored.recipients == [address])
+        #expect(restored.ccRecipients == [address])
+        #expect(restored.bccRecipients == [address])
+    }
+
+    @Test("Whitespace between adjacent encoded-words is ignored after unfolding")
+    func adjacentEncodedWordWhitespaceIsIgnored() throws {
+        let name = String(repeating: "한", count: 16)
+        let words = name.rfc2047EncodedHeader().components(separatedBy: "\r\n ")
+        #expect(words.count > 1)
+
+        let eml = """
+        From: sender@example.com\r
+        Subject: \(words.joined(separator: "\r\n "))\r
+        Content-Type: text/plain\r
+        \r
+        body\r
+        """
+        let parsed = try Message(emlData: Data(eml.utf8))
+
+        #expect(parsed.subject == name)
+    }
+
+    @Test("Encoded-word substrings inside phrase atoms remain literal")
+    func partialEncodedWordTokenRemainsLiteral() throws {
+        let literals = [
+            "pre=?UTF-8?B?SGVsbG8=?=post",
+            "pre=?UTF-8?B?Qg0KQmNjOiBhQGIuY29t?=post"
+        ]
+
+        for literal in literals {
+            let value = "\(literal) <bob@example.com>"
+            let direct = try #require(EmailAddress(value))
+            #expect(direct.name == literal)
+            #expect(direct.address == "bob@example.com")
+
+            let eml = "From: \(value)\r\nContent-Type: text/plain\r\n\r\nbody\r\n"
+            let parsed = try Message(emlData: Data(eml.utf8))
+            let restored = try Email(message: parsed)
+            #expect(restored.sender.name == literal)
+            #expect(!restored.sender.name!.contains("\r"))
+            #expect(!restored.sender.name!.contains("\n"))
+        }
+    }
+
+    private static func email(senderName: String) -> Email {
+        Email(
+            sender: EmailAddress(name: senderName, address: "real@example.com"),
+            recipients: [EmailAddress(address: "you@example.com")],
+            subject: "Hello",
+            textBody: "body"
+        )
+    }
+
+    private static func headerNames(in data: Data) -> [String] {
+        guard let eml = String(data: data, encoding: .utf8) else { return [] }
+        return eml.components(separatedBy: "\r\n")
+            .prefix { !$0.isEmpty }
+            .compactMap { line in
+                guard !line.hasPrefix(" "), !line.hasPrefix("\t"),
+                      let colon = line.firstIndex(of: ":") else { return nil }
+                return String(line[..<colon])
+            }
+    }
+}

--- a/Tests/SwiftSMTPTests/RFC2047EncodeTests.swift
+++ b/Tests/SwiftSMTPTests/RFC2047EncodeTests.swift
@@ -6,7 +6,7 @@ import Foundation
 import Testing
 @testable import SwiftMail
 
-@Suite("RFC 2047 header encoding")
+@Suite("RFC 2047 header encoding", .serialized, .timeLimit(.minutes(1)))
 struct RFC2047EncodeTests {
 
     // MARK: - String.rfc2047EncodedHeader()
@@ -119,5 +119,205 @@ struct RFC2047EncodeTests {
             let value = String(subjectLine.dropFirst("Subject: ".count))
             #expect(value.decodeMIMEHeader() == "테스트 제목")
         }
+    }
+}
+
+/// Values that RFC 5322 §2.2 does not allow to appear literally in a header
+/// field body, and the RFC 2047 §2 75-octet ceiling. Kept in a second suite so
+/// neither type body grows past SwiftLint's `type_body_length` limit.
+@Suite("RFC 2047 header field body safety", .serialized, .timeLimit(.minutes(1)))
+struct RFC2047HeaderFieldBodyTests {
+
+    /// Every scalar a field body cannot carry literally: the C0 controls and
+    /// DEL. HTAB is excluded deliberately — it is WSP, which RFC 5322 §3.2.5
+    /// allows literally in an unstructured field body.
+    private static let forbiddenScalars: [Unicode.Scalar] =
+        ((0x00 as UInt32)...(0x1F as UInt32)).filter { $0 != 0x09 }.compactMap(Unicode.Scalar.init)
+            + [Unicode.Scalar(0x7F)!]
+
+    /// The exact words this encoder produced for the two values in
+    /// ``alreadyCorrectValuesFoldByteIdentically``. Both values are built from
+    /// grapheme clusters that fit inside the 45-byte per-word budget, so every
+    /// word they produced was already inside RFC 2047 §2's ceiling and none of
+    /// them had any reason to change.
+    private static let grinningWord =
+        "=?UTF-8?B?8J+YgPCfmIDwn5iA8J+YgPCfmIDwn5iA8J+YgPCfmIDwn5iA8J+YgA==?="
+    private static let thumbsUpWord = "=?UTF-8?B?8J+RjfCfj70=?="
+    private static let familyWord = "=?UTF-8?B?8J+RqOKAjfCfkanigI3wn5Gn4oCN8J+Rpg==?="
+
+    // MARK: - Trigger
+
+    @Test("Every C0 control and DEL is encoded and round-trips")
+    func c0AndDelAreEncoded() {
+        for scalar in Self.forbiddenScalars {
+            let value = "a\(String(scalar))b"
+            let encoded = value.rfc2047EncodedHeader()
+            let name = String(format: "U+%04X", scalar.value)
+
+            #expect(!encoded.unicodeScalars.contains(scalar), "\(name) survived literally")
+            #expect(encoded.hasPrefix("=?UTF-8?B?"), "\(name) was not encoded")
+            #expect(encoded.decodeMIMEHeader() == value, "\(name) did not round-trip")
+        }
+    }
+
+    @Test("Benign field bodies are returned byte-identical")
+    func benignValuesAreUnchanged() {
+        // HTAB is legal WSP and must not trigger encoding.
+        #expect("a b\tc".rfc2047EncodedHeader() == "a b\tc")
+        #expect("Re: Q3 report".rfc2047EncodedHeader() == "Re: Q3 report")
+        // `"` and `\` are ordinary printable text in an unstructured field body;
+        // only the quoted-string of a display name has to care about them.
+        #expect(#""quoted" and \back\"#.rfc2047EncodedHeader() == #""quoted" and \back\"#)
+    }
+
+    // MARK: - 75-octet ceiling
+
+    @Test("A grapheme cluster wider than one word cannot produce an oversized encoded-word")
+    func wideGraphemeClusterStaysWithinCeiling() {
+        // "a" followed by 23 combining acute accents is a single extended
+        // grapheme cluster of 47 UTF-8 bytes; flushing only between clusters
+        // emits it as one 12 + 4*ceil(47/3) = 76-octet word.
+        let value = "a" + String(repeating: "\u{0301}", count: 23)
+        let encoded = value.rfc2047EncodedHeader()
+        let words = encoded.components(separatedBy: "\r\n ")
+
+        #expect(words.count > 1, "expected the value to fold into multiple words")
+        for word in words {
+            #expect(word.utf8.count <= 75, "encoded-word is \(word.utf8.count) octets, over the 75 limit")
+            #expect(word.hasPrefix("=?UTF-8?B?") && word.hasSuffix("?="))
+        }
+        // Scalar-exact: splitting between scalars must not drop, reorder or
+        // re-normalize anything.
+        #expect(Array(encoded.decodeMIMEHeader().unicodeScalars) == Array(value.unicodeScalars))
+    }
+
+    @Test("An oversized cluster is split between scalars and bounded at 72 octets")
+    func oversizedClusterIsBoundedAtSeventyTwoOctets() {
+        // The same 47-byte cluster, held to the tighter bound the per-scalar
+        // fallback actually guarantees: a scalar is at most 4 bytes, so a chunk
+        // built out of scalars never exceeds the 45-byte budget and the widest
+        // word it can produce is 12 + 4*ceil(45/3) = 72 octets.
+        let value = "a" + String(repeating: "\u{0301}", count: 23)
+        let words = value.rfc2047EncodedHeader().components(separatedBy: "\r\n ")
+
+        #expect(words.count == 2)
+        for word in words {
+            #expect(word.utf8.count <= 72, "encoded-word is \(word.utf8.count) octets, over the 72 bound")
+        }
+    }
+
+    @Test("A value that already folded within the ceiling folds byte-identically")
+    func alreadyCorrectValuesFoldByteIdentically() {
+        // Ten grinning faces (4 bytes each) then one thumbs-up with a skin-tone
+        // modifier — a two-scalar, 8-byte cluster. Splitting on scalars puts the
+        // word boundary *inside* that cluster; splitting on clusters does not.
+        let thumbsUp = String(repeating: "😀", count: 10) + "👍🏽"
+        let expectedThumbsUp = [Self.grinningWord, Self.thumbsUpWord].joined(separator: "\r\n ")
+        #expect(thumbsUp.rfc2047EncodedHeader() == expectedThumbsUp)
+
+        // A ZWJ family sequence: one 25-byte cluster of seven scalars.
+        let family = String(repeating: "👨‍👩‍👧‍👦", count: 3)
+        let expectedFamily = [Self.familyWord, Self.familyWord, Self.familyWord].joined(separator: "\r\n ")
+        #expect(family.rfc2047EncodedHeader() == expectedFamily)
+
+        // Neither was ever over the ceiling, so neither had anything to fix.
+        for encoded in [expectedThumbsUp, expectedFamily] {
+            for word in encoded.components(separatedBy: "\r\n ") {
+                #expect(word.utf8.count <= 75, "encoded-word is \(word.utf8.count) octets, over the 75 limit")
+            }
+        }
+        #expect(expectedThumbsUp.decodeMIMEHeader() == thumbsUp)
+        #expect(expectedFamily.decodeMIMEHeader() == family)
+    }
+
+    // MARK: - constructContent integration
+
+    @Test("A CRLF-bearing subject cannot open a second header field")
+    func subjectCannotInjectAHeaderField() {
+        let injected = "Hi\r\nBcc: attacker@example.com"
+        let email = Email(
+            sender: EmailAddress(address: "me@example.com"),
+            recipients: [EmailAddress(address: "you@example.com")],
+            subject: injected,
+            textBody: "body"
+        )
+        let lines = email.constructContent().components(separatedBy: "\r\n")
+
+        #expect(lines.filter { $0.hasPrefix("Subject: ") }.count == 1)
+        #expect(!lines.contains { $0.lowercased().hasPrefix("bcc:") })
+
+        let subjectLine = lines.first { $0.hasPrefix("Subject: ") }
+        #expect(subjectLine != nil)
+        guard let subjectLine else { return }
+        // Nothing is dropped: the recipient still sees exactly what was written.
+        #expect(String(subjectLine.dropFirst("Subject: ".count)).decodeMIMEHeader() == injected)
+    }
+
+    @Test("A CRLF-bearing display name cannot open a second header field")
+    func displayNameCannotInjectAHeaderField() {
+        let injected = "Bob\r\nBcc: attacker@example.com"
+        let email = Email(
+            sender: EmailAddress(address: "me@example.com"),
+            recipients: [EmailAddress(name: injected, address: "bob@example.com")],
+            subject: "Hello",
+            textBody: "body"
+        )
+        let lines = email.constructContent().components(separatedBy: "\r\n")
+
+        #expect(lines.filter { $0.hasPrefix("To: ") }.count == 1)
+        #expect(!lines.contains { $0.lowercased().hasPrefix("bcc:") })
+
+        let toLine = lines.first { $0.hasPrefix("To: ") }
+        #expect(toLine != nil)
+        guard let toLine else { return }
+        let value = String(toLine.dropFirst("To: ".count))
+        #expect(value.hasSuffix(" <bob@example.com>"))
+        #expect(Self.recoveredDisplayName(from: value) == injected)
+    }
+
+    @Test("A display name containing a quote cannot escape the quoted-string")
+    func displayNameQuoteCannotEscapeTheQuotedString() {
+        let name = #"Alice "The Boss" Smith"#
+        let header = EmailAddress(name: name, address: "alice@example.com").headerString()
+
+        #expect(header.hasSuffix(" <alice@example.com>"))
+        #expect(Self.recoveredDisplayName(from: header) == name)
+    }
+
+    @Test("A display name containing a backslash keeps its literal text")
+    func displayNameBackslashKeepsItsLiteralText() {
+        let name = #"Team\Ops"#
+        let header = EmailAddress(name: name, address: "ops@example.com").headerString()
+
+        #expect(header.hasSuffix(" <ops@example.com>"))
+        #expect(Self.recoveredDisplayName(from: header) == name)
+    }
+
+    /// Recover the display name the way a *conforming* reader would: a
+    /// quoted-string is unescaped per RFC 5322 §3.2.4 (a `\` escapes the next
+    /// character), an unquoted phrase is taken as-is, and either result is then
+    /// RFC 2047-decoded. Deliberately independent of ``EmailAddress/init(_:)``,
+    /// which does not implement quoted-pairs and so would report a name that a
+    /// real recipient never sees.
+    private static func recoveredDisplayName(from header: String) -> String? {
+        guard let addressStart = header.lastIndex(of: "<") else { return nil }
+        let phrase = header[..<addressStart].trimmingCharacters(in: .whitespaces)
+        guard phrase.hasPrefix("\"") else { return phrase.decodeMIMEHeader() }
+
+        var recovered = ""
+        var isEscaped = false
+        for character in phrase.dropFirst() {
+            if isEscaped {
+                recovered.append(character)
+                isEscaped = false
+            } else if character == "\\" {
+                isEscaped = true
+            } else if character == "\"" {
+                return recovered.decodeMIMEHeader()
+            } else {
+                recovered.append(character)
+            }
+        }
+        return nil // unterminated quoted-string
     }
 }

--- a/Tests/SwiftSMTPTests/RFC2047EncodeTests.swift
+++ b/Tests/SwiftSMTPTests/RFC2047EncodeTests.swift
@@ -170,6 +170,40 @@ struct RFC2047HeaderFieldBodyTests {
         #expect(#""quoted" and \back\"#.rfc2047EncodedHeader() == #""quoted" and \back\"#)
     }
 
+    @Test("Legal folding whitespace is returned byte-identical")
+    func legalFoldingWhitespaceIsUnchanged() {
+        let firstWord = "=?UTF-8?B?8J+YgPCfmIDwn5iA8J+YgPCfmIA=?="
+        let secondWord = "=?UTF-8?B?8J+YgA==?="
+
+        let foldedValues = [
+            firstWord + "\r\n " + secondWord,
+            firstWord + "\r\n\t" + secondWord,
+            firstWord + " \t\r\n   \t" + secondWord,
+            firstWord + "\r\n " + secondWord + "\r\n " + firstWord
+        ]
+        for folded in foldedValues {
+            #expect(folded.rfc2047EncodedHeader() == folded)
+        }
+    }
+
+    @Test("Only complete folding whitespace may contain a literal line break")
+    func malformedFoldingWhitespaceIsEncoded() {
+        for value in [
+            "Hi\rthere",
+            "Hi\n there",
+            "Hi\r\nBcc: example@example.com",
+            "Hi\r\n",
+            "Hi\r\n ",
+            "Hi\r\n \r\n next",
+            "Hi\r\n okay\n Bcc: example@example.com"
+        ] {
+            let encoded = value.rfc2047EncodedHeader()
+            #expect(!encoded.contains("\r\nBcc:"))
+            #expect(encoded.hasPrefix("=?UTF-8?B?"))
+            #expect(encoded.decodeMIMEHeader() == value)
+        }
+    }
+
     // MARK: - 75-octet ceiling
 
     @Test("A grapheme cluster wider than one word cannot produce an oversized encoded-word")

--- a/Tests/SwiftSMTPTests/RFC2047EncodeTests.swift
+++ b/Tests/SwiftSMTPTests/RFC2047EncodeTests.swift
@@ -179,7 +179,9 @@ struct RFC2047HeaderFieldBodyTests {
             firstWord + "\r\n " + secondWord,
             firstWord + "\r\n\t" + secondWord,
             firstWord + " \t\r\n   \t" + secondWord,
-            firstWord + "\r\n " + secondWord + "\r\n " + firstWord
+            firstWord + "\r\n " + secondWord + "\r\n " + firstWord,
+            "head\r\n !tail",
+            "head\r\n ~tail"
         ]
         for folded in foldedValues {
             #expect(folded.rfc2047EncodedHeader() == folded)


### PR DESCRIPTION
Supersedes #215, keeping its original commits and adding the fixes requested there.