### PR TITLE
Require the fetched message count before indexing in header fallback tests

### DIFF
--- a/Tests/SwiftIMAPTests/FetchMessageInfoHeaderFallbackTests.swift
+++ b/Tests/SwiftIMAPTests/FetchMessageInfoHeaderFallbackTests.swift
@@ -23,7 +23,7 @@ struct FetchMessageInfoHeaderFallbackTests {
             "A001 OK FETCH completed\r\n"
         ])
 
-        #expect(infos.count == 1)
+        try #require(infos.count == 1)
         #expect(infos[0].replyTo == ["replies@example.com"])
     }
 
@@ -49,7 +49,7 @@ struct FetchMessageInfoHeaderFallbackTests {
             "A001 OK FETCH completed\r\n"
         ])
 
-        #expect(infos.count == 1)
+        try #require(infos.count == 1)
         #expect(infos[0].subject == "What's New at A-Basin This Winter?")
         #expect(infos[0].from == "Arapahoe Basin <info@connect.arapahoebasin.com>")
         #expect(infos[0].to == ["Joel <joel@example.com>", "Michelle <michelle@example.com>"])
@@ -74,7 +74,7 @@ struct FetchMessageInfoHeaderFallbackTests {
             "A001 OK FETCH completed\r\n"
         ])
 
-        #expect(infos.count == 1)
+        try #require(infos.count == 1)
         #expect(infos[0].replyTo == ["Reply Desk <replies@example.com>"])
         #expect(infos[0].additionalFields?["reply-to"] == nil)
         #expect(infos[0].additionalHeaderFields == nil)
@@ -108,7 +108,7 @@ struct FetchMessageInfoHeaderFallbackTests {
             "A001 OK FETCH completed\r\n"
         ])
 
-        #expect(infos.count == 1)
+        try #require(infos.count == 1)
         #expect(infos[0].subject == "Envelope subject")
         #expect(infos[0].from == "\"Envelope Sender\" <envelope@example.com>")
         #expect(infos[0].replyTo == ["envelope-reply@example.com"])
@@ -139,7 +139,7 @@ struct FetchMessageInfoHeaderFallbackTests {
             "A001 OK FETCH completed\r\n"
         ])
 
-        #expect(infos.count == 1)
+        try #require(infos.count == 1)
         #expect(infos[0].subject == "")
         #expect(infos[0].from == "Header Sender <header@example.com>")
     }
@@ -156,7 +156,7 @@ struct FetchMessageInfoHeaderFallbackTests {
             Data("A001 OK FETCH completed\r\n".utf8)
         ])
 
-        #expect(infos.count == 1)
+        try #require(infos.count == 1)
         #expect(infos[0].subject == "Legacy receipt")
         #expect(infos[0].from == "René <rene@example.com>")
         #expect(infos[0].messageId == MessageID("<legacy@example.com>"))


### PR DESCRIPTION
## Summary

`FetchMessageInfoHeaderFallbackTests` asserts the fetched count with a non-fatal `#expect(infos.count == 1)` and then immediately subscripts `infos[0]`. If the fetch ever returns nothing, the subscript traps and takes the whole test process down, hiding every other result instead of reporting one failed test.

This switches the six count checks to `try #require(infos.count == 1)`, matching the pattern already used in `EMLByteLevelTests`. No behavior change.

## Verification

- `swift test --filter FetchMessageInfoHeaderFallbackTests`: 6 tests in 1 suite passed.
- `swiftlint lint --strict`: clean.
- Fork CI (macOS, Linux, iOS, Android, SwiftLint) green on this exact commit.

Noticed while working on #233; kept separate since it is unrelated test hygiene.
