### PR TITLE
Expose Reply-To in MessageInfo metadata

### DIFF
--- a/Sources/SwiftMail/IMAP/IMAP/Handler/FetchMessageInfoHandler.swift
+++ b/Sources/SwiftMail/IMAP/IMAP/Handler/FetchMessageInfoHandler.swift
@@ -151,6 +151,7 @@ final class FetchMessageInfoHandler: BaseIMAPCommandHandler<[MessageInfo]>, IMAP
         let parsed = EMLParser.buildMessageInfo(from: fields)
         if header.subject == nil { header.subject = parsed.subject }
         if header.from == nil { header.from = parsed.from }
+        if header.replyTo.isEmpty { header.replyTo = parsed.replyTo }
         if header.to.isEmpty { header.to = parsed.to }
         if header.cc.isEmpty { header.cc = parsed.cc }
         if header.bcc.isEmpty { header.bcc = parsed.bcc }
@@ -237,6 +238,7 @@ final class FetchMessageInfoHandler: BaseIMAPCommandHandler<[MessageInfo]>, IMAP
         if !envelope.from.isEmpty {
             header.from = formatAddress(envelope.from[0])
         }
+        header.replyTo = envelope.reply.map { formatAddress($0) }
         header.to = envelope.to.map { formatAddress($0) }
         header.cc = envelope.cc.map { formatAddress($0) }
         header.bcc = envelope.bcc.map { formatAddress($0) }

--- a/Sources/SwiftMail/IMAP/Models/FetchMessageInfoOptions.swift
+++ b/Sources/SwiftMail/IMAP/Models/FetchMessageInfoOptions.swift
@@ -16,7 +16,7 @@ public struct FetchMessageInfoOptions: OptionSet, Sendable {
         self.rawValue = rawValue
     }
 
-    /// Request `ENVELOPE` (subject, from/to/cc/bcc, date, Message-ID, In-Reply-To).
+    /// Request `ENVELOPE` (subject, from/reply-to/to/cc/bcc, date, Message-ID, In-Reply-To).
     public static let envelope      = FetchMessageInfoOptions(rawValue: 1 << 0)
 
     /// Request `INTERNALDATE` (server-side delivery timestamp).

