### PR TITLE
SMTP: surface the server's reply when login() fails

### DIFF
--- a/Sources/SwiftMail/SMTP/SMTPServer+Authentication.swift
+++ b/Sources/SwiftMail/SMTP/SMTPServer+Authentication.swift
@@ -35,6 +35,11 @@ extension SMTPServer {
         holding permit: SMTPOperationGate.Permit
     ) async throws {
 
+        // Each attempt's AuthResult already carries the server's reply in
+        // `errorMessage`; collect them so the caller can tell a bad password from a
+        // disabled account or a provider demanding an app-specific password.
+        var failures: [String] = []
+
         // Check if we have PLAIN auth support
         if capabilities.contains("AUTH PLAIN") {
             let plainCommand = PlainAuthCommand(username: username, password: password)
@@ -43,6 +48,9 @@ extension SMTPServer {
             // If successful, return success
             if result.success {
                 return
+            }
+            if let message = result.errorMessage {
+                failures.append("PLAIN: \(message)")
             }
         }
 
@@ -55,9 +63,16 @@ extension SMTPServer {
             if result.success {
                 return
             }
+            if let message = result.errorMessage {
+                failures.append("LOGIN: \(message)")
+            }
         }
 
-        // If we get here, authentication failed
+        // If we get here, authentication failed. Report what the server said when it
+        // said anything, matching what authenticateXOAUTH2 already does.
+        guard failures.isEmpty else {
+            throw SMTPError.authenticationFailed(failures.joined(separator: "; "))
+        }
         throw SMTPError.authenticationFailed("Authentication failed with all available methods")
     }
 


### PR DESCRIPTION
## What

`SMTPServer.login()` discards the server's reply when authentication fails.

Both `PlainAuthCommand` and `LoginAuthCommand` return an `AuthResult` that already
carries the server's response text in `errorMessage`, but `login()` ignores it and
throws a fixed string:

```swift
throw SMTPError.authenticationFailed("Authentication failed with all available methods")
```

## Why it matters

The caller cannot distinguish a mistyped password from a disabled account, an
account that requires an app-specific password, or a provider that has blocked
basic authentication entirely. Those need different actions from the user, and the
server already says which one it is.

`authenticateXOAUTH2` in the same file does surface it
(`result.errorMessage ?? "XOAUTH2 authentication failed"`), so this is an
inconsistency rather than a deliberate design.

## Change

Collect each attempted mechanism's reply and report them, falling back to the
previous wording when the server said nothing — for example when no supported
mechanism was advertised. No API change, no behaviour change on success.

## Verified

Against live servers with deliberately wrong credentials:

| Server | Before | After |
|---|---|---|
| smtp.gmail.com:587 | `Authentication failed with all available methods` | `PLAIN: 535-5.7.8 Username and Password not accepted. For more information, go to` |
| smtp.yandex.ru:465 | same | `PLAIN: 535 5.7.8 Error: authentication failed: Invalid user or password!; LOGIN: …` |
| smtp.mail.ru:465 | same | `PLAIN: 535 5.7.0 … Application password is REQUIRED; LOGIN: …` |

The Mail.ru case is the clearest: the server explains exactly what the user has to
do, and that explanation was previously thrown away.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
