### PR TITLE
Surface BADCHARSET from SEARCH as a typed error and keep response codes in search failures

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Handler/ExtendedSearchHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/ExtendedSearchHandler.swift
@@ -49,10 +49,14 @@ final class ExtendedSearchHandler<T: MessageIdentifier>:
     private func failOnNegativeStatus(_ status: UntaggedStatus) -> Bool {
         switch status {
             case .bad(let text):
-                failWithError(IMAPError.commandFailed("Extended search failed: BAD \(text.text)"))
+                failWithError(
+                    IMAPError.searchRejected(operation: "Extended search", status: "BAD", responseText: text)
+                )
                 return true
             case .no(let text):
-                failWithError(IMAPError.commandFailed("Extended search failed: NO \(text.text)"))
+                failWithError(
+                    IMAPError.searchRejected(operation: "Extended search", status: "NO", responseText: text)
+                )
                 return true
             default:
                 return false
@@ -134,9 +138,13 @@ final class ExtendedSearchHandler<T: MessageIdentifier>:
     override func handleTaggedErrorResponse(_ response: TaggedResponse) {
         switch response.state {
             case .bad(let responseText):
-                failWithError(IMAPError.commandFailed("Extended search failed: BAD \(responseText.text)"))
+                failWithError(
+                    IMAPError.searchRejected(operation: "Extended search", status: "BAD", responseText: responseText)
+                )
             case .no(let responseText):
-                failWithError(IMAPError.commandFailed("Extended search failed: NO \(responseText.text)"))
+                failWithError(
+                    IMAPError.searchRejected(operation: "Extended search", status: "NO", responseText: responseText)
+                )
             default:
                 failWithError(IMAPError.commandFailed("Extended search failed: \(String(describing: response.state))"))
         }

--- a/Sources/SwiftMail/IMAP/IMAP/Handler/SearchHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/SearchHandler.swift
@@ -30,11 +30,15 @@ final class SearchHandler<T: MessageIdentifier>:
             switch status {
                 case .bad(let responseText):
                     // Handle BAD response (protocol error)
-                    failWithError(IMAPError.commandFailed("Search failed: BAD \(responseText.text)"))
+                    failWithError(
+                        IMAPError.searchRejected(operation: "Search", status: "BAD", responseText: responseText)
+                    )
                     return true
                 case .no(let responseText):
                     // Handle NO response (operational error)
-                    failWithError(IMAPError.commandFailed("Search failed: NO \(responseText.text)"))
+                    failWithError(
+                        IMAPError.searchRejected(operation: "Search", status: "NO", responseText: responseText)
+                    )
                     return true
                 default:
                     // Other status responses are handled by the base class
@@ -78,9 +82,13 @@ final class SearchHandler<T: MessageIdentifier>:
         // If the search command fails, report the error with more specific information
         switch response.state {
             case .bad(let responseText):
-                failWithError(IMAPError.commandFailed("Search failed: BAD \(responseText.text)"))
+                failWithError(
+                    IMAPError.searchRejected(operation: "Search", status: "BAD", responseText: responseText)
+                )
             case .no(let responseText):
-                failWithError(IMAPError.commandFailed("Search failed: NO \(responseText.text)"))
+                failWithError(
+                    IMAPError.searchRejected(operation: "Search", status: "NO", responseText: responseText)
+                )
             default:
                 failWithError(IMAPError.commandFailed("Search failed: \(String(describing: response.state))"))
         }

--- a/Sources/SwiftMail/IMAP/IMAPError.swift
+++ b/Sources/SwiftMail/IMAP/IMAPError.swift
@@ -204,7 +204,8 @@ extension IMAPError: LocalizedError {
             case .malformedCopyUIDAfterTaggedOK:
                 return "Do not retry. The command completed; refresh the affected mailboxes before continuing."
             case .searchCharsetNotSupported:
-                return "Retry with a charset the server supports, or limit the search text to US-ASCII."
+                return "Retry with a charset the server supports: US-ASCII-only search text for SEARCH, "
+                    + "or a supported sortCharset for SORT."
             default:
                 return "Check the error details and try again."
         }
@@ -216,7 +217,14 @@ extension IMAPError {
     /// response carries that code, otherwise `commandFailed` with the response code kept in wire
     /// form, so `[NONEXISTENT]`, `[THROTTLED]` and the like stay readable in the message.
     static func searchRejected(operation: String, status: String, responseText: ResponseText) -> IMAPError {
-        let reason = "\(operation) failed: \(status) \(responseText.debugDescription)"
+        // Rendered by hand rather than through ResponseText's description: NIO accepts a NO or
+        // BAD with no text (iCloud, Oracle) and the description substitutes a placeholder space,
+        // which would turn the established "NO " wording of a code-less rejection into "NO  ".
+        var reason = "\(operation) failed: \(status)"
+        if let code = responseText.code {
+            reason += " [\(code.debugDescription)]"
+        }
+        reason += " \(responseText.text)"
         if case .badCharset(let supportedCharsets)? = responseText.code {
             return .searchCharsetNotSupported(supportedCharsets: supportedCharsets, reason: reason)
         }

--- a/Sources/SwiftMail/IMAP/IMAPError.swift
+++ b/Sources/SwiftMail/IMAP/IMAPError.swift
@@ -2,6 +2,7 @@
 // Custom IMAP errors
 
 import Foundation
+import NIOIMAPCore
 
 /// Errors that can occur during IMAP operations
 public enum IMAPError: Error {
@@ -15,6 +16,10 @@ public enum IMAPError: Error {
     case invalidArgument(String)
     case emptyIdentifierSet
     case commandFailed(String)
+    /// SEARCH, UID SEARCH, or SORT was answered `NO [BADCHARSET ...]` (RFC 3501 §7.1, RFC 9051 §7.1):
+    /// the server does not support the CHARSET the command carried. `supportedCharsets` is the
+    /// server's optional list of charsets it does accept; empty when it named none.
+    case searchCharsetNotSupported(supportedCharsets: [String], reason: String)
     case createFailed(String)
     case deleteFailed(String)
     case renameFailed(String)
@@ -67,6 +72,8 @@ extension IMAPError: CustomStringConvertible {
                 return "Empty identifier set provided"
             case .commandFailed(let reason):
                 return "Command failed: \(reason)"
+            case .searchCharsetNotSupported(_, let reason):
+                return "Search charset not supported: \(reason)"
             case .createFailed(let reason):
                 return "Create mailbox failed: \(reason)"
             case .deleteFailed(let reason):
@@ -129,6 +136,12 @@ extension IMAPError: LocalizedError {
                 return "An empty set of message identifiers was provided"
             case .commandFailed(let reason):
                 return "The IMAP command failed to execute: \(reason)"
+            case .searchCharsetNotSupported(let supportedCharsets, _):
+                if supportedCharsets.isEmpty {
+                    return "The server does not support the charset the search used"
+                }
+                return "The server does not support the charset the search used; "
+                    + "it supports \(supportedCharsets.joined(separator: ", "))"
             case .createFailed(let reason):
                 return "Failed to create mailbox: \(reason)"
             case .deleteFailed(let reason):
@@ -190,6 +203,8 @@ extension IMAPError: LocalizedError {
                 return "Do not retry. Refresh both mailboxes and reconcile their current state first."
             case .malformedCopyUIDAfterTaggedOK:
                 return "Do not retry. The command completed; refresh the affected mailboxes before continuing."
+            case .searchCharsetNotSupported:
+                return "Retry with a charset the server supports, or limit the search text to US-ASCII."
             default:
                 return "Check the error details and try again."
         }
@@ -197,6 +212,17 @@ extension IMAPError: LocalizedError {
 }
 
 extension IMAPError {
+    /// The error for a rejected SEARCH, UID SEARCH, or SORT: the typed BADCHARSET case when the
+    /// response carries that code, otherwise `commandFailed` with the response code kept in wire
+    /// form, so `[NONEXISTENT]`, `[THROTTLED]` and the like stay readable in the message.
+    static func searchRejected(operation: String, status: String, responseText: ResponseText) -> IMAPError {
+        let reason = "\(operation) failed: \(status) \(responseText.debugDescription)"
+        if case .badCharset(let supportedCharsets)? = responseText.code {
+            return .searchCharsetNotSupported(supportedCharsets: supportedCharsets, reason: reason)
+        }
+        return .commandFailed(reason)
+    }
+
     static func moveFallbackFailed(after copyUID: CopyUID?, underlying error: Error) -> IMAPError {
         let reason = "COPY completed before fallback failed: \(error)"
         if let copyUID {

--- a/Tests/SwiftIMAPTests/SearchBadCharsetTests.swift
+++ b/Tests/SwiftIMAPTests/SearchBadCharsetTests.swift
@@ -1,0 +1,150 @@
+import Foundation
+import NIO
+import NIOEmbedded
+@preconcurrency import NIOIMAP
+@preconcurrency import NIOIMAPCore
+import Testing
+@testable import SwiftMail
+
+private typealias UID = SwiftMail.UID
+
+/// RFC 3501 §7.1 lets a server refuse the CHARSET a SEARCH carried with `NO [BADCHARSET ...]`,
+/// optionally listing the charsets it does support; Exchange Online answers every
+/// `CHARSET UTF-8` search that way. Both search handlers surface it as a typed error and keep
+/// every other response code readable in the failure text instead of dropping it.
+@Suite(.serialized, .timeLimit(.minutes(1)))
+struct SearchBadCharsetTests {
+    @Test
+    func extendedSearchSurfacesBadCharsetWithTheServersList() async throws {
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
+        let promise = channel.eventLoop.makePromise(of: ExtendedSearchResult<UID>.self)
+        try await channel.pipeline.addHandler(ExtendedSearchHandler<UID>(commandTag: "B001", promise: promise))
+        try await Self.send(Self.extendedSearch(tag: "B001"), on: channel)
+        try await Self.respond("B001 NO [BADCHARSET (US-ASCII)] The specified charset is not supported.", on: channel)
+
+        guard case .searchCharsetNotSupported(let supportedCharsets, let reason)? =
+            await Self.failure(of: promise.futureResult) else {
+            Issue.record("Expected searchCharsetNotSupported")
+            return
+        }
+        #expect(supportedCharsets == ["US-ASCII"])
+        #expect(reason == "Extended search failed: NO [BADCHARSET (US-ASCII)] The specified charset is not supported.")
+    }
+
+    @Test
+    func plainSearchSurfacesBadCharsetWithoutAList() async throws {
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
+        let promise = channel.eventLoop.makePromise(of: MessageIdentifierSet<UID>.self)
+        try await channel.pipeline.addHandler(SearchHandler<UID>(commandTag: "B002", promise: promise))
+        try await Self.send(Self.plainSearch(tag: "B002"), on: channel)
+        try await Self.respond("B002 NO [BADCHARSET] Unsupported charset", on: channel)
+
+        guard case .searchCharsetNotSupported(let supportedCharsets, let reason)? =
+            await Self.failure(of: promise.futureResult) else {
+            Issue.record("Expected searchCharsetNotSupported")
+            return
+        }
+        #expect(supportedCharsets.isEmpty)
+        #expect(reason == "Search failed: NO [BADCHARSET] Unsupported charset")
+    }
+
+    @Test
+    func untaggedBadCharsetFailsTheExtendedSearchBeforeTheTaggedLine() async throws {
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
+        let promise = channel.eventLoop.makePromise(of: ExtendedSearchResult<UID>.self)
+        try await channel.pipeline.addHandler(ExtendedSearchHandler<UID>(commandTag: "B003", promise: promise))
+        try await Self.send(Self.extendedSearch(tag: "B003"), on: channel)
+        try await Self.respond("* NO [BADCHARSET (US-ASCII UTF-16)] Charset not supported", on: channel)
+
+        guard case .searchCharsetNotSupported(let supportedCharsets, let reason)? =
+            await Self.failure(of: promise.futureResult) else {
+            Issue.record("Expected searchCharsetNotSupported")
+            return
+        }
+        #expect(supportedCharsets == ["US-ASCII", "UTF-16"])
+        #expect(reason == "Extended search failed: NO [BADCHARSET (US-ASCII UTF-16)] Charset not supported")
+    }
+
+    @Test
+    func otherResponseCodesStayReadableInTheFailureText() async throws {
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
+        let promise = channel.eventLoop.makePromise(of: ExtendedSearchResult<UID>.self)
+        try await channel.pipeline.addHandler(ExtendedSearchHandler<UID>(commandTag: "B004", promise: promise))
+        try await Self.send(Self.extendedSearch(tag: "B004"), on: channel)
+        try await Self.respond("B004 NO [NONEXISTENT] Unknown Mailbox: Foo (Failure)", on: channel)
+
+        guard case .commandFailed(let reason)? = await Self.failure(of: promise.futureResult) else {
+            Issue.record("Expected commandFailed")
+            return
+        }
+        #expect(reason == "Extended search failed: NO [NONEXISTENT] Unknown Mailbox: Foo (Failure)")
+    }
+
+    @Test
+    func rejectionsWithoutAResponseCodeKeepTheirWording() async throws {
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
+        let promise = channel.eventLoop.makePromise(of: MessageIdentifierSet<UID>.self)
+        try await channel.pipeline.addHandler(SearchHandler<UID>(commandTag: "B005", promise: promise))
+        try await Self.send(Self.plainSearch(tag: "B005"), on: channel)
+        try await Self.respond("B005 BAD Could not parse command", on: channel)
+
+        guard case .commandFailed(let reason)? = await Self.failure(of: promise.futureResult) else {
+            Issue.record("Expected commandFailed")
+            return
+        }
+        #expect(reason == "Search failed: BAD Could not parse command")
+    }
+
+    @Test
+    func descriptionsNameTheCharsetsTheServerListed() {
+        let listed = IMAPError.searchCharsetNotSupported(supportedCharsets: ["US-ASCII"], reason: "reason")
+        let unlisted = IMAPError.searchCharsetNotSupported(supportedCharsets: [], reason: "reason")
+
+        #expect(listed.description == "Search charset not supported: reason")
+        #expect(
+            listed.failureReason
+                == "The server does not support the charset the search used; it supports US-ASCII"
+        )
+        #expect(unlisted.failureReason == "The server does not support the charset the search used")
+        #expect(
+            listed.recoverySuggestion
+                == "Retry with a charset the server supports, or limit the search text to US-ASCII."
+        )
+    }
+
+    // MARK: - Helpers
+
+    private static func extendedSearch(tag: String) -> NIOIMAPCore.TaggedCommand {
+        ExtendedSearchCommand<UID>(criteria: [.subject("Morning brief")], useEsearch: true)
+            .toTaggedCommand(tag: tag)
+    }
+
+    private static func plainSearch(tag: String) -> NIOIMAPCore.TaggedCommand {
+        SearchCommand<UID>(criteria: [.text("invoice")]).toTaggedCommand(tag: tag)
+    }
+
+    private static func send(_ tagged: NIOIMAPCore.TaggedCommand, on channel: NIOAsyncTestingChannel) async throws {
+        let wrapped = IMAPClientHandler.OutboundIn.part(NIOIMAPCore.CommandStreamPart.tagged(tagged))
+        try await channel.writeAndFlush(wrapped)
+        _ = try await channel.readOutbound(as: ByteBuffer.self)
+    }
+
+    private static func respond(_ line: String, on channel: NIOAsyncTestingChannel) async throws {
+        var buffer = channel.allocator.buffer(capacity: line.utf8.count + 2)
+        buffer.writeString(line + "\r\n")
+        try await channel.writeInbound(buffer)
+    }
+
+    private static func failure<T>(of future: EventLoopFuture<T>) async -> IMAPError? {
+        do {
+            _ = try await future.get()
+            Issue.record("Expected the search to fail")
+            return nil
+        } catch let error as IMAPError {
+            return error
+        } catch {
+            Issue.record("Unexpected error: \(error)")
+            return nil
+        }
+    }
+}

--- a/Tests/SwiftIMAPTests/SearchBadCharsetTests.swift
+++ b/Tests/SwiftIMAPTests/SearchBadCharsetTests.swift
@@ -108,8 +108,37 @@ struct SearchBadCharsetTests {
         #expect(unlisted.failureReason == "The server does not support the charset the search used")
         #expect(
             listed.recoverySuggestion
-                == "Retry with a charset the server supports, or limit the search text to US-ASCII."
+                == "Retry with a charset the server supports: US-ASCII-only search text for SEARCH, "
+                + "or a supported sortCharset for SORT."
         )
+    }
+
+    @Test
+    func rejectionsWithoutTextKeepTheirWording() async throws {
+        let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
+        let promise = channel.eventLoop.makePromise(of: MessageIdentifierSet<UID>.self)
+        try await channel.pipeline.addHandler(SearchHandler<UID>(commandTag: "B006", promise: promise))
+        try await Self.send(Self.plainSearch(tag: "B006"), on: channel)
+        try await Self.respond("B006 NO", on: channel)
+
+        guard case .commandFailed(let reason)? = await Self.failure(of: promise.futureResult) else {
+            Issue.record("Expected commandFailed")
+            return
+        }
+        #expect(reason == "Search failed: NO ")
+    }
+
+    @Test
+    func badCharsetWithoutTextCarriesTheCodeAlone() {
+        let responseText = NIOIMAPCore.ResponseText(code: .badCharset(["US-ASCII"]), text: "")
+        let error = IMAPError.searchRejected(operation: "Extended search", status: "NO", responseText: responseText)
+
+        guard case .searchCharsetNotSupported(let supportedCharsets, let reason) = error else {
+            Issue.record("Expected searchCharsetNotSupported")
+            return
+        }
+        #expect(supportedCharsets == ["US-ASCII"])
+        #expect(reason == "Extended search failed: NO [BADCHARSET (US-ASCII)] ")
     }
 
     // MARK: - Helpers


### PR DESCRIPTION
## Summary

Both search handlers dropped the response code of a NO/BAD and reported only its text. Two things were lost:

- `NO [BADCHARSET (US-ASCII)] The specified charset is not supported.` is how Exchange Online answers every `SEARCH ... CHARSET UTF-8`, which #222 now sends for non-ASCII criteria. RFC 3501 §7.1 (and RFC 9051 §7.1) define BADCHARSET for exactly this, with an optional list of the charsets the server does support. Callers saw a generic `commandFailed` and could not tell "this server cannot search this text" from any other failure.
- Every other code (`[NONEXISTENT]`, `[THROTTLED]`, `[LIMIT]`, …) disappeared from the message.

## Changes

- `IMAPError.searchCharsetNotSupported(supportedCharsets:reason:)`, thrown by `SearchHandler` and `ExtendedSearchHandler` when the rejection carries `[BADCHARSET ...]`. The list is the server's; empty when it named none. Description, failure reason, and recovery suggestion follow the existing cases.
- `IMAPError.searchRejected(operation:status:responseText:)` builds the error for both handlers, replacing eight hand-formatted strings. Any other rejection keeps its message shape (`Extended search failed: NO ...`) with the response code rendered in wire form through NIO's `ResponseText` description, so a rejection without a code is worded exactly as before.

No retry is attempted here: a raw non-ASCII literal without CHARSET is what Gmail rejects (#222), so the right follow-up on a BADCHARSET is the caller's to decide, and this PR gives it the information to do so.

## Tests

`SearchBadCharsetTests` (6) drive both handlers through the IMAP client parser with the wire lines: BADCHARSET with a list, without a list, untagged before the tagged line, another code (`[NONEXISTENT]`) kept in the text, a code-less `BAD Could not parse command` worded as before, and the description strings. Full suite: 523 tests pass. `swiftlint lint --strict` is clean.

## Context

Seen live on 2026-09-07 from Kestrel Mail against `outlook.office365.com`: the first two Outlook context searches with a non-ASCII subject after repinning to #224 failed this way.