--- a/Sources/SwiftMail/IMAP/Models/MessageInfo.swift
+++ b/Sources/SwiftMail/IMAP/Models/MessageInfo.swift
@@ -17,6 +17,9 @@ public struct MessageInfo: Codable, Sendable {
     /// The sender of the message
     public var from: String?
 
+    /// The addresses to which replies should be sent
+    public var replyTo: [String] = []
+
     /// The recipients of the message
     public var to: [String] = []
 
@@ -62,6 +65,7 @@ public struct MessageInfo: Codable, Sendable {
         case uid
         case subject
         case from
+        case replyTo
         case to
         case cc
         case bcc
@@ -83,6 +87,7 @@ public struct MessageInfo: Codable, Sendable {
     ///   - uid: The UID of the message (if available)
     ///   - subject: The subject of the message
     ///   - from: The sender of the message
+    ///   - replyTo: The addresses to which replies should be sent
     ///   - to: The recipients of the message
     ///   - cc: The CC recipients of the message
     ///   - date: The date of the message (envelope Date: header)
@@ -98,6 +103,7 @@ public struct MessageInfo: Codable, Sendable {
         uid: SwiftMail.UID? = nil,
         subject: String? = nil,
         from: String? = nil,
+        replyTo: [String] = [],
         to: [String] = [],
         cc: [String] = [],
         bcc: [String] = [],
@@ -116,6 +122,7 @@ public struct MessageInfo: Codable, Sendable {
         self.uid = uid
         self.subject = subject
         self.from = from
+        self.replyTo = replyTo
         self.to = to
         self.cc = cc
         self.bcc = bcc
@@ -141,6 +148,7 @@ public extension MessageInfo {
             uid: try container.decodeIfPresent(UID.self, forKey: .uid),
             subject: try container.decodeIfPresent(String.self, forKey: .subject),
             from: try container.decodeIfPresent(String.self, forKey: .from),
+            replyTo: try container.decodeIfPresent([String].self, forKey: .replyTo) ?? [],
             to: try container.decodeIfPresent([String].self, forKey: .to) ?? [],
             cc: try container.decodeIfPresent([String].self, forKey: .cc) ?? [],
             bcc: try container.decodeIfPresent([String].self, forKey: .bcc) ?? [],

--- a/Sources/SwiftMail/MIME/EMLParser+Headers.swift
+++ b/Sources/SwiftMail/MIME/EMLParser+Headers.swift
@@ -166,6 +166,7 @@ extension EMLParser {
         let subject = headers["subject"].flatMap { decodeRFC2047($0) } ?? headers["subject"]
         let messageId = headers["message-id"].flatMap { MessageID($0) }
 
+        let replyTo = parseAddressList(headers["reply-to"])
         let to = parseAddressList(headers["to"])
         let cc = parseAddressList(headers["cc"])
         let bcc = parseAddressList(headers["bcc"])
@@ -174,7 +175,7 @@ extension EMLParser {
 
         // Collect additional headers (everything except standard ones)
         let standardKeys: Set<String> = [
-            "from", "to", "cc", "bcc", "subject", "date", "message-id",
+            "from", "reply-to", "to", "cc", "bcc", "subject", "date", "message-id",
             "content-type", "content-transfer-encoding", "mime-version"
         ]
         var additional: [String: String] = [:]
@@ -187,6 +188,7 @@ extension EMLParser {
             uid: nil,
             subject: subject,
             from: from,
+            replyTo: replyTo,
             to: to,
             cc: cc,
             bcc: bcc,

--- a/Tests/SwiftIMAPTests/AdditionalHeaderFieldsTests.swift
+++ b/Tests/SwiftIMAPTests/AdditionalHeaderFieldsTests.swift
@@ -97,6 +97,22 @@ struct AdditionalHeaderFieldsTests {
         #expect(decoded.additionalHeaderFields?[1].value == "<https://example.com/unsubscribe>")
     }
 
+    @Test
+    func testReplyToCodableRoundTripAndBackwardCompatibility() throws {
+        var info = MessageInfo(sequenceNumber: SequenceNumber(1))
+        info.replyTo = ["alice@example.com", "Bob <bob@example.com>"]
+
+        let data = try JSONEncoder().encode(info)
+        let decoded = try JSONDecoder().decode(MessageInfo.self, from: data)
+        #expect(decoded.replyTo == info.replyTo)
+
+        var legacyObject = try #require(JSONSerialization.jsonObject(with: data) as? [String: Any])
+        legacyObject.removeValue(forKey: "replyTo")
+        let legacyData = try JSONSerialization.data(withJSONObject: legacyObject)
+        let legacyDecoded = try JSONDecoder().decode(MessageInfo.self, from: legacyData)
+        #expect(legacyDecoded.replyTo.isEmpty)
+    }
+
     private func executeFetch(_ rawResponses: [String]) async throws -> [MessageInfo] {
         let channel = try await NIOAsyncTestingChannel.withIMAPClientHandler()
 

--- a/Tests/SwiftIMAPTests/FetchMessageInfoHeaderFallbackTests.swift
+++ b/Tests/SwiftIMAPTests/FetchMessageInfoHeaderFallbackTests.swift
@@ -9,6 +9,25 @@ import Testing
 @Suite(.serialized, .timeLimit(.minutes(1)))
 struct FetchMessageInfoHeaderFallbackTests {
     @Test
+    func testEnvelopeReplyToIsProjectedOntoMessageInfo() async throws {
+        let envelope = "(NIL NIL NIL NIL ((NIL NIL \"replies\" \"example.com\"))"
+            + " NIL NIL NIL NIL \"<message@example.com>\")"
+
+        let infos = try await executeFetch([
+            fetchResponse(
+                sequenceNumber: 1,
+                envelope: envelope,
+                headerFields: ["Reply-To"],
+                headerBlock: "\r\n"
+            ),
+            "A001 OK FETCH completed\r\n"
+        ])
+
+        #expect(infos.count == 1)
+        #expect(infos[0].replyTo == ["replies@example.com"])
+    }
+
+    @Test
     func testHeaderFieldsPopulateStandardFieldsWithoutEnvelope() async throws {
         let headerBlock = """
         Date: Wed, 05 Aug 2026 12:13:59 -0600\r
@@ -47,20 +66,37 @@ struct FetchMessageInfoHeaderFallbackTests {
     }
 
     @Test
+    func testSelectiveReplyToHeaderPopulatesMessageInfoWithoutEnvelope() async throws {
+        let headerBlock = "Reply-To: Reply Desk <replies@example.com>\r\n\r\n"
+
+        let infos = try await executeFetch([
+            fetchResponse(sequenceNumber: 1, headerFields: ["Reply-To"], headerBlock: headerBlock),
+            "A001 OK FETCH completed\r\n"
+        ])
+
+        #expect(infos.count == 1)
+        #expect(infos[0].replyTo == ["Reply Desk <replies@example.com>"])
+        #expect(infos[0].additionalFields?["reply-to"] == nil)
+        #expect(infos[0].additionalHeaderFields == nil)
+    }
+
+    @Test
     func testHeaderFieldsDoNotOverrideEnvelopeFields() async throws {
         let envelope = "(\"Wed, 05 Aug 2026 10:00:00 -0600\" \"Envelope subject\""
-            + " ((\"Envelope Sender\" NIL \"envelope\" \"example.com\")) NIL NIL"
+            + " ((\"Envelope Sender\" NIL \"envelope\" \"example.com\")) NIL"
+            + " ((NIL NIL \"envelope-reply\" \"example.com\"))"
             + " ((NIL NIL \"recipient\" \"example.com\")) NIL NIL NIL \"<envelope@example.com>\")"
         let headerBlock = """
         Date: Wed, 05 Aug 2026 12:13:59 -0600\r
         Subject: Header subject\r
         From: Header Sender <header@example.com>\r
+        Reply-To: Header Reply <header-reply@example.com>\r
         To: Header Recipient <header-recipient@example.com>\r
         Message-ID: <header@example.com>\r
         In-Reply-To: <root@example.com>\r
         \r
         """
-        let fields = ["Date", "Subject", "From", "To", "Message-ID", "In-Reply-To"]
+        let fields = ["Date", "Subject", "From", "Reply-To", "To", "Message-ID", "In-Reply-To"]
 
         let infos = try await executeFetch([
             fetchResponse(
@@ -75,6 +111,7 @@ struct FetchMessageInfoHeaderFallbackTests {
         #expect(infos.count == 1)
         #expect(infos[0].subject == "Envelope subject")
         #expect(infos[0].from == "\"Envelope Sender\" <envelope@example.com>")
+        #expect(infos[0].replyTo == ["envelope-reply@example.com"])
         #expect(infos[0].to == ["recipient@example.com"])
         let expectedDate = Self.makeDate(DateComponents(year: 2026, month: 8, day: 5, hour: 16))
         #expect(infos[0].date == expectedDate)


### PR DESCRIPTION
Resolves #217.

Adds a public, `Codable` `MessageInfo.replyTo: [String]`, populated from the IMAP ENVELOPE and from a selectively fetched `Reply-To` header. ENVELOPE keeps precedence when both are present, matching the existing standard-header fallback.

Covered by regression tests for the ENVELOPE projection, the `headerFields: ["Reply-To"]` path, and `MessageInfo` Codable round trips.

🤖 Generated with [Claude Code](https://claude.com/claude-code)